### PR TITLE
Fix some build errors on gcc 10.2.0 (Linux)

### DIFF
--- a/source/matplot/axes_objects/contours.cpp
+++ b/source/matplot/axes_objects/contours.cpp
@@ -135,7 +135,7 @@ namespace matplot {
             bool z_has_nans = false;
             for (size_t i = 0; !z_has_nans && i < Z_data_.size(); ++i) {
                 for (size_t j = 0; !z_has_nans && j < Z_data_[i].size(); ++j) {
-                    if (!isfinite(Z_data_[i][j])) {
+                    if (!std::isfinite(Z_data_[i][j])) {
                         z_has_nans = true;
                     }
                 }
@@ -801,7 +801,7 @@ namespace matplot {
             bool z_has_nans = false;
             for (size_t i = 0; !z_has_nans && i < Z_data_.size(); ++i) {
                 for (size_t j = 0; !z_has_nans && j < Z_data_[i].size(); ++j) {
-                    if (!isfinite(Z_data_[i][j])) {
+                    if (!std::isfinite(Z_data_[i][j])) {
                         z_has_nans = true;
                     }
                 }
@@ -813,7 +813,7 @@ namespace matplot {
                 for (size_t i = 0; i < Z_data_.size(); ++i) {
                     bool all_nan = true;
                     for (size_t j = 0; j < Z_data_[i].size(); ++j) {
-                        if (isfinite(Z_data_[i][j])) {
+                        if (std::isfinite(Z_data_[i][j])) {
                             all_nan = false;
                             break;
                         }
@@ -826,7 +826,7 @@ namespace matplot {
                 for (size_t i = 0; i < Z_data_[0].size(); ++i) {
                     bool all_nan = true;
                     for (size_t j = 0; j < Z_data_.size(); ++j) {
-                        if (isfinite(Z_data_[j][i])) {
+                        if (std::isfinite(Z_data_[j][i])) {
                             all_nan = false;
                             break;
                         }
@@ -889,7 +889,7 @@ namespace matplot {
         // For the lines, we don't need to plot the segments separately
         // One line is separated from the other with NaNs
         auto is_separator = [](double x, double y) {
-            return !isfinite(x) || !isfinite(y);
+            return !std::isfinite(x) || !std::isfinite(y);
         };
 
         for (size_t i = 0; i < lines_.size(); ++i) {
@@ -988,12 +988,12 @@ namespace matplot {
                         constexpr double moving_average_reduction_factor = 0.1;
                         direction_u *= (1-moving_average_reduction_factor);
                         direction_v *= (1-moving_average_reduction_factor);
-                        bool has_previous = j != 0 && isfinite(lines_[i].first[j-1]);
+                        bool has_previous = j != 0 && std::isfinite(lines_[i].first[j-1]);
                         if (has_previous) {
                             direction_u += lines_[i].first[j] - lines_[i].first[j-1];
                             direction_v += lines_[i].second[j] - lines_[i].second[j-1];
                         } else {
-                            bool has_next = j != lines_[i].first.size() - 1 && isfinite(lines_[i].first[j+1]);
+                            bool has_next = j != lines_[i].first.size() - 1 && std::isfinite(lines_[i].first[j+1]);
                             if (has_next) {
                                 direction_u += lines_[i].first[j + 1] - lines_[i].first[j];
                                 direction_v += lines_[i].second[j + 1] - lines_[i].second[j];
@@ -1479,7 +1479,7 @@ namespace matplot {
                 std::get<1>(cur_parent) = 0;
                 size_t j = 0;
                 while (j < filled_lines_[i].first.size()) {
-                    if (isfinite(filled_lines_[i].first[j])) {
+                    if (std::isfinite(filled_lines_[i].first[j])) {
                         ++j;
                     } else {
                         // Nan indicates and end of segment
@@ -1490,7 +1490,7 @@ namespace matplot {
                             std::get<1>(cur).emplace_back(cur_child);
                         }
                         // Two nans in a row indicate a new parent
-                        bool only_one_nan = isfinite(filled_lines_[i].first[j+1]);
+                        bool only_one_nan = std::isfinite(filled_lines_[i].first[j+1]);
                         if (only_one_nan) {
                             is_parent = false;
                             ++j;
@@ -1503,7 +1503,7 @@ namespace matplot {
                             line_segments_.emplace_back(cur);
                             std::get<1>(cur).clear();
                             ++j;
-                            while (!isfinite(filled_lines_[i].first[j])) {
+                            while (!std::isfinite(filled_lines_[i].first[j])) {
                                 ++j;
                             }
                             // start new parent

--- a/source/matplot/axes_objects/contours.h
+++ b/source/matplot/axes_objects/contours.h
@@ -75,7 +75,7 @@ namespace matplot {
     public /* getters and setters */:
         class contours& line_style(const std::string& line_spec);
 
-        const line_spec &line_spec() const;
+        const class line_spec &line_spec() const;
         class line_spec &line_spec();
         class contours& line_spec(const class line_spec &line_spec);
 

--- a/source/matplot/axes_objects/filled_area.cpp
+++ b/source/matplot/axes_objects/filled_area.cpp
@@ -60,7 +60,7 @@ namespace matplot {
         if (!stacked_) {
             // send data for filled curve
             for (size_t i = 0; i < y_data_.size(); ++i) {
-                if (isfinite(y_data_[i])) {
+                if (std::isfinite(y_data_[i])) {
                     double base_value = base_data_.empty() ? 0.0 :
                                         base_data_.size() == 1 ? base_data_[0] : base_data_[i];
                     ss << "    " << x_data_[i] << " " << base_value << " " << y_data_[i] << "\n";
@@ -104,7 +104,7 @@ namespace matplot {
         for (size_t i = 0; i < y_data_.size(); ++i) {
             double base_value = base_data_.empty() ? 0.0 :
                                 base_data_.size() == 1 ? base_data_[0] : base_data_[i];
-            if (isfinite(base_value) && isfinite(x_data_[i])) {
+            if (std::isfinite(base_value) && std::isfinite(x_data_[i])) {
                 ss << "    " << x_data_[i] << " " << base_value << "\n";
             } else {
                 ss << "    \n";

--- a/source/matplot/axes_objects/histogram.cpp
+++ b/source/matplot/axes_objects/histogram.cpp
@@ -280,7 +280,7 @@ namespace matplot {
             n_bins_actual = nbins;
         }
 
-        if (!isfinite(bin_width)) {
+        if (!std::isfinite(bin_width)) {
             return linspace(left_edge, right_edge, n_bins_actual + 1);
         } else {
             std::vector<double> edges;
@@ -387,7 +387,7 @@ namespace matplot {
         size_t nbins = std::max(ceil(log2(x.size())+1.),1.);
         if (!hard_limits) {
             double binwidth = (maxx - minx) / nbins;
-            if (isfinite(binwidth)) {
+            if (std::isfinite(binwidth)) {
                 return bin_picker(minx, maxx, 0, binwidth);
             } else {
                 return bin_picker(minx, maxx, nbins, binwidth);
@@ -401,7 +401,7 @@ namespace matplot {
         size_t nbins = std::max(ceil(log2(x.size())+1.),1.);
         if (!hard_limits) {
             double binwidth = (maxx - minx) / nbins;
-            if (isfinite(binwidth)) {
+            if (std::isfinite(binwidth)) {
                 return bin_picker(minx, maxx, 0, binwidth);
             } else {
                 return bin_picker(minx, maxx, nbins, binwidth);

--- a/source/matplot/axes_objects/labels.cpp
+++ b/source/matplot/axes_objects/labels.cpp
@@ -74,19 +74,19 @@ namespace matplot {
             auto [xmin, xmax, ymin, ymax] = parent_->child_limits();
             if (parent_->x_axis().limits_mode_manual()) {
                 auto [axmin, axmax] = parent_->x_axis().limits();
-                if (isfinite(axmin)) {
+                if (std::isfinite(axmin)) {
                     xmin = std::min(xmin, axmin);
                 }
-                if (isfinite(axmax)) {
+                if (std::isfinite(axmax)) {
                     xmax = std::max(xmax, axmax);
                 }
             }
             if (parent_->y_axis().limits_mode_manual()) {
                 auto [aymin, aymax] = parent_->y_axis().limits();
-                if (isfinite(aymin)) {
+                if (std::isfinite(aymin)) {
                     ymin = std::min(ymin, aymin);
                 }
-                if (isfinite(aymax)) {
+                if (std::isfinite(aymax)) {
                     ymax = std::max(ymax, aymax);
                 }
             }

--- a/source/matplot/axes_objects/line.cpp
+++ b/source/matplot/axes_objects/line.cpp
@@ -148,7 +148,7 @@ namespace matplot {
                     size_t index = only_at_marker_indices ? marker_indices_[i] : i;
 
                     double x_value = x_is_manual ? x_data_[index] : index + 1;
-                    if (!isfinite(x_value) || !isfinite(y_data_[i])) {
+                    if (!std::isfinite(x_value) || !std::isfinite(y_data_[i])) {
                         ss << "    \n";
                         continue;
                     }

--- a/source/matplot/axes_objects/line.h
+++ b/source/matplot/axes_objects/line.h
@@ -41,7 +41,7 @@ namespace matplot {
     public /* getters and setters */:
         class line& line_style(const std::string& line_spec);
 
-        const line_spec &line_spec() const;
+        const class line_spec &line_spec() const;
         class line_spec &line_spec();
         class line& line_spec(const class line_spec &line_spec);
 

--- a/source/matplot/axes_objects/network.cpp
+++ b/source/matplot/axes_objects/network.cpp
@@ -3,6 +3,7 @@
 //
 
 #include <cmath>
+#include <iomanip>
 #include <sstream>
 #include <regex>
 #include <random>

--- a/source/matplot/axes_objects/network.h
+++ b/source/matplot/axes_objects/network.h
@@ -48,7 +48,7 @@ namespace matplot {
     public /* getters and setters */:
         class network& line_style(const std::string& line_spec);
 
-        const line_spec &line_spec() const;
+        const class line_spec &line_spec() const;
         class line_spec &line_spec();
         class network& line_spec(const class line_spec &line_spec);
 

--- a/source/matplot/axes_objects/parallel_lines.cpp
+++ b/source/matplot/axes_objects/parallel_lines.cpp
@@ -2,6 +2,7 @@
 // Created by Alan Freitas on 15/07/20.
 //
 
+#include <iomanip>
 #include <sstream>
 #include <regex>
 #include <matplot/util/common.h>

--- a/source/matplot/axes_objects/parallel_lines.h
+++ b/source/matplot/axes_objects/parallel_lines.h
@@ -35,7 +35,7 @@ namespace matplot {
         enum axes_object::axes_category axes_category() override;
 
     public /* getters and setters */:
-        const line_spec &line_spec() const;
+        const class line_spec &line_spec() const;
         class parallel_lines& line_spec(const class line_spec &line_spec);
 
         const std::vector<std::vector<double>> &data() const;

--- a/source/matplot/axes_objects/surface.cpp
+++ b/source/matplot/axes_objects/surface.cpp
@@ -307,7 +307,7 @@ namespace matplot {
             ss << "    " << x;
             ss << "  " << y;
             ss << "  " << z;
-            if (isfinite(c)) {
+            if (std::isfinite(c)) {
                 ss << "  " << c;
             }
             ss << "\n";
@@ -319,7 +319,7 @@ namespace matplot {
             ss << "  " << z;
             ss << "  " << zlow;
             ss << "  " << zhigh;
-            if (isfinite(c)) {
+            if (std::isfinite(c)) {
                 ss << "  " << c;
             }
             ss << "\n";
@@ -400,7 +400,7 @@ namespace matplot {
             ss << "    " << x;
             ss << "  " << y;
             ss << "  " << z;
-            if (isfinite(c)) {
+            if (std::isfinite(c)) {
                 ss << "  " << c;
             }
             ss << "\n";

--- a/source/matplot/axes_objects/surface.h
+++ b/source/matplot/axes_objects/surface.h
@@ -49,7 +49,7 @@ namespace matplot {
     public /* getters and setters */:
         class surface& line_style(const std::string& line_spec);
 
-        const line_spec &line_spec() const;
+        const class line_spec &line_spec() const;
         class line_spec &line_spec();
         class surface& line_spec(const class line_spec &line_spec);
 

--- a/source/matplot/axes_objects/vectors.cpp
+++ b/source/matplot/axes_objects/vectors.cpp
@@ -51,12 +51,12 @@ namespace matplot {
                 double v_value = v_data_.size() > i ? v_data_[i] : 0;
                 double w_value = w_data_.size() > i ? w_data_[i] : 0;
 
-                bool is_end_of_series = !isfinite(x_value) ||
-                                        !isfinite(y_value) ||
-                                        !isfinite(z_value) ||
-                                        !isfinite(u_value) ||
-                                        !isfinite(v_value) ||
-                                        !isfinite(w_value);
+                bool is_end_of_series = !std::isfinite(x_value) ||
+                                        !std::isfinite(y_value) ||
+                                        !std::isfinite(z_value) ||
+                                        !std::isfinite(u_value) ||
+                                        !std::isfinite(v_value) ||
+                                        !std::isfinite(w_value);
                 if (is_end_of_series) {
                     ss << "    \n";
                     continue;

--- a/source/matplot/axes_objects/vectors.h
+++ b/source/matplot/axes_objects/vectors.h
@@ -51,7 +51,7 @@ namespace matplot {
     public /* getters and setters */:
         class vectors& line_style(const std::string& line_spec);
 
-        const line_spec &line_spec() const;
+        const class line_spec &line_spec() const;
         class line_spec &line_spec();
         class vectors& line_spec(const class line_spec &line_spec);
 

--- a/source/matplot/backend/backend_registry.h
+++ b/source/matplot/backend/backend_registry.h
@@ -5,6 +5,7 @@
 #ifndef MATPLOTPLUSPLUS_BACKEND_REGISTRY_H
 #define MATPLOTPLUSPLUS_BACKEND_REGISTRY_H
 
+#include <stdexcept>
 #include <matplot/backend/backend_interface.h>
 #include <matplot/backend/gnuplot.h>
 

--- a/source/matplot/core/axes.cpp
+++ b/source/matplot/core/axes.cpp
@@ -763,7 +763,7 @@ namespace matplot {
             run_command("set yrange [0:1]");
         }
         run_command("set key off");
-        if (y_axis().limits_mode_auto() || !isfinite(y_axis().limits()[1])) {
+        if (y_axis().limits_mode_auto() || !std::isfinite(y_axis().limits()[1])) {
             run_command("plot 2 with lines");
         } else {
             run_command("plot " + std::to_string(y_axis().limits_[1] + 1) + " with lines");
@@ -3573,7 +3573,7 @@ namespace matplot {
                 // copy next submap
                 std::vector<double> submap_x;
                 std::vector<double> submap_y;
-                while (i < map_x.size() && isfinite(map_x[i]) && isfinite(map_y[i])) {
+                while (i < map_x.size() && std::isfinite(map_x[i]) && std::isfinite(map_y[i])) {
                     submap_x.emplace_back(map_x[i]);
                     submap_y.emplace_back(map_y[i]);
                     ++i;
@@ -3581,7 +3581,7 @@ namespace matplot {
 
                 // fn to check if a point is inside the limits we want
                 auto inside_the_map = [&](double x, double y) {
-                    return isfinite(x) && isfinite(y) &&
+                    return std::isfinite(x) && std::isfinite(y) &&
                            x <= longitude[1] && x >= longitude[0] &&
                            y <= latitude[1] && y >= latitude[0];
                 };

--- a/source/matplot/core/axes.cpp
+++ b/source/matplot/core/axes.cpp
@@ -3,6 +3,7 @@
 //
 
 #include <cmath>
+#include <iomanip>
 #include <sstream>
 #include <memory>
 

--- a/source/matplot/core/axes.h
+++ b/source/matplot/core/axes.h
@@ -5,6 +5,8 @@
 #ifndef MATPLOTPLUSPLUS_AXES_H
 #define MATPLOTPLUSPLUS_AXES_H
 
+#include <array>
+#include <memory>
 #include <optional>
 
 #include <matplot/util/colors.h>

--- a/source/matplot/core/axes_object.h
+++ b/source/matplot/core/axes_object.h
@@ -6,6 +6,7 @@
 #define MATPLOTPLUSPLUS_CHARTOBJECT_H
 
 #include <vector>
+#include <memory>
 
 namespace matplot {
     class axes;

--- a/source/matplot/core/axis.cpp
+++ b/source/matplot/core/axis.cpp
@@ -37,7 +37,7 @@ namespace matplot {
     }
 
     bool axis::limits_mode_auto() const {
-        return limits_mode_auto_ || (!isfinite(limits_[0]) && !isfinite(limits_[0]));
+        return limits_mode_auto_ || (!std::isfinite(limits_[0]) && !std::isfinite(limits_[0]));
     }
 
     bool axis::limits_mode_manual() const {
@@ -59,22 +59,22 @@ namespace matplot {
     std::string axis::range_string() const {
         if (!reverse_) {
             std::string r = "[";
-            if (!limits_mode_auto_ && isfinite(limits_[0])) {
+            if (!limits_mode_auto_ && std::isfinite(limits_[0])) {
                 r += std::to_string(limits_[0]);
             }
             r += ":";
-            if (!limits_mode_auto_ && isfinite(limits_[1])) {
+            if (!limits_mode_auto_ && std::isfinite(limits_[1])) {
                 r += std::to_string(limits_[1]);
             }
             r += "] noreverse";
             return r;
         } else {
             std::string r = "[";
-            if (!limits_mode_auto_ && isfinite(limits_[1])) {
+            if (!limits_mode_auto_ && std::isfinite(limits_[1])) {
                 r += std::to_string(limits_[1]);
             }
             r += ":";
-            if (!limits_mode_auto_ && isfinite(limits_[0])) {
+            if (!limits_mode_auto_ && std::isfinite(limits_[0])) {
                 r += std::to_string(limits_[0]);
             }
             r += "] reverse";

--- a/source/matplot/core/line_spec.h
+++ b/source/matplot/core/line_spec.h
@@ -6,6 +6,7 @@
 #define MATPLOTPLUSPLUS_LINE_SPEC_H
 
 #include <array>
+#include <functional>
 #include <matplot/util/colors.h>
 #include <matplot/util/concepts.h>
 

--- a/source/matplot/util/colors.cpp
+++ b/source/matplot/util/colors.cpp
@@ -3,6 +3,7 @@
 //
 
 #include <cmath>
+#include <algorithm>
 #include <vector>
 #include <matplot/util/colors.h>
 

--- a/source/matplot/util/colors.h
+++ b/source/matplot/util/colors.h
@@ -7,6 +7,7 @@
 
 #include <string>
 #include <array>
+#include <vector>
 
 namespace matplot {
     enum class color {

--- a/source/matplot/util/common.h
+++ b/source/matplot/util/common.h
@@ -5,6 +5,7 @@
 #ifndef MATPLOTPLUSPLUS_COMMON_H
 #define MATPLOTPLUSPLUS_COMMON_H
 
+#include <algorithm>
 #include <vector>
 #include <string>
 #include <sstream>

--- a/source/matplot/util/contourc.cpp
+++ b/source/matplot/util/contourc.cpp
@@ -357,7 +357,7 @@ namespace matplot {
                 vertices_list.second.emplace_back(point->y);
                 ++inserted;
             } else {
-                bool last_segment_is_not_empty = inserted > 0 && isfinite(vertices_list.first.back()) && isfinite(vertices_list.first.back());
+                bool last_segment_is_not_empty = inserted > 0 && std::isfinite(vertices_list.first.back()) && std::isfinite(vertices_list.first.back());
                 if (last_segment_is_not_empty) {
                     vertices_list.first.emplace_back(NaN);
                     vertices_list.second.emplace_back(NaN);
@@ -365,7 +365,7 @@ namespace matplot {
 
             }
         }
-        bool last_segment_is_not_empty = inserted > 0 && isfinite(vertices_list.first.back()) && isfinite(vertices_list.first.back());
+        bool last_segment_is_not_empty = inserted > 0 && std::isfinite(vertices_list.first.back()) && std::isfinite(vertices_list.first.back());
         if (last_segment_is_not_empty) {
             vertices_list.first.emplace_back(NaN);
             vertices_list.second.emplace_back(NaN);
@@ -403,7 +403,7 @@ namespace matplot {
                 }
 
                 auto is_valid_point = [](double x, double y) {
-                    return isfinite(x) && isfinite(y) && x != 0. && y != 0.;
+                    return std::isfinite(x) && std::isfinite(y) && x != 0. && y != 0.;
                 };
 
                 // for each point in this line

--- a/source/matplot/util/contourc.cpp
+++ b/source/matplot/util/contourc.cpp
@@ -14,6 +14,7 @@
 // #include "mplutils.h"
 // https://github.com/matplotlib/matplotlib/blob/master/src/mplutils.h
 // https://github.com/matplotlib/matplotlib/blob/master/src/mplutils.cpp
+#include <cassert>
 #include <matplot/util/contourc.h>
 #include <matplot/axes_objects/contours.h>
 #include <algorithm>

--- a/source/matplot/util/geodata.h
+++ b/source/matplot/util/geodata.h
@@ -5,7 +5,9 @@
 #ifndef MATPLOTPLUSPLUS_GEODATA_H
 #define MATPLOTPLUSPLUS_GEODATA_H
 
+#include <limits>
 #include <vector>
+#include <string>
 
 namespace matplot {
     std::pair<std::vector<double>, std::vector<double>>& world_map_10m();

--- a/source/matplot/util/handle_types.h
+++ b/source/matplot/util/handle_types.h
@@ -6,6 +6,7 @@
 #define MATPLOTPLUSPLUS_HANDLE_TYPES_H
 
 #include <array>
+#include <memory>
 
 namespace matplot {
     using color_array = std::array<float,4>;

--- a/source/matplot/util/keywords.h
+++ b/source/matplot/util/keywords.h
@@ -5,6 +5,8 @@
 #ifndef MATPLOTPLUSPLUS_KEYWORDS_H
 #define MATPLOTPLUSPLUS_KEYWORDS_H
 
+#include <limits>
+
 namespace matplot {
     class keyword_automatic_type {};
     constexpr keyword_automatic_type automatic;

--- a/source/matplot/util/type_traits.h
+++ b/source/matplot/util/type_traits.h
@@ -7,6 +7,7 @@
 
 #include <string>
 #include <type_traits>
+#include <vector>
 
 namespace matplot {
     template<typename C>


### PR DESCRIPTION
This fixes #5 for me. This also fixes build errors because of missing `std` namespace qualifiers and missing `class` keywords for some return types.

There are still some build failures that need to be addressed, namely #4 and a template related error in `axes::surf()` (matplot/core/axes.h:2211).