### PR TITLE
Fix compilation errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ cmake-build-*
 codealike.json
 .idea
 gh-md-toc
+build*/
+CMakeLists.txt.user

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,10 +1,10 @@
 cmake_minimum_required(VERSION 3.14)
 project(matplotplusplus)
 
-set(CMAKE_CXX_STANDARD 17)
-set(CMAKE_CXX_FLAGS_RELEASE "-O3")
+# https://cliutils.gitlab.io/modern-cmake/chapters/basics/variables.html
+set(CMAKE_CXX_FLAGS_RELEASE "-O3" CACHE STRING "")
 
-set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
+list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 include(cmake/CPM.cmake)
 message("CMAKE_MODULE_PATH=${CMAKE_MODULE_PATH}")
 
@@ -12,6 +12,7 @@ option(BUILD_EXAMPLES "Build examples" ON)
 option(BUILD_TESTS "Build tests" ON)
 option(BUILD_FOR_DOCUMENTATION_IMAGES "Bypass wait() commands and save figures as .svg at destruction" OFF)
 option(BUILD_HIGH_RESOLUTION_WORLD_MAP "Compile the high resolution maps for geoplots" ON)
+option(BUILD_SHARED_LIBS "Build shared libraries" OFF)
 
 if (${CMAKE_CURRENT_SOURCE_DIR} STREQUAL ${CMAKE_SOURCE_DIR})
     set(MASTER_PROJECT ON)

--- a/cmake/FindFilesystem.cmake
+++ b/cmake/FindFilesystem.cmake
@@ -1,0 +1,247 @@
+# Distributed under the OSI-approved BSD 3-Clause License.  See accompanying
+# file Copyright.txt or https://cmake.org/licensing for details.
+
+#[=======================================================================[.rst:
+
+FindFilesystem
+##############
+
+This module supports the C++17 standard library's filesystem utilities. Use the
+:imp-target:`std::filesystem` imported target to
+
+Options
+*******
+
+The ``COMPONENTS`` argument to this module supports the following values:
+
+.. find-component:: Experimental
+    :name: fs.Experimental
+
+    Allows the module to find the "experimental" Filesystem TS version of the
+    Filesystem library. This is the library that should be used with the
+    ``std::experimental::filesystem`` namespace.
+
+.. find-component:: Final
+    :name: fs.Final
+
+    Finds the final C++17 standard version of the filesystem library.
+
+If no components are provided, behaves as if the
+:find-component:`fs.Final` component was specified.
+
+If both :find-component:`fs.Experimental` and :find-component:`fs.Final` are
+provided, first looks for ``Final``, and falls back to ``Experimental`` in case
+of failure. If ``Final`` is found, :imp-target:`std::filesystem` and all
+:ref:`variables <fs.variables>` will refer to the ``Final`` version.
+
+
+Imported Targets
+****************
+
+.. imp-target:: std::filesystem
+
+    The ``std::filesystem`` imported target is defined when any requested
+    version of the C++ filesystem library has been found, whether it is
+    *Experimental* or *Final*.
+
+    If no version of the filesystem library is available, this target will not
+    be defined.
+
+    .. note::
+        This target has ``cxx_std_17`` as an ``INTERFACE``
+        :ref:`compile language standard feature <req-lang-standards>`. Linking
+        to this target will automatically enable C++17 if no later standard
+        version is already required on the linking target.
+
+
+.. _fs.variables:
+
+Variables
+*********
+
+.. variable:: CXX_FILESYSTEM_IS_EXPERIMENTAL
+
+    Set to ``TRUE`` when the :find-component:`fs.Experimental` version of C++
+    filesystem library was found, otherwise ``FALSE``.
+
+.. variable:: CXX_FILESYSTEM_HAVE_FS
+
+    Set to ``TRUE`` when a filesystem header was found.
+
+.. variable:: CXX_FILESYSTEM_HEADER
+
+    Set to either ``filesystem`` or ``experimental/filesystem`` depending on
+    whether :find-component:`fs.Final` or :find-component:`fs.Experimental` was
+    found.
+
+.. variable:: CXX_FILESYSTEM_NAMESPACE
+
+    Set to either ``std::filesystem`` or ``std::experimental::filesystem``
+    depending on whether :find-component:`fs.Final` or
+    :find-component:`fs.Experimental` was found.
+
+
+Examples
+********
+
+Using `find_package(Filesystem)` with no component arguments:
+
+.. code-block:: cmake
+
+    find_package(Filesystem REQUIRED)
+
+    add_executable(my-program main.cpp)
+    target_link_libraries(my-program PRIVATE std::filesystem)
+
+
+#]=======================================================================]
+
+
+if(TARGET std::filesystem)
+    # This module has already been processed. Don't do it again.
+    return()
+endif()
+
+cmake_minimum_required(VERSION 3.10)
+
+include(CMakePushCheckState)
+include(CheckIncludeFileCXX)
+
+# If we're not cross-compiling, try to run test executables.
+# Otherwise, assume that compile + link is a sufficient check.
+if(CMAKE_CROSSCOMPILING)
+    include(CheckCXXSourceCompiles)
+    macro(_cmcm_check_cxx_source code var)
+        check_cxx_source_compiles("${code}" ${var})
+    endmacro()
+else()
+    include(CheckCXXSourceRuns)
+    macro(_cmcm_check_cxx_source code var)
+        check_cxx_source_runs("${code}" ${var})
+    endmacro()
+endif()
+
+cmake_push_check_state()
+
+set(CMAKE_REQUIRED_QUIET ${Filesystem_FIND_QUIETLY})
+
+# All of our tests required C++17 or later
+set(CMAKE_CXX_STANDARD 17)
+
+# Normalize and check the component list we were given
+set(want_components ${Filesystem_FIND_COMPONENTS})
+if(Filesystem_FIND_COMPONENTS STREQUAL "")
+    set(want_components Final)
+endif()
+
+# Warn on any unrecognized components
+set(extra_components ${want_components})
+list(REMOVE_ITEM extra_components Final Experimental)
+foreach(component IN LISTS extra_components)
+    message(WARNING "Extraneous find_package component for Filesystem: ${component}")
+endforeach()
+
+# Detect which of Experimental and Final we should look for
+set(find_experimental TRUE)
+set(find_final TRUE)
+if(NOT "Final" IN_LIST want_components)
+    set(find_final FALSE)
+endif()
+if(NOT "Experimental" IN_LIST want_components)
+    set(find_experimental FALSE)
+endif()
+
+if(find_final)
+    check_include_file_cxx("filesystem" _CXX_FILESYSTEM_HAVE_HEADER)
+    mark_as_advanced(_CXX_FILESYSTEM_HAVE_HEADER)
+    if(_CXX_FILESYSTEM_HAVE_HEADER)
+        # We found the non-experimental header. Don't bother looking for the
+        # experimental one.
+        set(find_experimental FALSE)
+    endif()
+else()
+    set(_CXX_FILESYSTEM_HAVE_HEADER FALSE)
+endif()
+
+if(find_experimental)
+    check_include_file_cxx("experimental/filesystem" _CXX_FILESYSTEM_HAVE_EXPERIMENTAL_HEADER)
+    mark_as_advanced(_CXX_FILESYSTEM_HAVE_EXPERIMENTAL_HEADER)
+else()
+    set(_CXX_FILESYSTEM_HAVE_EXPERIMENTAL_HEADER FALSE)
+endif()
+
+if(_CXX_FILESYSTEM_HAVE_HEADER)
+    set(_have_fs TRUE)
+    set(_fs_header filesystem)
+    set(_fs_namespace std::filesystem)
+    set(_is_experimental FALSE)
+elseif(_CXX_FILESYSTEM_HAVE_EXPERIMENTAL_HEADER)
+    set(_have_fs TRUE)
+    set(_fs_header experimental/filesystem)
+    set(_fs_namespace std::experimental::filesystem)
+    set(_is_experimental TRUE)
+else()
+    set(_have_fs FALSE)
+endif()
+
+set(CXX_FILESYSTEM_HAVE_FS ${_have_fs} CACHE BOOL "TRUE if we have the C++ filesystem headers")
+set(CXX_FILESYSTEM_HEADER ${_fs_header} CACHE STRING "The header that should be included to obtain the filesystem APIs")
+set(CXX_FILESYSTEM_NAMESPACE ${_fs_namespace} CACHE STRING "The C++ namespace that contains the filesystem APIs")
+set(CXX_FILESYSTEM_IS_EXPERIMENTAL ${_is_experimental} CACHE BOOL "TRUE if the C++ filesystem library is the experimental version")
+
+set(_found FALSE)
+
+if(CXX_FILESYSTEM_HAVE_FS)
+    # We have some filesystem library available. Do link checks
+    string(CONFIGURE [[
+        #include <cstdlib>
+        #include <@CXX_FILESYSTEM_HEADER@>
+
+        int main() {
+            auto cwd = @CXX_FILESYSTEM_NAMESPACE@::current_path();
+            printf("%s", cwd.c_str());
+            return EXIT_SUCCESS;
+        }
+    ]] code @ONLY)
+
+    # Check a simple filesystem program without any linker flags
+    _cmcm_check_cxx_source("${code}" CXX_FILESYSTEM_NO_LINK_NEEDED)
+
+    set(can_link ${CXX_FILESYSTEM_NO_LINK_NEEDED})
+
+    if(NOT CXX_FILESYSTEM_NO_LINK_NEEDED)
+        set(prev_libraries ${CMAKE_REQUIRED_LIBRARIES})
+        # Add the libstdc++ flag
+        set(CMAKE_REQUIRED_LIBRARIES ${prev_libraries} -lstdc++fs)
+        _cmcm_check_cxx_source("${code}" CXX_FILESYSTEM_STDCPPFS_NEEDED)
+        set(can_link ${CXX_FILESYSTEM_STDCPPFS_NEEDED})
+        if(NOT CXX_FILESYSTEM_STDCPPFS_NEEDED)
+            # Try the libc++ flag
+            set(CMAKE_REQUIRED_LIBRARIES ${prev_libraries} -lc++fs)
+            _cmcm_check_cxx_source("${code}" CXX_FILESYSTEM_CPPFS_NEEDED)
+            set(can_link ${CXX_FILESYSTEM_CPPFS_NEEDED})
+        endif()
+    endif()
+
+    if(can_link)
+        add_library(std::filesystem INTERFACE IMPORTED)
+        set_property(TARGET std::filesystem APPEND PROPERTY INTERFACE_COMPILE_FEATURES cxx_std_17)
+        set(_found TRUE)
+
+        if(CXX_FILESYSTEM_NO_LINK_NEEDED)
+            # Nothing to add...
+        elseif(CXX_FILESYSTEM_STDCPPFS_NEEDED)
+            set_property(TARGET std::filesystem APPEND PROPERTY INTERFACE_LINK_LIBRARIES -lstdc++fs)
+        elseif(CXX_FILESYSTEM_CPPFS_NEEDED)
+            set_property(TARGET std::filesystem APPEND PROPERTY INTERFACE_LINK_LIBRARIES -lc++fs)
+        endif()
+    endif()
+endif()
+
+cmake_pop_check_state()
+
+set(Filesystem_FOUND ${_found} CACHE BOOL "TRUE if we can run a program using std::filesystem" FORCE)
+
+if(Filesystem_FIND_REQUIRED AND NOT Filesystem_FOUND)
+    message(FATAL_ERROR "Cannot run simple program using std::filesystem")
+endif()

--- a/source/matplot/CMakeLists.txt
+++ b/source/matplot/CMakeLists.txt
@@ -86,6 +86,9 @@ add_library(matplot
 target_include_directories(matplot PUBLIC ${MATPLOT_ROOT_DIR}/source)
 target_link_libraries(matplot PUBLIC nodesoup cimg)
 
+# https://cmake.org/cmake/help/v3.14/manual/cmake-compile-features.7.html#requiring-language-standards
+target_compile_features(matplot PUBLIC cxx_std_17)
+
 if (BUILD_FOR_DOCUMENTATION_IMAGES)
     message("Building matplot for documentation images. wait() commands will be ignored. ~figure will save the files.")
     target_compile_definitions(matplot PUBLIC MATPLOT_BUILD_FOR_DOCUMENTATION_IMAGES)

--- a/source/matplot/CMakeLists.txt
+++ b/source/matplot/CMakeLists.txt
@@ -89,6 +89,15 @@ target_link_libraries(matplot PUBLIC nodesoup cimg)
 # https://cmake.org/cmake/help/v3.14/manual/cmake-compile-features.7.html#requiring-language-standards
 target_compile_features(matplot PUBLIC cxx_std_17)
 
+include(CheckSymbolExists)
+
+# Some hack to not depend on FILE* internals
+# https://github.com/alandefreitas/matplotplusplus/issues/4
+check_symbol_exists(__fbufsize "stdio_ext.h" HAVE_FBUFSIZE)
+if (HAVE_FBUFSIZE)
+    target_compile_definitions(matplot PRIVATE MATPLOT_HAS_FBUFSIZE)
+endif()
+
 if (BUILD_FOR_DOCUMENTATION_IMAGES)
     message("Building matplot for documentation images. wait() commands will be ignored. ~figure will save the files.")
     target_compile_definitions(matplot PUBLIC MATPLOT_BUILD_FOR_DOCUMENTATION_IMAGES)

--- a/source/matplot/CMakeLists.txt
+++ b/source/matplot/CMakeLists.txt
@@ -98,6 +98,13 @@ if (HAVE_FBUFSIZE)
     target_compile_definitions(matplot PRIVATE MATPLOT_HAS_FBUFSIZE)
 endif()
 
+# Another hack to check for min in Windows.h
+# http://www.suodenjoki.dk/us/archive/2010/min-max.htm
+check_symbol_exists(min "Windows.h" HAVE_WINDOWS_MINMAX)
+if (HAVE_WINDOWS_MINMAX)
+    target_compile_definitions(matplot PUBLIC NOMINMAX)
+endif()
+
 if (BUILD_FOR_DOCUMENTATION_IMAGES)
     message("Building matplot for documentation images. wait() commands will be ignored. ~figure will save the files.")
     target_compile_definitions(matplot PUBLIC MATPLOT_BUILD_FOR_DOCUMENTATION_IMAGES)

--- a/source/matplot/CMakeLists.txt
+++ b/source/matplot/CMakeLists.txt
@@ -1,5 +1,7 @@
 include(FindDependencies.cmake)
 
+find_package(Filesystem REQUIRED)
+
 add_library(matplot
         matplot.h
 
@@ -84,7 +86,7 @@ add_library(matplot
 )
 
 target_include_directories(matplot PUBLIC ${MATPLOT_ROOT_DIR}/source)
-target_link_libraries(matplot PUBLIC nodesoup cimg)
+target_link_libraries(matplot PUBLIC nodesoup cimg std::filesystem)
 
 # https://cmake.org/cmake/help/v3.14/manual/cmake-compile-features.7.html#requiring-language-standards
 target_compile_features(matplot PUBLIC cxx_std_17)

--- a/source/matplot/FindDependencies.cmake
+++ b/source/matplot/FindDependencies.cmake
@@ -14,6 +14,10 @@ add_library(nodesoup
         )
 target_include_directories(nodesoup PUBLIC ${nodesoup_SOURCE_DIR}/include/)
 
+# Hackfix to support MSVC standard library
+# https://docs.microsoft.com/en-us/cpp/c-runtime-library/math-constants?view=vs-2019
+target_compile_definitions(nodesoup PRIVATE _USE_MATH_DEFINES)
+
 # Add CImg library
 CPMAddPackage(NAME cimg GITHUB_REPOSITORY dtschump/CImg VERSION 0.221 GIT_TAG v.221 DOWNLOAD_ONLY TRUE)
 find_package(PkgConfig)

--- a/source/matplot/axes_objects/bars.cpp
+++ b/source/matplot/axes_objects/bars.cpp
@@ -4,6 +4,7 @@
 
 #include <cmath>
 #include <sstream>
+#include <algorithm>
 #include <matplot/util/common.h>
 #include <matplot/core/axes.h>
 #include <matplot/axes_objects/bars.h>

--- a/source/matplot/axes_objects/circles.cpp
+++ b/source/matplot/axes_objects/circles.cpp
@@ -3,6 +3,7 @@
 //
 
 #include <sstream>
+#include <algorithm>
 #include <matplot/util/common.h>
 #include <matplot/axes_objects/circles.h>
 #include <matplot/axes_objects/labels.h>

--- a/source/matplot/axes_objects/contours.cpp
+++ b/source/matplot/axes_objects/contours.cpp
@@ -7,6 +7,7 @@
 #include <numeric>
 #include <regex>
 #include <unordered_set>
+#include <algorithm>
 #include <matplot/axes_objects/contours.h>
 #include <matplot/axes_objects/histogram.h>
 #include <matplot/core/axes.h>

--- a/source/matplot/axes_objects/contours.cpp
+++ b/source/matplot/axes_objects/contours.cpp
@@ -136,7 +136,7 @@ namespace matplot {
             bool z_has_nans = false;
             for (size_t i = 0; !z_has_nans && i < Z_data_.size(); ++i) {
                 for (size_t j = 0; !z_has_nans && j < Z_data_[i].size(); ++j) {
-                    if (!isfinite(Z_data_[i][j])) {
+                    if (!std::isfinite(Z_data_[i][j])) {
                         z_has_nans = true;
                     }
                 }
@@ -802,7 +802,7 @@ namespace matplot {
             bool z_has_nans = false;
             for (size_t i = 0; !z_has_nans && i < Z_data_.size(); ++i) {
                 for (size_t j = 0; !z_has_nans && j < Z_data_[i].size(); ++j) {
-                    if (!isfinite(Z_data_[i][j])) {
+                    if (!std::isfinite(Z_data_[i][j])) {
                         z_has_nans = true;
                     }
                 }
@@ -814,7 +814,7 @@ namespace matplot {
                 for (size_t i = 0; i < Z_data_.size(); ++i) {
                     bool all_nan = true;
                     for (size_t j = 0; j < Z_data_[i].size(); ++j) {
-                        if (isfinite(Z_data_[i][j])) {
+                        if (std::isfinite(Z_data_[i][j])) {
                             all_nan = false;
                             break;
                         }
@@ -827,7 +827,7 @@ namespace matplot {
                 for (size_t i = 0; i < Z_data_[0].size(); ++i) {
                     bool all_nan = true;
                     for (size_t j = 0; j < Z_data_.size(); ++j) {
-                        if (isfinite(Z_data_[j][i])) {
+                        if (std::isfinite(Z_data_[j][i])) {
                             all_nan = false;
                             break;
                         }
@@ -890,7 +890,7 @@ namespace matplot {
         // For the lines, we don't need to plot the segments separately
         // One line is separated from the other with NaNs
         auto is_separator = [](double x, double y) {
-            return !isfinite(x) || !isfinite(y);
+            return !std::isfinite(x) || !std::isfinite(y);
         };
 
         for (size_t i = 0; i < lines_.size(); ++i) {
@@ -989,12 +989,12 @@ namespace matplot {
                         constexpr double moving_average_reduction_factor = 0.1;
                         direction_u *= (1-moving_average_reduction_factor);
                         direction_v *= (1-moving_average_reduction_factor);
-                        bool has_previous = j != 0 && isfinite(lines_[i].first[j-1]);
+                        bool has_previous = j != 0 && std::isfinite(lines_[i].first[j-1]);
                         if (has_previous) {
                             direction_u += lines_[i].first[j] - lines_[i].first[j-1];
                             direction_v += lines_[i].second[j] - lines_[i].second[j-1];
                         } else {
-                            bool has_next = j != lines_[i].first.size() - 1 && isfinite(lines_[i].first[j+1]);
+                            bool has_next = j != lines_[i].first.size() - 1 && std::isfinite(lines_[i].first[j+1]);
                             if (has_next) {
                                 direction_u += lines_[i].first[j + 1] - lines_[i].first[j];
                                 direction_v += lines_[i].second[j + 1] - lines_[i].second[j];
@@ -1480,7 +1480,7 @@ namespace matplot {
                 std::get<1>(cur_parent) = 0;
                 size_t j = 0;
                 while (j < filled_lines_[i].first.size()) {
-                    if (isfinite(filled_lines_[i].first[j])) {
+                    if (std::isfinite(filled_lines_[i].first[j])) {
                         ++j;
                     } else {
                         // Nan indicates and end of segment
@@ -1491,7 +1491,7 @@ namespace matplot {
                             std::get<1>(cur).emplace_back(cur_child);
                         }
                         // Two nans in a row indicate a new parent
-                        bool only_one_nan = isfinite(filled_lines_[i].first[j+1]);
+                        bool only_one_nan = std::isfinite(filled_lines_[i].first[j+1]);
                         if (only_one_nan) {
                             is_parent = false;
                             ++j;
@@ -1504,7 +1504,7 @@ namespace matplot {
                             line_segments_.emplace_back(cur);
                             std::get<1>(cur).clear();
                             ++j;
-                            while (!isfinite(filled_lines_[i].first[j])) {
+                            while (!std::isfinite(filled_lines_[i].first[j])) {
                                 ++j;
                             }
                             // start new parent

--- a/source/matplot/axes_objects/contours.cpp
+++ b/source/matplot/axes_objects/contours.cpp
@@ -928,7 +928,7 @@ namespace matplot {
             // We always check if a label is not too close to another label
             constexpr double minimum_distance = 0.8;
             auto too_close = [](double x1, double y1, double x2, double y2) {
-                return abs(x1 - x2) < minimum_distance && abs(y1 - y2) < minimum_distance;
+                return std::abs(x1 - x2) < minimum_distance && std::abs(y1 - y2) < minimum_distance;
             };
 
             // Instead of iterating each line, we iterate

--- a/source/matplot/axes_objects/contours.cpp
+++ b/source/matplot/axes_objects/contours.cpp
@@ -1288,7 +1288,7 @@ namespace matplot {
         // The starting point
         // We convert tot int because the square trace algorithm
         // might go outside the image
-        auto start = std::make_pair<int,int>(start_i, start_j);
+        auto start = std::make_pair(static_cast<int>(start_i), static_cast<int>(start_j));
 
         const size_t n_rows = Z.size();
         const size_t n_cols = Z[0].size();

--- a/source/matplot/axes_objects/contours.h
+++ b/source/matplot/axes_objects/contours.h
@@ -138,6 +138,7 @@ namespace matplot {
         template <class T>
         class contours& color(T c) {
             line_spec().color(c);
+            return *this;
         }
         inline class contours& color(std::initializer_list<float> c) {
             line_spec().color(c);

--- a/source/matplot/axes_objects/contours.h
+++ b/source/matplot/axes_objects/contours.h
@@ -75,8 +75,8 @@ namespace matplot {
     public /* getters and setters */:
         class contours& line_style(const std::string& line_spec);
 
-        const line_spec &line_spec() const;
-        class line_spec &line_spec();
+        const matplot::line_spec &line_spec() const;
+        matplot::line_spec &line_spec();
         class contours& line_spec(const class line_spec &line_spec);
 
         const vector_2d &Y_data() const;

--- a/source/matplot/axes_objects/filled_area.cpp
+++ b/source/matplot/axes_objects/filled_area.cpp
@@ -60,7 +60,7 @@ namespace matplot {
         if (!stacked_) {
             // send data for filled curve
             for (size_t i = 0; i < y_data_.size(); ++i) {
-                if (isfinite(y_data_[i])) {
+                if (std::isfinite(y_data_[i])) {
                     double base_value = base_data_.empty() ? 0.0 :
                                         base_data_.size() == 1 ? base_data_[0] : base_data_[i];
                     ss << "    " << x_data_[i] << " " << base_value << " " << y_data_[i] << "\n";
@@ -104,7 +104,7 @@ namespace matplot {
         for (size_t i = 0; i < y_data_.size(); ++i) {
             double base_value = base_data_.empty() ? 0.0 :
                                 base_data_.size() == 1 ? base_data_[0] : base_data_[i];
-            if (isfinite(base_value) && isfinite(x_data_[i])) {
+            if (std::isfinite(base_value) && std::isfinite(x_data_[i])) {
                 ss << "    " << x_data_[i] << " " << base_value << "\n";
             } else {
                 ss << "    \n";

--- a/source/matplot/axes_objects/histogram.cpp
+++ b/source/matplot/axes_objects/histogram.cpp
@@ -4,6 +4,7 @@
 
 #include <cmath>
 #include <sstream>
+#include <algorithm>
 #include <matplot/axes_objects/histogram.h>
 #include <matplot/util/common.h>
 #include <matplot/core/axes.h>

--- a/source/matplot/axes_objects/histogram.cpp
+++ b/source/matplot/axes_objects/histogram.cpp
@@ -281,7 +281,7 @@ namespace matplot {
             n_bins_actual = nbins;
         }
 
-        if (!isfinite(bin_width)) {
+        if (!std::isfinite(bin_width)) {
             return linspace(left_edge, right_edge, n_bins_actual + 1);
         } else {
             std::vector<double> edges;
@@ -388,7 +388,7 @@ namespace matplot {
         size_t nbins = std::max(ceil(log2(x.size())+1.),1.);
         if (!hard_limits) {
             double binwidth = (maxx - minx) / nbins;
-            if (isfinite(binwidth)) {
+            if (std::isfinite(binwidth)) {
                 return bin_picker(minx, maxx, 0, binwidth);
             } else {
                 return bin_picker(minx, maxx, nbins, binwidth);
@@ -402,7 +402,7 @@ namespace matplot {
         size_t nbins = std::max(ceil(log2(x.size())+1.),1.);
         if (!hard_limits) {
             double binwidth = (maxx - minx) / nbins;
-            if (isfinite(binwidth)) {
+            if (std::isfinite(binwidth)) {
                 return bin_picker(minx, maxx, 0, binwidth);
             } else {
                 return bin_picker(minx, maxx, nbins, binwidth);

--- a/source/matplot/axes_objects/histogram.cpp
+++ b/source/matplot/axes_objects/histogram.cpp
@@ -233,7 +233,7 @@ namespace matplot {
     /// Calculate edges given max values and a target width
     /// This will round the bin edges to values more appropriate for visualization
     std::vector<double> histogram::bin_picker(double xmin, double xmax, size_t nbins, double bin_width) {
-        double xscale = std::max(abs(xmin),abs(xmax));
+        double xscale = std::max(std::abs(xmin),std::abs(xmax));
         double xrange = xmax - xmin;
         bin_width = std::max(bin_width, nextafter(xscale,xscale+1)-xscale);
         double left_edge = 0.;
@@ -294,7 +294,7 @@ namespace matplot {
     }
 
     std::vector<double> bin_pickerbl(double xmin, double xmax, double minlimit, double maxlimit, double bin_width) {
-        double xscale = std::max(abs(xmin),abs(xmax));
+        double xscale = std::max(std::abs(xmin),std::abs(xmax));
         double xrange = xmax - xmin;
         bin_width = std::max(bin_width, nextafter(xscale, xscale+1-xscale));
         bool non_constant_data = xrange > std::max(sqrt(nextafter(xscale, xscale+1-xscale)), std::numeric_limits<double>::min());
@@ -346,7 +346,7 @@ namespace matplot {
         double xrange = maxx - minx;
         double binwidth = 1.0;
         if (!x.empty()) {
-            std::vector abs_x = transform(x, [](double x) { return abs(x); });
+            std::vector abs_x = transform(x, [](double x) { return std::abs(x); });
             double xscale = *std::max_element(abs_x.begin(), abs_x.end());
             xrange = *std::max_element(x.begin(),x.end()) - *std::min_element(x.begin(),x.end());
             if (xrange > max_num_of_bins) {
@@ -415,7 +415,7 @@ namespace matplot {
     std::vector<double> histogram::automatic_rule(const std::vector<double>& x, double minx, double maxx, bool hard_limits) {
         double xrange = maxx - minx;
         bool is_around_integers = std::all_of(x.begin(), x.end(), [](double x) {
-            return abs(x - round(x)) < 0.01;
+            return std::abs(x - round(x)) < 0.01;
         });
         if (is_around_integers && xrange <= 50) {
             return integers_rule(x,minx,maxx,hard_limits);

--- a/source/matplot/axes_objects/labels.cpp
+++ b/source/matplot/axes_objects/labels.cpp
@@ -75,19 +75,19 @@ namespace matplot {
             auto [xmin, xmax, ymin, ymax] = parent_->child_limits();
             if (parent_->x_axis().limits_mode_manual()) {
                 auto [axmin, axmax] = parent_->x_axis().limits();
-                if (isfinite(axmin)) {
+                if (std::isfinite(axmin)) {
                     xmin = std::min(xmin, axmin);
                 }
-                if (isfinite(axmax)) {
+                if (std::isfinite(axmax)) {
                     xmax = std::max(xmax, axmax);
                 }
             }
             if (parent_->y_axis().limits_mode_manual()) {
                 auto [aymin, aymax] = parent_->y_axis().limits();
-                if (isfinite(aymin)) {
+                if (std::isfinite(aymin)) {
                     ymin = std::min(ymin, aymin);
                 }
-                if (isfinite(aymax)) {
+                if (std::isfinite(aymax)) {
                     ymax = std::max(ymax, aymax);
                 }
             }

--- a/source/matplot/axes_objects/labels.cpp
+++ b/source/matplot/axes_objects/labels.cpp
@@ -4,6 +4,7 @@
 
 #include <sstream>
 #include <cmath>
+#include <algorithm>
 #include <matplot/util/common.h>
 #include <matplot/axes_objects/labels.h>
 #include <matplot/core/axes.h>

--- a/source/matplot/axes_objects/line.cpp
+++ b/source/matplot/axes_objects/line.cpp
@@ -148,7 +148,7 @@ namespace matplot {
                     size_t index = only_at_marker_indices ? marker_indices_[i] : i;
 
                     double x_value = x_is_manual ? x_data_[index] : index + 1;
-                    if (!isfinite(x_value) || !isfinite(y_data_[i])) {
+                    if (!std::isfinite(x_value) || !std::isfinite(y_data_[i])) {
                         ss << "    \n";
                         continue;
                     }

--- a/source/matplot/axes_objects/line.cpp
+++ b/source/matplot/axes_objects/line.cpp
@@ -204,7 +204,7 @@ namespace matplot {
             }
             auto [min_rho, max_rho] = std::minmax_element(y_data_.begin(), y_data_.end());
             if (max_rho != y_data_.end() && min_rho != y_data_.end()) {
-                return +round_polar_max(abs(*max_rho));
+                return +round_polar_max(std::abs(*max_rho));
             } else {
                 return 1;
             }
@@ -228,7 +228,7 @@ namespace matplot {
             }
             auto [min_rho, max_rho] = std::minmax_element(y_data_.begin(), y_data_.end());
             if (max_rho != y_data_.end() && min_rho != y_data_.end()) {
-                return -round_polar_max(abs(*max_rho));
+                return -round_polar_max(std::abs(*max_rho));
             } else {
                 return -1;
             }
@@ -248,7 +248,7 @@ namespace matplot {
             }
             auto [min_rho, max_rho] = std::minmax_element(y_data_.begin(), y_data_.end());
             if (max_rho != y_data_.end() && min_rho != y_data_.end()) {
-                return +round_polar_max(abs(*max_rho));
+                return +round_polar_max(std::abs(*max_rho));
             } else {
                 return 1;
             }
@@ -268,7 +268,7 @@ namespace matplot {
             }
             auto [min_rho, max_rho] = std::minmax_element(y_data_.begin(), y_data_.end());
             if (max_rho != y_data_.end() && min_rho != y_data_.end()) {
-                return -round_polar_max(abs(*max_rho));
+                return -round_polar_max(std::abs(*max_rho));
             } else {
                 return -1;
             }

--- a/source/matplot/axes_objects/line.h
+++ b/source/matplot/axes_objects/line.h
@@ -41,8 +41,8 @@ namespace matplot {
     public /* getters and setters */:
         class line& line_style(const std::string& line_spec);
 
-        const line_spec &line_spec() const;
-        class line_spec &line_spec();
+        const matplot::line_spec &line_spec() const;
+        matplot::line_spec &line_spec();
         class line& line_spec(const class line_spec &line_spec);
 
         const std::vector<double> &y_data() const;
@@ -161,7 +161,7 @@ namespace matplot {
 
     protected:
         /// Line style
-        class line_spec line_spec_;
+        matplot::line_spec line_spec_;
 
         /// Data in the xlim
         std::vector<double> y_data_{};

--- a/source/matplot/axes_objects/network.cpp
+++ b/source/matplot/axes_objects/network.cpp
@@ -6,6 +6,7 @@
 #include <sstream>
 #include <regex>
 #include <random>
+#include <iomanip>
 #include <matplot/axes_objects/network.h>
 #include <matplot/core/axes.h>
 #include <matplot/util/common.h>

--- a/source/matplot/axes_objects/network.h
+++ b/source/matplot/axes_objects/network.h
@@ -48,8 +48,8 @@ namespace matplot {
     public /* getters and setters */:
         class network& line_style(const std::string& line_spec);
 
-        const line_spec &line_spec() const;
-        class line_spec &line_spec();
+        const matplot::line_spec &line_spec() const;
+        matplot::line_spec &line_spec();
         class network& line_spec(const class line_spec &line_spec);
 
         const std::vector<double> &y_data() const;

--- a/source/matplot/axes_objects/parallel_lines.cpp
+++ b/source/matplot/axes_objects/parallel_lines.cpp
@@ -4,6 +4,7 @@
 
 #include <sstream>
 #include <regex>
+#include <iomanip>
 #include <matplot/util/common.h>
 #include <matplot/axes_objects/parallel_lines.h>
 #include <matplot/core/axes.h>

--- a/source/matplot/axes_objects/parallel_lines.h
+++ b/source/matplot/axes_objects/parallel_lines.h
@@ -35,8 +35,8 @@ namespace matplot {
         enum axes_object::axes_category axes_category() override;
 
     public /* getters and setters */:
-        const line_spec &line_spec() const;
-        class parallel_lines& line_spec(const class line_spec &line_spec);
+        const matplot::line_spec &line_spec() const;
+        class parallel_lines& line_spec(const matplot::line_spec &line_spec);
 
         const std::vector<std::vector<double>> &data() const;
         class parallel_lines& data(const std::vector<std::vector<double>> &data);

--- a/source/matplot/axes_objects/stair.cpp
+++ b/source/matplot/axes_objects/stair.cpp
@@ -2,6 +2,7 @@
 // Created by Alan Freitas on 2020-07-07.
 //
 
+#include <algorithm>
 #include <matplot/axes_objects/stair.h>
 #include <matplot/core/axes.h>
 

--- a/source/matplot/axes_objects/surface.cpp
+++ b/source/matplot/axes_objects/surface.cpp
@@ -307,7 +307,7 @@ namespace matplot {
             ss << "    " << x;
             ss << "  " << y;
             ss << "  " << z;
-            if (isfinite(c)) {
+            if (std::isfinite(c)) {
                 ss << "  " << c;
             }
             ss << "\n";
@@ -319,7 +319,7 @@ namespace matplot {
             ss << "  " << z;
             ss << "  " << zlow;
             ss << "  " << zhigh;
-            if (isfinite(c)) {
+            if (std::isfinite(c)) {
                 ss << "  " << c;
             }
             ss << "\n";
@@ -400,7 +400,7 @@ namespace matplot {
             ss << "    " << x;
             ss << "  " << y;
             ss << "  " << z;
-            if (isfinite(c)) {
+            if (std::isfinite(c)) {
                 ss << "  " << c;
             }
             ss << "\n";

--- a/source/matplot/axes_objects/surface.h
+++ b/source/matplot/axes_objects/surface.h
@@ -50,8 +50,8 @@ namespace matplot {
     public /* getters and setters */:
         class surface& line_style(const std::string& line_spec);
 
-        const line_spec &line_spec() const;
-        class line_spec &line_spec();
+        const matplot::line_spec &line_spec() const;
+        matplot::line_spec &line_spec();
         class surface& line_spec(const class line_spec &line_spec);
 
         const vector_2d &Y_data() const;

--- a/source/matplot/axes_objects/surface.h
+++ b/source/matplot/axes_objects/surface.h
@@ -6,6 +6,7 @@
 #define MATPLOTPLUSPLUS_SURFACE_H
 
 #include <array>
+#include <optional>
 #include <matplot/util/concepts.h>
 #include <matplot/util/handle_types.h>
 #include <matplot/core/figure.h>

--- a/source/matplot/axes_objects/vectors.cpp
+++ b/source/matplot/axes_objects/vectors.cpp
@@ -51,12 +51,12 @@ namespace matplot {
                 double v_value = v_data_.size() > i ? v_data_[i] : 0;
                 double w_value = w_data_.size() > i ? w_data_[i] : 0;
 
-                bool is_end_of_series = !isfinite(x_value) ||
-                                        !isfinite(y_value) ||
-                                        !isfinite(z_value) ||
-                                        !isfinite(u_value) ||
-                                        !isfinite(v_value) ||
-                                        !isfinite(w_value);
+                bool is_end_of_series = !std::isfinite(x_value) ||
+                                        !std::isfinite(y_value) ||
+                                        !std::isfinite(z_value) ||
+                                        !std::isfinite(u_value) ||
+                                        !std::isfinite(v_value) ||
+                                        !std::isfinite(w_value);
                 if (is_end_of_series) {
                     ss << "    \n";
                     continue;

--- a/source/matplot/axes_objects/vectors.cpp
+++ b/source/matplot/axes_objects/vectors.cpp
@@ -122,7 +122,7 @@ namespace matplot {
             }
             auto [min_rho, max_rho] = std::minmax_element(y_data_.begin(), y_data_.end());
             if (max_rho != y_data_.end() && min_rho != y_data_.end()) {
-                return +round_polar_max(abs(*max_rho));
+                return +round_polar_max(std::abs(*max_rho));
             } else {
                 return 1;
             }
@@ -146,7 +146,7 @@ namespace matplot {
             }
             auto [min_rho, max_rho] = std::minmax_element(y_data_.begin(), y_data_.end());
             if (max_rho != y_data_.end() && min_rho != y_data_.end()) {
-                return -round_polar_max(abs(*max_rho));
+                return -round_polar_max(std::abs(*max_rho));
             } else {
                 return -1;
             }
@@ -166,7 +166,7 @@ namespace matplot {
             }
             auto [min_rho, max_rho] = std::minmax_element(y_data_.begin(), y_data_.end());
             if (max_rho != y_data_.end() && min_rho != y_data_.end()) {
-                return +round_polar_max(abs(*max_rho));
+                return +round_polar_max(std::abs(*max_rho));
             } else {
                 return 1;
             }
@@ -186,7 +186,7 @@ namespace matplot {
             }
             auto [min_rho, max_rho] = std::minmax_element(y_data_.begin(), y_data_.end());
             if (max_rho != y_data_.end() && min_rho != y_data_.end()) {
-                return -round_polar_max(abs(*max_rho));
+                return -round_polar_max(std::abs(*max_rho));
             } else {
                 return -1;
             }

--- a/source/matplot/axes_objects/vectors.h
+++ b/source/matplot/axes_objects/vectors.h
@@ -51,8 +51,8 @@ namespace matplot {
     public /* getters and setters */:
         class vectors& line_style(const std::string& line_spec);
 
-        const line_spec &line_spec() const;
-        class line_spec &line_spec();
+        const matplot::line_spec &line_spec() const;
+        matplot::line_spec &line_spec();
         class vectors& line_spec(const class line_spec &line_spec);
 
         const std::vector<double> &y_data() const;

--- a/source/matplot/backend/backend_registry.h
+++ b/source/matplot/backend/backend_registry.h
@@ -5,6 +5,7 @@
 #ifndef MATPLOTPLUSPLUS_BACKEND_REGISTRY_H
 #define MATPLOTPLUSPLUS_BACKEND_REGISTRY_H
 
+#include <stdexcept>
 #include <matplot/backend/backend_interface.h>
 #include <matplot/backend/gnuplot.h>
 

--- a/source/matplot/backend/gnuplot.cpp
+++ b/source/matplot/backend/gnuplot.cpp
@@ -66,7 +66,7 @@ namespace matplot::backend {
         // look at the extension
         namespace fs = std::filesystem;
         fs::path p{filename};
-        std::string ext = p.extension();
+        std::string ext = p.extension().string();
 
         // check terminal for that extension
         constexpr auto exts = extension_terminal();
@@ -124,7 +124,7 @@ namespace matplot::backend {
         terminal_ = format;
 
         // Append extension if needed
-        std::string ext = p.extension();
+        std::string ext = p.extension().string();
         if (ext.empty()) {
             output_ += it->first;
         }

--- a/source/matplot/backend/gnuplot.h
+++ b/source/matplot/backend/gnuplot.h
@@ -77,7 +77,7 @@ namespace matplot::backend {
         static constexpr bool trace_commands = false;
 #endif
 
-        static constexpr size_t pipe_capacity_worst_case = 4096;
+        static constexpr size_t pipe_capacity_worst_case = BUFSIZ;
         /// File formats for figures and properties of terminals
         static constexpr std::array<std::pair<std::string_view,std::string_view>,33> extension_terminal() {
             return std::array<std::pair<std::string_view,std::string_view>,33>

--- a/source/matplot/core/axes.cpp
+++ b/source/matplot/core/axes.cpp
@@ -764,7 +764,7 @@ namespace matplot {
             run_command("set yrange [0:1]");
         }
         run_command("set key off");
-        if (y_axis().limits_mode_auto() || !isfinite(y_axis().limits()[1])) {
+        if (y_axis().limits_mode_auto() || !std::isfinite(y_axis().limits()[1])) {
             run_command("plot 2 with lines");
         } else {
             run_command("plot " + std::to_string(y_axis().limits_[1] + 1) + " with lines");
@@ -3574,7 +3574,7 @@ namespace matplot {
                 // copy next submap
                 std::vector<double> submap_x;
                 std::vector<double> submap_y;
-                while (i < map_x.size() && isfinite(map_x[i]) && isfinite(map_y[i])) {
+                while (i < map_x.size() && std::isfinite(map_x[i]) && std::isfinite(map_y[i])) {
                     submap_x.emplace_back(map_x[i]);
                     submap_y.emplace_back(map_y[i]);
                     ++i;
@@ -3582,7 +3582,7 @@ namespace matplot {
 
                 // fn to check if a point is inside the limits we want
                 auto inside_the_map = [&](double x, double y) {
-                    return isfinite(x) && isfinite(y) &&
+                    return std::isfinite(x) && std::isfinite(y) &&
                            x <= longitude[1] && x >= longitude[0] &&
                            y <= latitude[1] && y >= latitude[0];
                 };

--- a/source/matplot/core/axes.cpp
+++ b/source/matplot/core/axes.cpp
@@ -5,6 +5,8 @@
 #include <cmath>
 #include <sstream>
 #include <memory>
+#include <algorithm>
+#include <iomanip>
 
 #include <matplot/core/axes.h>
 #include <matplot/core/axes_object.h>

--- a/source/matplot/core/axes.cpp
+++ b/source/matplot/core/axes.cpp
@@ -3555,8 +3555,8 @@ namespace matplot {
         // if we found the map
         if (map) {
             // calculate the perimeter of the new limits
-            double latitude_kms = 111.12 * abs(latitude[1] - latitude[0]);
-            double longitude_kms = 111.12 * abs(longitude[1] - longitude[0]);
+            double latitude_kms = 111.12 * std::abs(latitude[1] - latitude[0]);
+            double longitude_kms = 111.12 * std::abs(longitude[1] - longitude[0]);
             double w_pixels = this->width() * this->parent()->width();
             double h_pixels = this->height() * this->parent()->height();
             double w_km_per_pixel = longitude_kms / w_pixels;

--- a/source/matplot/core/axes.h
+++ b/source/matplot/core/axes.h
@@ -2206,7 +2206,7 @@ namespace matplot {
                             const IterableIterables<T3> &Z,
                             const IterableIterables<T4> &C = {}, std::string
                             line_spec = "") {
-            return IterableIterables(to_vector_2d(X),to_vector_2d(Y),to_vector_2d(Z),to_vector_2d(C),line_spec);
+            return IterableIterables<T1>(to_vector_2d(X),to_vector_2d(Y),to_vector_2d(Z),to_vector_2d(C),line_spec);
         }
 
         template <class T1, class T2, class T3, class T4>

--- a/source/matplot/core/axes_object.h
+++ b/source/matplot/core/axes_object.h
@@ -6,6 +6,7 @@
 #define MATPLOTPLUSPLUS_CHARTOBJECT_H
 
 #include <vector>
+#include <memory>
 
 namespace matplot {
     class axes;

--- a/source/matplot/core/axis.cpp
+++ b/source/matplot/core/axis.cpp
@@ -37,7 +37,7 @@ namespace matplot {
     }
 
     bool axis::limits_mode_auto() const {
-        return limits_mode_auto_ || (!isfinite(limits_[0]) && !isfinite(limits_[0]));
+        return limits_mode_auto_ || (!std::isfinite(limits_[0]) && !std::isfinite(limits_[0]));
     }
 
     bool axis::limits_mode_manual() const {
@@ -59,22 +59,22 @@ namespace matplot {
     std::string axis::range_string() const {
         if (!reverse_) {
             std::string r = "[";
-            if (!limits_mode_auto_ && isfinite(limits_[0])) {
+            if (!limits_mode_auto_ && std::isfinite(limits_[0])) {
                 r += std::to_string(limits_[0]);
             }
             r += ":";
-            if (!limits_mode_auto_ && isfinite(limits_[1])) {
+            if (!limits_mode_auto_ && std::isfinite(limits_[1])) {
                 r += std::to_string(limits_[1]);
             }
             r += "] noreverse";
             return r;
         } else {
             std::string r = "[";
-            if (!limits_mode_auto_ && isfinite(limits_[1])) {
+            if (!limits_mode_auto_ && std::isfinite(limits_[1])) {
                 r += std::to_string(limits_[1]);
             }
             r += ":";
-            if (!limits_mode_auto_ && isfinite(limits_[0])) {
+            if (!limits_mode_auto_ && std::isfinite(limits_[0])) {
                 r += std::to_string(limits_[0]);
             }
             r += "] reverse";

--- a/source/matplot/core/figure.cpp
+++ b/source/matplot/core/figure.cpp
@@ -4,6 +4,7 @@
 
 #include <map>
 #include <sstream>
+#include <algorithm>
 #include <matplot/backend/backend_registry.h>
 #include <matplot/core/figure.h>
 #include <matplot/util/common.h>

--- a/source/matplot/core/legend.cpp
+++ b/source/matplot/core/legend.cpp
@@ -5,7 +5,6 @@
 #include <matplot/core/legend.h>
 #include <matplot/core/axes.h>
 #include <matplot/util/common.h>
-#include <curses.h>
 
 namespace matplot {
     legend::legend(class axes* parent)

--- a/source/matplot/core/line_spec.h
+++ b/source/matplot/core/line_spec.h
@@ -6,6 +6,7 @@
 #define MATPLOTPLUSPLUS_LINE_SPEC_H
 
 #include <array>
+#include <functional>
 #include <matplot/util/colors.h>
 #include <matplot/util/concepts.h>
 

--- a/source/matplot/freestanding/axes_functions.cpp
+++ b/source/matplot/freestanding/axes_functions.cpp
@@ -2,6 +2,7 @@
 // Created by Alan Freitas on 10/08/20.
 //
 
+#include <algorithm>
 #include <matplot/freestanding/axes_functions.h>
 
 namespace matplot {

--- a/source/matplot/freestanding/histcounts.cpp
+++ b/source/matplot/freestanding/histcounts.cpp
@@ -2,6 +2,7 @@
 // Created by Alan Freitas on 13/08/20.
 //
 
+#include <algorithm>
 #include <matplot/freestanding/histcounts.h>
 
 namespace matplot {

--- a/source/matplot/util/colors.cpp
+++ b/source/matplot/util/colors.cpp
@@ -4,6 +4,7 @@
 
 #include <cmath>
 #include <vector>
+#include <algorithm>
 #include <matplot/util/colors.h>
 
 namespace matplot {

--- a/source/matplot/util/colors.h
+++ b/source/matplot/util/colors.h
@@ -7,6 +7,7 @@
 
 #include <string>
 #include <array>
+#include <vector>
 
 namespace matplot {
     enum class color {

--- a/source/matplot/util/common.cpp
+++ b/source/matplot/util/common.cpp
@@ -49,7 +49,7 @@ namespace matplot {
     }
 
     std::string run_and_get_output(const std::string &cmd) {
-        std::unique_ptr<FILE, decltype(&pclose)> pipe(POPEN(cmd.c_str(), "r"), PCLOSE);
+        std::unique_ptr<FILE, decltype(&PCLOSE)> pipe(POPEN(cmd.c_str(), "r"), PCLOSE);
         if (!pipe) {
             throw std::runtime_error("popen() failed!");
         }

--- a/source/matplot/util/common.cpp
+++ b/source/matplot/util/common.cpp
@@ -840,7 +840,7 @@ namespace matplot {
         std::vector<std::vector<double>> deltas(niceVec.size(), std::vector<double>(roughInts.size()));
         for (size_t i = 0; i < deltas.size(); ++i) {
             for (size_t j = 0; j < deltas[i].size(); ++j) {
-                deltas[i][j] = abs(normRoughInts[j] - niceVec[i]);
+                deltas[i][j] = std::abs(normRoughInts[j] - niceVec[i]);
             }
         }
 
@@ -889,10 +889,10 @@ namespace matplot {
         // Set values that are almost exactly the original limits to be the original
         // limit value.
         for (size_t idx = 0; idx < lLims.size(); ++idx) {
-            if (abs(lLims[idx] - limits_min) < 10*eps(limits_min)) {
+            if (std::abs(lLims[idx] - limits_min) < 10*eps(limits_min)) {
                 lLims[idx] = limits_min;
             }
-            if (abs(uLims[idx] - limits_max) < 10*eps(limits_max)) {
+            if (std::abs(uLims[idx] - limits_max) < 10*eps(limits_max)) {
                 uLims[idx] = limits_max;
             }
         }
@@ -913,7 +913,7 @@ namespace matplot {
         // Determine label size for each interval
         // Get the decade span of the limits and the decade of the intervals
         std::vector<double> maxAbs = transform(lLims,uLims,[](double x, double y) {
-            return abs(x) > abs(y) ? abs(x) : abs(y);
+            return std::abs(x) > std::abs(y) ? std::abs(x) : std::abs(y);
         });
         std::vector<double> decMax = transform(maxAbs, [](double x) { return floor(log10(x)); });// - nDec;
         std::vector<double> decInts = transform(niceInts, [](double x) { return floor(log10(x)); }); // - nDec;
@@ -1005,12 +1005,12 @@ namespace matplot {
         std::vector<double> rangeTest = transform(niceInts, [&](double x) { return range/x; });
         std::vector<bool> isInt(rangeTest.size());
         for (size_t i = 0; i < rangeTest.size(); ++i) {
-            isInt[i] = abs(rangeTest[i]-round(rangeTest[i])) < 1e-6;
+            isInt[i] = std::abs(rangeTest[i]-round(rangeTest[i])) < 1e-6;
         }
         // Test for intervals that land exactly on the endpoints
         std::vector<bool> hitsEnds(lLims.size());
         for (size_t i = 0; i < hitsEnds.size(); ++i) {
-            hitsEnds[i] = (abs(lLims[i]-limits_min)<100*lEps) && (abs(uLims[i]-limits_max)<100*uEps);
+            hitsEnds[i] = (std::abs(lLims[i]-limits_min)<100*lEps) && (std::abs(uLims[i]-limits_max)<100*uEps);
         }
         // Compute a score using the above tests and the tick score and penalty
         std::vector<double> scores(isInt.size());
@@ -1051,7 +1051,7 @@ namespace matplot {
         ticks.emplace_back(uLim);
         // Handle 0 as a special case
         for (size_t i = 0; i < ticks.size(); ++i) {
-            if (abs(ticks[i]) < 10*minEps) {
+            if (std::abs(ticks[i]) < 10*minEps) {
                 ticks[i] = 0;
             }
         }
@@ -1061,7 +1061,7 @@ namespace matplot {
                                         max(0.,uLim-limits_max+labelSize[bestIdx]/2)};
         // Create tick labels
         // Get the decade span of the limits and the decade of the intervals
-        double maxAbs_d = max(abs(ticks.front()), abs(ticks.back()));
+        double maxAbs_d = max(std::abs(ticks.front()), std::abs(ticks.back()));
         double decMax_d = floor(log10(maxAbs_d));
         double decInt = floor(log10(interval));
 
@@ -1132,7 +1132,7 @@ namespace matplot {
 
             std::string scaleStr = "";
             for (size_t i = 0; i < tickLabels.size(); ++i) {
-                if (abs(ticks[i])<10*minEps) {
+                if (std::abs(ticks[i])<10*minEps) {
                     tickLabels[i] = "0";
                 }
             }

--- a/source/matplot/util/common.h
+++ b/source/matplot/util/common.h
@@ -10,6 +10,8 @@
 #include <sstream>
 #include <complex>
 #include <map>
+#include <functional>
+#include <algorithm>
 #include <matplot/util/concepts.h>
 
 namespace matplot {

--- a/source/matplot/util/contourc.cpp
+++ b/source/matplot/util/contourc.cpp
@@ -17,6 +17,7 @@
 #include <matplot/util/contourc.h>
 #include <matplot/axes_objects/contours.h>
 #include <algorithm>
+#include <cassert>
 
 namespace matplot {
 

--- a/source/matplot/util/contourc.cpp
+++ b/source/matplot/util/contourc.cpp
@@ -341,16 +341,16 @@ namespace matplot {
     void QuadContourGenerator::append_contour_line_to_vertices(
             ContourLine &contour_line,
             vertices_list_type& vertices_list) const {
-        double x_diff = abs(_x[0][1] - _x[0][0]);
-        double y_diff = abs(_y[1][0] - _y[0][0]);
+        double x_diff = std::abs(_x[0][1] - _x[0][0]);
+        double y_diff = std::abs(_y[1][0] - _y[0][0]);
         // Convert ContourLine to vertices_list
         size_t i = 0;
         size_t inserted = 0;
         for (ContourLine::const_iterator point = contour_line.begin();
              point != contour_line.end(); ++point, ++i) {
             bool is_origin = point->x == 0. && point->y == 0.;
-            bool is_x_jump_to_origin = is_origin && inserted != 0 && abs(vertices_list.first.back()) > 3 * x_diff;
-            bool is_y_jump_to_origin = is_origin && inserted != 0 && abs(vertices_list.second.back()) > 3 * y_diff;
+            bool is_x_jump_to_origin = is_origin && inserted != 0 && std::abs(vertices_list.first.back()) > 3 * x_diff;
+            bool is_y_jump_to_origin = is_origin && inserted != 0 && std::abs(vertices_list.second.back()) > 3 * y_diff;
             bool is_end_of_segment = is_x_jump_to_origin && is_y_jump_to_origin;
             if (!is_end_of_segment) {
                 vertices_list.first.emplace_back(point->x);

--- a/source/matplot/util/contourc.cpp
+++ b/source/matplot/util/contourc.cpp
@@ -357,7 +357,7 @@ namespace matplot {
                 vertices_list.second.emplace_back(point->y);
                 ++inserted;
             } else {
-                bool last_segment_is_not_empty = inserted > 0 && isfinite(vertices_list.first.back()) && isfinite(vertices_list.first.back());
+                bool last_segment_is_not_empty = inserted > 0 && std::isfinite(vertices_list.first.back()) && std::isfinite(vertices_list.first.back());
                 if (last_segment_is_not_empty) {
                     vertices_list.first.emplace_back(NaN);
                     vertices_list.second.emplace_back(NaN);
@@ -365,7 +365,7 @@ namespace matplot {
 
             }
         }
-        bool last_segment_is_not_empty = inserted > 0 && isfinite(vertices_list.first.back()) && isfinite(vertices_list.first.back());
+        bool last_segment_is_not_empty = inserted > 0 && std::isfinite(vertices_list.first.back()) && std::isfinite(vertices_list.first.back());
         if (last_segment_is_not_empty) {
             vertices_list.first.emplace_back(NaN);
             vertices_list.second.emplace_back(NaN);
@@ -403,7 +403,7 @@ namespace matplot {
                 }
 
                 auto is_valid_point = [](double x, double y) {
-                    return isfinite(x) && isfinite(y) && x != 0. && y != 0.;
+                    return std::isfinite(x) && std::isfinite(y) && x != 0. && y != 0.;
                 };
 
                 // for each point in this line

--- a/source/matplot/util/geodata.h
+++ b/source/matplot/util/geodata.h
@@ -6,6 +6,7 @@
 #define MATPLOTPLUSPLUS_GEODATA_H
 
 #include <vector>
+#include <string>
 
 namespace matplot {
     std::pair<std::vector<double>, std::vector<double>>& world_map_10m();

--- a/source/matplot/util/handle_types.h
+++ b/source/matplot/util/handle_types.h
@@ -6,6 +6,7 @@
 #define MATPLOTPLUSPLUS_HANDLE_TYPES_H
 
 #include <array>
+#include <memory>
 
 namespace matplot {
     using color_array = std::array<float,4>;

--- a/source/matplot/util/type_traits.h
+++ b/source/matplot/util/type_traits.h
@@ -6,6 +6,7 @@
 #define MATPLOTPLUSPLUS_TYPE_TRAITS_H
 
 #include <string>
+#include <vector>
 #include <type_traits>
 
 namespace matplot {

--- a/source/matplot/util/world_cities.cpp
+++ b/source/matplot/util/world_cities.cpp
@@ -3,6 +3,7 @@
 //
 
 #include <string>
+#include <algorithm>
 #include <matplot/util/geodata.h>
 #include <matplot/util/common.h>
 

--- a/test/generate_examples/CMakeLists.txt
+++ b/test/generate_examples/CMakeLists.txt
@@ -1,1 +1,2 @@
 add_executable(generate_examples main.cpp)
+target_compile_features(generate_examples PRIVATE cxx_std_17)

--- a/test/generate_examples/main.cpp
+++ b/test/generate_examples/main.cpp
@@ -322,7 +322,7 @@ int main() {
             const auto update_gallery = [&]() {
                 // Append image to the large image gallery
                 // - Append HTML anchor
-                string anchor = p.stem();
+                string anchor = p.stem().string();
                 gallery << "<a name=\"" << anchor << "\"></a>";
                 // - Append name of source file relative to the repository
                 const auto source_file_path = p.lexically_relative(root_path).string();
@@ -361,11 +361,11 @@ int main() {
             bool dont_have_the_large_image_yet = !fs::exists(figure_destination_svg) && !fs::exists(figure_destination_png);
             if (dont_have_the_large_image_yet) {
                 // Go to directory and run the executable
-                string exe_str = executable;
+                string exe_str = executable.string();
                 exe_str = regex_replace(exe_str, regex(" "), "\\ ");
                 exe_str = regex_replace(exe_str, regex("~"), "\\~");
 
-                string dir_str = p.parent_path();
+                string dir_str = p.parent_path().string();
                 dir_str = regex_replace(dir_str, regex(" "), "\\ ");
                 dir_str = regex_replace(dir_str, regex("~"), "\\~");
 


### PR DESCRIPTION
This compiles with LLVM 10 for Windows and the MSVC standard library:

`cmake -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang ..`

Also includes fixes for gcc 8 and some CMake modernization supersedes #8