### PR TITLE
Fix compilation for MSVC

### DIFF
--- a/examples/polar_plots/ezpolar/ezpolar_1.cpp
+++ b/examples/polar_plots/ezpolar/ezpolar_1.cpp
@@ -1,5 +1,4 @@
 #include <cmath>
-#include <cstdbool>
 #include <matplot/matplot.h>
 
 int main() {

--- a/source/matplot/CMakeLists.txt
+++ b/source/matplot/CMakeLists.txt
@@ -91,6 +91,12 @@ target_link_libraries(matplot PUBLIC nodesoup cimg std::filesystem)
 # https://cmake.org/cmake/help/v3.14/manual/cmake-compile-features.7.html#requiring-language-standards
 target_compile_features(matplot PUBLIC cxx_std_17)
 
+# Hacks to support MSVC
+if(MSVC)
+    # World maps require this option because there is so much in the file
+    target_compile_options(matplot PRIVATE /bigobj)
+endif()
+
 include(CheckSymbolExists)
 
 # Some hack to not depend on FILE* internals

--- a/source/matplot/CMakeLists.txt
+++ b/source/matplot/CMakeLists.txt
@@ -95,6 +95,7 @@ target_compile_features(matplot PUBLIC cxx_std_17)
 if(MSVC)
     # World maps require this option because there is so much in the file
     target_compile_options(matplot PRIVATE /bigobj)
+    target_compile_options(matplot PUBLIC /wd4305)
 endif()
 
 include(CheckSymbolExists)

--- a/source/matplot/axes_objects/contours.cpp
+++ b/source/matplot/axes_objects/contours.cpp
@@ -1032,7 +1032,7 @@ namespace matplot {
 
         if (contour_text_) {
             // We always check if a label is not too close to another label
-            constexpr double minimum_distance = 0.8;
+            static constexpr double minimum_distance = 0.8;
             auto too_close = [](double x1, double y1, double x2, double y2) {
                 return std::abs(x1 - x2) < minimum_distance &&
                        std::abs(y1 - y2) < minimum_distance;

--- a/source/matplot/axes_objects/contours.h
+++ b/source/matplot/axes_objects/contours.h
@@ -138,7 +138,7 @@ namespace matplot {
 
         const std::array<float, 4> &color() const;
 
-        template <class T> class contours &color(T c) {
+        template <class T> contours &color(T c) {
             line_spec().color(c);
             return *this;
         }

--- a/source/matplot/axes_objects/labels.h
+++ b/source/matplot/axes_objects/labels.h
@@ -79,7 +79,7 @@ namespace matplot {
 
         const color_array &color() const;
         class labels &color(const color_array &color);
-        template <class T> class labels &color(T c) {
+        template <class T> labels &color(T c) {
             color(to_array(c));
             return *this;
         }

--- a/source/matplot/axes_objects/line.h
+++ b/source/matplot/axes_objects/line.h
@@ -86,13 +86,13 @@ namespace matplot {
         class line &line_width(float line_width);
 
         enum line_spec::marker_style marker_style() const;
-        template <class T> class line &marker_style(T marker_style) {
+        template <class T> line &marker_style(T marker_style) {
             line_spec_.marker_style(marker_style);
             return *this;
         }
 
         enum line_spec::marker_style marker() const;
-        template <class T> class line &marker(T marker) {
+        template <class T> line &marker(T marker) {
             line_spec_.marker(marker);
             return *this;
         }
@@ -106,7 +106,7 @@ namespace matplot {
         class line &marker_face(bool size);
 
         const std::array<float, 4> &color() const;
-        template <class T> class line &color(T c) {
+        template <class T> line &color(T c) {
             line_spec().color(c);
             return *this;
         }
@@ -118,7 +118,7 @@ namespace matplot {
 
         const std::array<float, 4> &marker_color() const;
 
-        template <class T> class line &marker_color(T c) {
+        template <class T> line &marker_color(T c) {
             line_spec().marker_color(c);
             return *this;
         }
@@ -136,7 +136,7 @@ namespace matplot {
 
         const std::array<float, 4> &marker_face_color() const;
 
-        template <class T> class line &marker_face_color(T c) {
+        template <class T> line &marker_face_color(T c) {
             line_spec().marker_face_color(c);
             return *this;
         }

--- a/source/matplot/axes_objects/network.h
+++ b/source/matplot/axes_objects/network.h
@@ -79,7 +79,7 @@ namespace matplot {
         class network &edge_labels(const std::vector<std::string> &edge_labels);
 
         template <class C>
-        class network &edge_labels(const IterableValues<C> &e_labels) {
+        network &edge_labels(const IterableValues<C> &e_labels) {
             std::vector<std::string> str_labels;
             std::stringstream ss;
             for (const auto &edge_label : e_labels) {
@@ -95,7 +95,7 @@ namespace matplot {
         class network &node_labels(const std::vector<std::string> &node_labels);
 
         template <class C>
-        class network &node_labels(const IterableValues<C> &e_labels) {
+        network &node_labels(const IterableValues<C> &e_labels) {
             std::vector<std::string> str_labels;
             std::stringstream ss;
             for (const auto &edge_label : e_labels) {
@@ -144,13 +144,13 @@ namespace matplot {
         class network &line_width(float line_width);
 
         enum line_spec::marker_style marker_style() const;
-        template <class T> class network &marker_style(T marker_style) {
+        template <class T> network &marker_style(T marker_style) {
             line_spec_.marker_style(marker_style);
             return *this;
         }
 
         enum line_spec::marker_style marker() const;
-        template <class T> class network &marker(T marker) {
+        template <class T> network &marker(T marker) {
             line_spec_.marker(marker);
             return *this;
         }
@@ -164,7 +164,7 @@ namespace matplot {
         class network &marker_face(bool size);
 
         const std::array<float, 4> &color() const;
-        template <class T> class network &color(T c) {
+        template <class T> network &color(T c) {
             line_spec().color(c);
             return *this;
         }
@@ -175,12 +175,12 @@ namespace matplot {
 
         const std::array<float, 4> &marker_color() const;
 
-        template <class T> class network &marker_color(T c) {
+        template <class T> network &marker_color(T c) {
             line_spec().marker_color(c);
             return *this;
         }
 
-        template <class T> class network &node_color(T c) {
+        template <class T> network &node_color(T c) {
             marker_color(c);
             return *this;
         }
@@ -198,7 +198,7 @@ namespace matplot {
 
         const std::array<float, 4> &marker_face_color() const;
 
-        template <class T> class network &marker_face_color(T c) {
+        template <class T> network &marker_face_color(T c) {
             line_spec().marker_face_color(c);
             return *this;
         }

--- a/source/matplot/axes_objects/parallel_lines.cpp
+++ b/source/matplot/axes_objects/parallel_lines.cpp
@@ -279,14 +279,14 @@ namespace matplot {
         return *this;
     }
 
-    const std::vector<struct axis> &parallel_lines::axis() const {
+    const std::vector<class axis> &parallel_lines::axis() const {
         return axis_;
     }
 
-    std::vector<struct axis> &parallel_lines::axis() { return axis_; }
+    std::vector<class axis> &parallel_lines::axis() { return axis_; }
 
     class parallel_lines &
-    parallel_lines::axis(const std::vector<struct axis> &axis) {
+    parallel_lines::axis(const std::vector<class axis> &axis) {
         axis_ = axis;
         touch();
         return *this;

--- a/source/matplot/axes_objects/parallel_lines.h
+++ b/source/matplot/axes_objects/parallel_lines.h
@@ -44,9 +44,9 @@ namespace matplot {
         class parallel_lines &
         data(const std::vector<std::vector<double>> &data);
 
-        const std::vector<struct axis> &axis() const;
-        std::vector<struct axis> &axis();
-        class parallel_lines &axis(const std::vector<struct axis> &axis);
+        const std::vector<class axis> &axis() const;
+        std::vector<class axis> &axis();
+        class parallel_lines &axis(const std::vector<class axis> &axis);
 
         bool visible() const;
         class parallel_lines &visible(bool visible);

--- a/source/matplot/axes_objects/surface.h
+++ b/source/matplot/axes_objects/surface.h
@@ -172,7 +172,7 @@ namespace matplot {
 
         const std::array<float, 4> &edge_color() const;
 
-        template <class T> class surface &edge_color(T c) {
+        template <class T> surface &edge_color(T c) {
             line_spec().color(c);
             touch();
             return *this;

--- a/source/matplot/axes_objects/vectors.h
+++ b/source/matplot/axes_objects/vectors.h
@@ -107,13 +107,13 @@ namespace matplot {
         class vectors &line_width(float line_width);
 
         enum line_spec::marker_style marker_style() const;
-        template <class T> class vectors &marker_style(T marker_style) {
+        template <class T> vectors &marker_style(T marker_style) {
             line_spec_.marker_style(marker_style);
             return *this;
         }
 
         enum line_spec::marker_style marker() const;
-        template <class T> class vectors &marker(T marker) {
+        template <class T> vectors &marker(T marker) {
             line_spec_.marker(marker);
             return *this;
         }
@@ -127,7 +127,7 @@ namespace matplot {
         class vectors &marker_face(bool size);
 
         const std::array<float, 4> &color() const;
-        template <class T> class vectors &color(T c) {
+        template <class T> vectors &color(T c) {
             line_spec().color(c);
             return *this;
         }
@@ -138,7 +138,7 @@ namespace matplot {
 
         const std::array<float, 4> &marker_color() const;
 
-        template <class T> class vectors &marker_color(T c) {
+        template <class T> vectors &marker_color(T c) {
             line_spec().marker_color(c);
             return *this;
         }
@@ -156,7 +156,7 @@ namespace matplot {
 
         const std::array<float, 4> &marker_face_color() const;
 
-        template <class T> class vectors &marker_face_color(T c) {
+        template <class T> vectors &marker_face_color(T c) {
             line_spec().marker_face_color(c);
             return *this;
         }

--- a/source/matplot/core/axis.h
+++ b/source/matplot/core/axis.h
@@ -102,7 +102,7 @@ namespace matplot {
 
         const color_array &label_color() const;
         class axis &label_color(const color_array &label_color);
-        template <class T> class axis &label_color(T c) {
+        template <class T> axis &label_color(T c) {
             label_color(to_array(c));
             return *this;
         }

--- a/source/matplot/core/figure.h
+++ b/source/matplot/core/figure.h
@@ -125,9 +125,9 @@ namespace matplot {
         void current_axes(const std::shared_ptr<class axes> &current_axes);
 
         /// \brief Get reference to vector with all child axes
-        const std::vector<std::shared_ptr<struct axes>> &children() const;
+        const std::vector<std::shared_ptr<class axes>> &children() const;
         void
-        children(const std::vector<std::shared_ptr<struct axes>> &children);
+        children(const std::vector<std::shared_ptr<class axes>> &children);
 
       protected:
         static std::array<float, 4>

--- a/source/matplot/freestanding/axes_functions.h
+++ b/source/matplot/freestanding/axes_functions.h
@@ -242,17 +242,21 @@ namespace matplot {
     legend_handle legend(std::vector<axes_object_handle> objs,
                          const std::vector<std::string> &names);
 
-    template <typename... Args>
-    legend_handle legend(axes_handle ax, const std::string &name,
-                         Args const &... next_name) {
-        std::vector<std::string> legends = {name, next_name...};
-        return legend(ax, legends);
-    }
+    // Hackfix for a compiler bug in MSVC
+    namespace {
+        template <typename... Args>
+        legend_handle legend(axes_handle ax, const std::string &name,
+                             Args const &... next_name) {
+            std::vector<std::string> legends = {name, next_name...};
+            return ::matplot::legend(ax, legends);
+        }
 
-    template <typename... Args>
-    legend_handle legend(const std::string &name, Args const &... next_name) {
-        return legend(gca(), name, next_name...);
-    }
+        template <typename... Args>
+        legend_handle legend(const std::string &name,
+                             Args const &... next_name) {
+            return legend(gca(), name, next_name...);
+        }
+    } // namespace
 
     void colormap(axes_handle ax, const std::vector<std::vector<double>> &map);
     void colormap(const std::vector<std::vector<double>> &map);

--- a/source/matplot/freestanding/plot.h
+++ b/source/matplot/freestanding/plot.h
@@ -853,13 +853,13 @@ namespace matplot {
         return ax->arrow(args...);
     }
 
-    template <class T1, class... Args>
-    auto line(NotAxesHandle<T1> x, Args... args) {
-        return gca()->line(x, args...);
+    inline auto line(double x1, double y1, double x2, double y2) {
+        return gca()->line(x1, x1, x2, y2);
     }
 
-    template <class... Args> auto line(axes_handle ax, Args... args) {
-        return ax->line(args...);
+    inline auto line(axes_handle ax, double x1, double y1, double x2,
+                     double y2) {
+        return ax->line(x1, x1, x2, y2);
     }
 
     template <class T1, class... Args>

--- a/source/matplot/util/colors.h
+++ b/source/matplot/util/colors.h
@@ -36,19 +36,19 @@ namespace matplot {
         std::array<float, 4> r;
         if (c.size() == 1) {
             r[0] = 0;
-            r[1] = c[0];
-            r[2] = c[0];
-            r[3] = c[0];
+            r[1] = static_cast<float>(c[0]);
+            r[2] = static_cast<float>(c[0]);
+            r[3] = static_cast<float>(c[0]);
         } else if (c.size() == 3) {
             r[0] = 0;
-            r[1] = c[0];
-            r[2] = c[1];
-            r[3] = c[2];
+            r[1] = static_cast<float>(c[0]);
+            r[2] = static_cast<float>(c[1]);
+            r[3] = static_cast<float>(c[2]);
         } else if (c.size() == 4) {
-            r[0] = c[0];
-            r[1] = c[1];
-            r[2] = c[2];
-            r[3] = c[3];
+            r[0] = static_cast<float>(c[0]);
+            r[1] = static_cast<float>(c[1]);
+            r[2] = static_cast<float>(c[2]);
+            r[3] = static_cast<float>(c[3]);
         }
         return r;
     }

--- a/source/matplot/util/world_map_110m.cpp
+++ b/source/matplot/util/world_map_110m.cpp
@@ -12,7 +12,7 @@ namespace matplot {
     // \n\n
     // \nstd::numeric_limits<double>::quiet_NaN(),\n
 	std::pair<std::vector<double>, std::vector<double>> prepare_world_map_110m() {
-        std::vector<double> x = {
+        static constexpr double x[] = {
                         -163.71289567772871,
                         -163.105800951163786,
                         -161.245113491846439,
@@ -5270,7 +5270,7 @@ namespace matplot {
                         178.277211542063895,
                         180.0
                 };
-        std::vector<double> y = {
+        static constexpr double y[] = {
                 -78.595667413241543,
                 -78.223338718578589,
                 -78.380176690584435,
@@ -10528,7 +10528,7 @@ namespace matplot {
                 -84.472517999202552,
                 -84.71338
         };
-        return std::make_pair(x,y);
+        return std::make_pair(std::vector(std::begin(x), std::end(x)), std::vector(std::begin(y), std::end(y)));
 	}
 
     std::pair<std::vector<double>, std::vector<double>>& world_map_110m() {

--- a/source/matplot/util/world_map_50m.cpp
+++ b/source/matplot/util/world_map_50m.cpp
@@ -13,8 +13,8 @@ namespace matplot {
     // \n\n
     // \nstd::numeric_limits<double>::quiet_NaN(),\n
 	std::pair<std::vector<double>, std::vector<double>> prepare_world_map_50m() {
-        std::vector<double> x = {
-            180.0,
+        static constexpr double x[] = {
+180.0,
 179.84814453125,
 179.788867187500045,
 179.715039062500011,
@@ -61858,7 +61858,8 @@ std::numeric_limits<double>::quiet_NaN(),
 179.620312500000011,
 180.0
         };
-        std::vector<double> y = {-16.152929687500006,
+        static constexpr double y[] = {
+-16.152929687500006,
 -16.214257812500009,
 -16.221484375,
 -16.207617187500006,
@@ -123702,7 +123703,7 @@ std::numeric_limits<double>::quiet_NaN(),
 -84.268359375000017,
 -84.3515625,
 };
-        return std::make_pair(x,y);
+        return std::make_pair(std::vector(std::begin(x), std::end(x)), std::vector(std::begin(y), std::end(y)));
 	}
 
     std::pair<std::vector<double>, std::vector<double>>& world_map_50m() {


### PR DESCRIPTION
Most of the fixes are workarounds for weird compiler bugs/quirks in MSVC, but everything is still standard C++ and compile with clang and gcc just fine.

Thanks to @can1357 for helping me diagnose and fix some of the issues.

The main issue is that there are free functions that have the same name as the class they construct (`legend` for example). This is all fine, until the free function is a template. The fix is to put the template function in an anonymous namespace. I think this is a compiler bug in MSVC, but it actually becomes impossible to call the class constructor if there is a function with that name available.

Another issue is that `typename... Args` is being abused. In many places there is only a single overload and the free function should just have the arguments explicitly instead of forwarding them. This helps with both readability and intellisense when fixed. I only changed `line`, which was problematic because of the compiler bug.

Other issues are with the pattern `class X` being used in many places where it's not necessary, this seems to trip up MSVC and cause internal compiler errors when done in a template. The `class X` should in my opinion only be used to disambiguate between a function and class, but again I only fixed the ones that crashed MSVC.

The world_map compilation speed improvement is necessary, because the initializer_list overload of the vector constructor is evaluated at compile-time and ultra slow. The fix shouldn't have any downsides.

Finally a lot of warnings come from truncating conversations from double -> float. I simply silenced them as a PUBLIC compile flag, instead of changing `1.45` to `1.45f` in hundreds of locations. The library still compiles with a lot of warnings, but most of the examples are now warning-free.