### PR TITLE
Fix split exit command on windows

### DIFF
--- a/source/matplot/backend/gnuplot.cpp
+++ b/source/matplot/backend/gnuplot.cpp
@@ -54,6 +54,7 @@ namespace matplot::backend {
                                             time_since_last_flush);
             }
         }
+        flush_commands();
         run_command("exit");
         flush_commands();
         if (pipe_) {


### PR DESCRIPTION
Fix for #27 