### PR TITLE
Make main dependencies private

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,6 +45,5 @@ if (MASTER_PROJECT)
         ${CMAKE_CURRENT_BINARY_DIR}/matplot++-config.cmake
         INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/Matplot++)
     install(FILES ${CMAKE_CURRENT_BINARY_DIR}/matplot++-config.cmake
-                  ${CMAKE_CURRENT_SOURCE_DIR}/cmake/FindFilesystem.cmake
         DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/Matplot++)
 endif()

--- a/matplot++-config.cmake.in
+++ b/matplot++-config.cmake.in
@@ -1,10 +1,4 @@
-include(CMakeFindDependencyMacro)
-
 @PACKAGE_INIT@
-
-list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}")
-find_dependency(Filesystem)
-list(POP_BACK CMAKE_MODULE_PATH)
 
 include("${CMAKE_CURRENT_LIST_DIR}/Matplot++Targets.cmake")
 

--- a/source/3rd_party/CMakeLists.txt
+++ b/source/3rd_party/CMakeLists.txt
@@ -1,5 +1,3 @@
-set(MATPLOT_DEPS_INCLUDE_DIR ${CMAKE_INSTALL_INCLUDEDIR}/matplot/deps)
-
 # Add nodesoup library
 if(WITH_SYSTEM_NODESOUP)
   find_path(NODESOUP_INCLUDE_DIR nodesoup.hpp REQUIRED)
@@ -39,23 +37,13 @@ else()
 endif()
 
 # Add CImg library
-add_library(cimg INTERFACE)
+add_library(cimg INTERFACE IMPORTED)
 if(WITH_SYSTEM_CIMG)
   find_path(CIMG_INCLUDE_DIR CImg.h REQUIRED)
-
-  target_include_directories(cimg INTERFACE ${CIMG_INCLUDE_DIR})
 else()
   set(CIMG_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/cimg)
-
-  target_include_directories(cimg
-      INTERFACE $<BUILD_INTERFACE:${CIMG_INCLUDE_DIR}>
-                $<INSTALL_INTERFACE:${MATPLOT_DEPS_INCLUDE_DIR}>)
-
-  if(MASTER_PROJECT)
-    install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/cimg/CImg.h
-        DESTINATION ${MATPLOT_DEPS_INCLUDE_DIR})
-  endif()
 endif()
+target_include_directories(cimg INTERFACE ${CIMG_INCLUDE_DIR})
 
 
 find_package(PkgConfig)
@@ -176,15 +164,4 @@ if(NOT WIN32)
 else()
   target_compile_definitions(cimg INTERFACE cimg_display=2)
   target_link_libraries(cimg INTERFACE gdi32)
-endif()
-
-# Install
-if(MASTER_PROJECT)
-  install(TARGETS cimg
-      EXPORT Matplot++Targets)
-  if(NOT BUILD_SHARED_LIBS)
-    install(TARGETS nodesoup
-        EXPORT Matplot++Targets
-        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}/Matplot++)
-  endif()
 endif()

--- a/source/3rd_party/CMakeLists.txt
+++ b/source/3rd_party/CMakeLists.txt
@@ -5,7 +5,7 @@ if(WITH_SYSTEM_NODESOUP)
   find_path(NODESOUP_INCLUDE_DIR nodesoup.hpp REQUIRED)
   find_library(NODESOUP_LIB nodesoup REQUIRED)
 
-  add_library(nodesoup INTERFACE)
+  add_library(nodesoup INTERFACE IMPORTED)
   target_include_directories(nodesoup INTERFACE ${NODESOUP_INCLUDE_DIR})
   target_link_libraries(nodesoup INTERFACE ${NODESOUP_LIB})
 else()
@@ -24,16 +24,17 @@ else()
   set_target_properties(nodesoup PROPERTIES
       CXX_VISIBILITY_PRESET     "hidden")
   target_include_directories(nodesoup
-      PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/nodesoup/include>
-             $<INSTALL_INTERFACE:${MATPLOT_DEPS_INCLUDE_DIR}>)
+      PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/nodesoup/include>)
 
   # Hackfix to support MSVC standard library
   # https://docs.microsoft.com/en-us/cpp/c-runtime-library/math-constants?view=vs-2019
   target_compile_definitions(nodesoup PRIVATE _USE_MATH_DEFINES)
 
-  if(MASTER_PROJECT)
-    install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/nodesoup/include/nodesoup.hpp
-        DESTINATION ${MATPLOT_DEPS_INCLUDE_DIR})
+  # Install
+  if(MASTER_PROJECT AND NOT BUILD_SHARED_LIBS)
+    install(TARGETS nodesoup
+        EXPORT Matplot++Targets
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}/Matplot++)
   endif()
 endif()
 
@@ -179,8 +180,11 @@ endif()
 
 # Install
 if(MASTER_PROJECT)
-  install(TARGETS nodesoup cimg
-      EXPORT Matplot++Targets
-      LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}/Matplot++
-      ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}/Matplot++)
+  install(TARGETS cimg
+      EXPORT Matplot++Targets)
+  if(NOT BUILD_SHARED_LIBS)
+    install(TARGETS nodesoup
+        EXPORT Matplot++Targets
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}/Matplot++)
+  endif()
 endif()

--- a/source/3rd_party/CMakeLists.txt
+++ b/source/3rd_party/CMakeLists.txt
@@ -3,7 +3,7 @@ if(WITH_SYSTEM_NODESOUP)
   find_path(NODESOUP_INCLUDE_DIR nodesoup.hpp REQUIRED)
   find_library(NODESOUP_LIB nodesoup REQUIRED)
 
-  add_library(nodesoup INTERFACE IMPORTED)
+  add_library(nodesoup INTERFACE IMPORTED GLOBAL)
   target_include_directories(nodesoup INTERFACE ${NODESOUP_INCLUDE_DIR})
   target_link_libraries(nodesoup INTERFACE ${NODESOUP_LIB})
 else()
@@ -37,7 +37,7 @@ else()
 endif()
 
 # Add CImg library
-add_library(cimg INTERFACE IMPORTED)
+add_library(cimg INTERFACE IMPORTED GLOBAL)
 if(WITH_SYSTEM_CIMG)
   find_path(CIMG_INCLUDE_DIR CImg.h REQUIRED)
 else()

--- a/source/matplot/CMakeLists.txt
+++ b/source/matplot/CMakeLists.txt
@@ -87,8 +87,7 @@ target_include_directories(matplot
     PUBLIC $<BUILD_INTERFACE:${MATPLOT_ROOT_DIR}/source>
            $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
 target_link_libraries(matplot
-    PUBLIC  cimg
-    PRIVATE nodesoup std::filesystem)
+    PRIVATE cimg nodesoup std::filesystem)
 
 # https://cmake.org/cmake/help/v3.14/manual/cmake-compile-features.7.html#requiring-language-standards
 target_compile_features(matplot PUBLIC cxx_std_17)

--- a/source/matplot/CMakeLists.txt
+++ b/source/matplot/CMakeLists.txt
@@ -86,7 +86,9 @@ add_library(matplot
 target_include_directories(matplot
     PUBLIC $<BUILD_INTERFACE:${MATPLOT_ROOT_DIR}/source>
            $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
-target_link_libraries(matplot PUBLIC nodesoup cimg std::filesystem)
+target_link_libraries(matplot
+    PUBLIC  nodesoup cimg
+    PRIVATE std::filesystem)
 
 # https://cmake.org/cmake/help/v3.14/manual/cmake-compile-features.7.html#requiring-language-standards
 target_compile_features(matplot PUBLIC cxx_std_17)

--- a/source/matplot/CMakeLists.txt
+++ b/source/matplot/CMakeLists.txt
@@ -87,8 +87,8 @@ target_include_directories(matplot
     PUBLIC $<BUILD_INTERFACE:${MATPLOT_ROOT_DIR}/source>
            $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
 target_link_libraries(matplot
-    PUBLIC  nodesoup cimg
-    PRIVATE std::filesystem)
+    PUBLIC  cimg
+    PRIVATE nodesoup std::filesystem)
 
 # https://cmake.org/cmake/help/v3.14/manual/cmake-compile-features.7.html#requiring-language-standards
 target_compile_features(matplot PUBLIC cxx_std_17)


### PR DESCRIPTION
Nodesoup, CImg and std::filesystem dependencies are only required during build and are not part of the public header API. Therefore, they can be made private, and we don't have to install them.

Unfortunately, CMake complains about nodesoup when building Matplot++ as a static library so we must still install `libnodesoup.a` in those cases.