### PR TITLE
Reduce possibly expensive copying and allocating

### DIFF
--- a/source/matplot/axes_objects/bars.cpp
+++ b/source/matplot/axes_objects/bars.cpp
@@ -88,7 +88,7 @@ namespace matplot {
         return res;
     }
 
-    std::string bars::legend_string(const std::string &title) {
+    std::string bars::legend_string(std::string_view title) {
         std::string res;
         for (size_t i = 0; i < ys_.size(); ++i) {
             res += " keyentry with boxes fillstyle solid border rgb '" +
@@ -231,7 +231,7 @@ namespace matplot {
         return *this;
     }
 
-    class bars &bars::face_color(const std::string &color) {
+    class bars &bars::face_color(std::string_view color) {
         face_color(to_array(color));
         return *this;
     }
@@ -268,7 +268,7 @@ namespace matplot {
         return *this;
     }
 
-    class bars &bars::edge_color(const std::string &color) {
+    class bars &bars::edge_color(std::string_view color) {
         edge_color(to_array(color));
         return *this;
     }

--- a/source/matplot/axes_objects/bars.h
+++ b/source/matplot/axes_objects/bars.h
@@ -38,7 +38,7 @@ namespace matplot {
       public /* xlim object virtual functions */:
         // std::string set_variables_string() override;
         std::string plot_string() override;
-        std::string legend_string(const std::string &title) override;
+        std::string legend_string(std::string_view title) override;
         std::string data_string() override;
         // std::string unset_variables_string() override;
         bool requires_colormap() override;
@@ -59,7 +59,7 @@ namespace matplot {
         class bars &face_color(const color_array &face_color);
         class bars &face_color(const std::array<float, 3> &face_color);
         class bars &face_color(std::initializer_list<float> face_color);
-        class bars &face_color(const std::string &color);
+        class bars &face_color(std::string_view color);
 
         const std::vector<color_array> &face_colors() const;
         std::vector<color_array> &face_colors();
@@ -73,7 +73,7 @@ namespace matplot {
         class bars &edge_color(const color_array &edge_color);
         class bars &edge_color(const std::array<float, 3> &edge_color);
         class bars &edge_color(std::initializer_list<float> face_color);
-        class bars &edge_color(const std::string &edge_color);
+        class bars &edge_color(std::string_view edge_color);
 
         const line_spec &edge_style() const;
         class bars &edge_style(const line_spec &edge_style);

--- a/source/matplot/axes_objects/circles.cpp
+++ b/source/matplot/axes_objects/circles.cpp
@@ -37,7 +37,7 @@ namespace matplot {
         return str;
     }
 
-    std::string circles::legend_string(const std::string &title) {
+    std::string circles::legend_string(std::string_view title) {
         return " keyentry with circles linecolor var lw 4 fillstyle solid "
                "border linecolor 'black' title \"" +
                escape(title) + "\"";

--- a/source/matplot/axes_objects/circles.h
+++ b/source/matplot/axes_objects/circles.h
@@ -34,7 +34,7 @@ namespace matplot {
       public /* mandatory virtual functions */:
         // std::string set_variables_string() override;
         std::string plot_string() override;
-        std::string legend_string(const std::string &title) override;
+        std::string legend_string(std::string_view title) override;
         std::string data_string() override;
         // std::string unset_variables_string() override;
         bool requires_colormap() override;

--- a/source/matplot/axes_objects/contours.cpp
+++ b/source/matplot/axes_objects/contours.cpp
@@ -17,7 +17,7 @@
 namespace matplot {
     contours::contours(class axes_type *parent, const vector_2d &X,
                        const vector_2d &Y, const vector_2d &Z,
-                       const std::string &line_spec)
+                       std::string_view line_spec)
         : axes_object(parent), X_data_(X), Y_data_(Y), Z_data_(Z),
           line_spec_(this, line_spec) {
         initialize_preprocessed_data();
@@ -26,7 +26,7 @@ namespace matplot {
     }
 
     contours::contours(class axes_type *parent, const vector_2d &Z,
-                       const std::string &line_spec)
+                       std::string_view line_spec)
         : axes_object(parent), Z_data_(Z), line_spec_(this, line_spec) {
         initialize_preprocessed_data();
         contour_generator_ = QuadContourGenerator(X_data_, Y_data_, Z_data_,
@@ -465,7 +465,7 @@ namespace matplot {
         return std::make_pair(lowers, uppers);
     }
 
-    std::string contours::legend_string(const std::string &title) {
+    std::string contours::legend_string(std::string_view title) {
         auto [min_level_it, max_level_it] =
             std::minmax_element(levels_.begin(), levels_.end());
         double zmax = *max_level_it;
@@ -1217,7 +1217,7 @@ namespace matplot {
         return axes_object::axes_category::two_dimensional;
     }
 
-    class contours &contours::line_style(const std::string &str) {
+    class contours &contours::line_style(std::string_view str) {
         line_spec_.parse_string(str);
         touch();
         return *this;
@@ -1322,7 +1322,7 @@ namespace matplot {
         }
     }
 
-    class contours &contours::font(const std::string &font) {
+    class contours &contours::font(std::string_view font) {
         font_ = font;
         touch();
         return *this;
@@ -1330,7 +1330,7 @@ namespace matplot {
 
     const std::string &contours::font_weight() const { return font_weight_; }
 
-    class contours &contours::font_weight(const std::string &font_weight) {
+    class contours &contours::font_weight(std::string_view font_weight) {
         font_weight_ = font_weight;
         touch();
         return *this;
@@ -1344,7 +1344,7 @@ namespace matplot {
         return *this;
     }
 
-    class contours &contours::font_color(const std::string &fc) {
+    class contours &contours::font_color(std::string_view fc) {
         font_color(to_array(fc));
         return *this;
     }

--- a/source/matplot/axes_objects/contours.h
+++ b/source/matplot/axes_objects/contours.h
@@ -52,10 +52,10 @@ namespace matplot {
         /// \param line_spec Line properties
         contours(class axes_type *parent, const vector_2d &X,
                  const vector_2d &Y, const vector_2d &Z,
-                 const std::string &line_spec = "");
+                 std::string_view line_spec = "");
 
         contours(class axes_type *parent, const vector_2d &Z,
-                 const std::string &line_spec = "");
+                 std::string_view line_spec = "");
 
         /// If we receive an axes_handle, we can convert it to a raw
         /// pointer because there is no ownership involved here
@@ -66,7 +66,7 @@ namespace matplot {
       public /* mandatory virtual functions */:
         std::string set_variables_string() override;
         std::string plot_string() override;
-        std::string legend_string(const std::string &title) override;
+        std::string legend_string(std::string_view title) override;
         std::string data_string() override;
         bool requires_colormap() override;
         double xmax() override;
@@ -76,7 +76,7 @@ namespace matplot {
         enum axes_object::axes_category axes_category() override;
 
       public /* getters and setters */:
-        class contours &line_style(const std::string &line_spec);
+        class contours &line_style(std::string_view line_spec);
 
         const matplot::line_spec &line_spec() const;
         matplot::line_spec &line_spec();
@@ -107,14 +107,14 @@ namespace matplot {
         class contours &font_size(const float &font_size);
 
         const std::string font() const;
-        class contours &font(const std::string &font);
+        class contours &font(std::string_view font);
 
         const std::string &font_weight() const;
-        class contours &font_weight(const std::string &font_weight);
+        class contours &font_weight(std::string_view font_weight);
 
         const color_array &font_color() const;
         class contours &font_color(const color_array &font_color);
-        class contours &font_color(const std::string &font_color);
+        class contours &font_color(std::string_view font_color);
 
         bool visible() const;
         class contours &visible(bool visible);

--- a/source/matplot/axes_objects/error_bar.cpp
+++ b/source/matplot/axes_objects/error_bar.cpp
@@ -16,7 +16,7 @@ namespace matplot {
                          const std::vector<double> &y_pos_delta,
                          const std::vector<double> &x_neg_delta,
                          const std::vector<double> &x_pos_delta,
-                         const std::string &line_spec)
+                         std::string_view line_spec)
         : line(parent, x, y, line_spec), y_negative_delta_(y_neg_delta),
           y_positive_delta_(y_pos_delta), x_negative_delta_(x_neg_delta),
           x_positive_delta_(x_pos_delta) {}
@@ -24,7 +24,7 @@ namespace matplot {
     error_bar::error_bar(class axes_type *parent, const std::vector<double> &x,
                          const std::vector<double> &y,
                          const std::vector<double> &error, error_bar::type type,
-                         const std::string &line_spec)
+                         std::string_view line_spec)
         : line(parent, x, y, line_spec),
           y_negative_delta_(type != error_bar::type::horizontal
                                 ? error

--- a/source/matplot/axes_objects/error_bar.h
+++ b/source/matplot/axes_objects/error_bar.h
@@ -24,14 +24,14 @@ namespace matplot {
                   const std::vector<double> &y_pos_delta,
                   const std::vector<double> &x_neg_delta,
                   const std::vector<double> &x_pos_delta,
-                  const std::string &line_spec = "");
+                  std::string_view line_spec = "");
 
         /// Construct with y error only
         error_bar(class axes_type *parent, const std::vector<double> &x_data,
                   const std::vector<double> &y_data,
                   const std::vector<double> &error,
                   error_bar::type type = error_bar::type::vertical,
-                  const std::string &line_spec = "");
+                  std::string_view line_spec = "");
 
         /// If we receive an axes_handle, we can convert it to a raw
         /// pointer because there is no ownership of the xlim

--- a/source/matplot/axes_objects/filled_area.cpp
+++ b/source/matplot/axes_objects/filled_area.cpp
@@ -14,7 +14,7 @@ namespace matplot {
                              const std::vector<double> &x,
                              const std::vector<double> &y,
                              const std::vector<double> &base_values,
-                             bool stacked, const std::string &line_spec)
+                             bool stacked, std::string_view line_spec)
         : line(parent, x, y, line_spec), stacked_(stacked),
           base_data_(base_values) {}
 

--- a/source/matplot/axes_objects/filled_area.h
+++ b/source/matplot/axes_objects/filled_area.h
@@ -21,7 +21,7 @@ namespace matplot {
         filled_area(class axes_type *parent, const std::vector<double> &x,
                     const std::vector<double> &y,
                     const std::vector<double> &base_values = {0.},
-                    bool stacked = true, const std::string &line_spec = "k-");
+                    bool stacked = true, std::string_view line_spec = "k-");
 
         /// If we receive an axes_handle, we can convert it to a raw
         /// pointer because there is no ownership of the xlim

--- a/source/matplot/axes_objects/function_line.cpp
+++ b/source/matplot/axes_objects/function_line.cpp
@@ -12,14 +12,14 @@ namespace matplot {
     function_line::function_line(class axes_type *parent,
                                  const function_type &function,
                                  std::array<double, 2> x_range,
-                                 const std::string &line_spec)
+                                 std::string_view line_spec)
         : line(parent, {}, line_spec), fn_x_(function), t_range_(x_range) {}
 
     function_line::function_line(class axes_type *parent,
                                  const function_type &function_x,
                                  const function_type &function_y,
                                  std::array<double, 2> t_range,
-                                 const std::string &line_spec)
+                                 std::string_view line_spec)
         : line(parent, {}, line_spec), fn_x_(function_x), fn_y_(function_y),
           t_range_(t_range) {}
 
@@ -28,7 +28,7 @@ namespace matplot {
                                  const function_type &function_y,
                                  const function_type &function_z,
                                  std::array<double, 2> t_range,
-                                 const std::string &line_spec)
+                                 std::string_view line_spec)
         : line(parent, {}, line_spec), fn_x_(function_x), fn_y_(function_y),
           fn_z_(function_z), t_range_(t_range) {}
 

--- a/source/matplot/axes_objects/function_line.h
+++ b/source/matplot/axes_objects/function_line.h
@@ -20,18 +20,18 @@ namespace matplot {
 
         function_line(class axes_type *parent, const function_type &equation,
                       std::array<double, 2> x_range = {-5, 5},
-                      const std::string &line_spec = "");
+                      std::string_view line_spec = "");
 
         function_line(class axes_type *parent, const function_type &function_x,
                       const function_type &function_y,
                       std::array<double, 2> t_range = {-5, 5},
-                      const std::string &line_spec = "");
+                      std::string_view line_spec = "");
 
         function_line(class axes_type *parent, const function_type &function_x,
                       const function_type &function_y,
                       const function_type &function_z,
                       std::array<double, 2> t_range = {-5, 5},
-                      const std::string &line_spec = "");
+                      std::string_view line_spec = "");
 
         /// If we receive an axes_handle, we can convert it to a raw
         /// pointer because there is no ownership involved here

--- a/source/matplot/axes_objects/histogram.cpp
+++ b/source/matplot/axes_objects/histogram.cpp
@@ -78,7 +78,7 @@ namespace matplot {
         return ss.str();
     }
 
-    std::string histogram::legend_string(const std::string &title) {
+    std::string histogram::legend_string(std::string_view title) {
         return " keyentry with boxes fillstyle solid border rgb '" +
                to_string(edge_color_) + "' fillcolor '" +
                to_string(face_color_) + "' title \"" + escape(title) + "\"";
@@ -705,7 +705,7 @@ namespace matplot {
         return *this;
     }
 
-    class histogram &histogram::face_color(const std::string &color) {
+    class histogram &histogram::face_color(std::string_view color) {
         face_color(to_array(color));
         return *this;
     }
@@ -744,7 +744,7 @@ namespace matplot {
         return *this;
     }
 
-    class histogram &histogram::edge_color(const std::string &color) {
+    class histogram &histogram::edge_color(std::string_view color) {
         edge_color(to_array(color));
         return *this;
     }

--- a/source/matplot/axes_objects/histogram.h
+++ b/source/matplot/axes_objects/histogram.h
@@ -65,7 +65,7 @@ namespace matplot {
       public /* xlim object virtual functions */:
         // std::string set_variables_string() override;
         std::string plot_string() override;
-        std::string legend_string(const std::string &title) override;
+        std::string legend_string(std::string_view title) override;
         std::string data_string() override;
         // std::string unset_variables_string() override;
         double xmax() override;
@@ -140,7 +140,7 @@ namespace matplot {
         const color_array &face_color() const;
         class histogram &face_color(const color_array &face_color);
         class histogram &face_color(std::initializer_list<float> face_color);
-        class histogram &face_color(const std::string &color);
+        class histogram &face_color(std::string_view color);
 
         class histogram &face_alpha(float alpha);
         class histogram &edge_alpha(float alpha);
@@ -151,7 +151,7 @@ namespace matplot {
         const color_array &edge_color() const;
         class histogram &edge_color(const color_array &edge_color);
         class histogram &edge_color(std::initializer_list<float> face_color);
-        class histogram &edge_color(const std::string &edge_color);
+        class histogram &edge_color(std::string_view edge_color);
 
         const line_spec &edge_style() const;
         class histogram &edge_style(const line_spec &edge_style);

--- a/source/matplot/axes_objects/labels.cpp
+++ b/source/matplot/axes_objects/labels.cpp
@@ -203,7 +203,7 @@ namespace matplot {
 
     const std::string &labels::font() const { return font_; }
 
-    class labels &labels::font(const std::string &font) {
+    class labels &labels::font(std::string_view font) {
         font_ = font;
         touch();
         return *this;

--- a/source/matplot/axes_objects/labels.h
+++ b/source/matplot/axes_objects/labels.h
@@ -85,7 +85,7 @@ namespace matplot {
         }
 
         const std::string &font() const;
-        class labels &font(const std::string &font);
+        class labels &font(std::string_view font);
 
         float font_size() const;
         class labels &font_size(float font_size);

--- a/source/matplot/axes_objects/line.cpp
+++ b/source/matplot/axes_objects/line.cpp
@@ -13,17 +13,17 @@ namespace matplot {
     line::line(class axes_type *parent) : axes_object(parent) {}
 
     line::line(class axes_type *parent, const std::vector<double> &y_data,
-               const std::string &line_spec)
+               std::string_view line_spec)
         : axes_object(parent), y_data_(y_data), line_spec_(this, line_spec) {}
 
     line::line(class axes_type *parent, const std::vector<double> &x_data,
-               const std::vector<double> &y_data, const std::string &line_spec)
+               const std::vector<double> &y_data, std::string_view line_spec)
         : axes_object(parent), x_data_(x_data), y_data_(y_data),
           line_spec_(this, line_spec) {}
 
     line::line(class axes_type *parent, const std::vector<double> &x_data,
                const std::vector<double> &y_data,
-               const std::vector<double> &z_data, const std::string &line_spec)
+               const std::vector<double> &z_data, std::string_view line_spec)
         : axes_object(parent), x_data_(x_data), y_data_(y_data),
           z_data_(z_data), line_spec_(this, line_spec) {}
 
@@ -132,7 +132,7 @@ namespace matplot {
         return res;
     }
 
-    std::string line::legend_string(const std::string &title) {
+    std::string line::legend_string(std::string_view title) {
         if (line_spec_.has_line() && line_spec_.has_non_custom_marker()) {
             return " keyentry " +
                    line_spec_.plot_string(
@@ -348,7 +348,7 @@ namespace matplot {
 
     bool line::requires_colormap() { return !marker_colors_.empty(); }
 
-    class line &line::line_style(const std::string &str) {
+    class line &line::line_style(std::string_view str) {
         line_spec_.parse_string(str);
         touch();
         return *this;

--- a/source/matplot/axes_objects/line.h
+++ b/source/matplot/axes_objects/line.h
@@ -18,14 +18,14 @@ namespace matplot {
       public:
         explicit line(class axes_type *parent);
         line(class axes_type *parent, const std::vector<double> &y_data,
-             const std::string &line_spec = "");
+             std::string_view line_spec = "");
         line(class axes_type *parent, const std::vector<double> &x_data,
              const std::vector<double> &y_data,
-             const std::string &line_spec = "");
+             std::string_view line_spec = "");
         line(class axes_type *parent, const std::vector<double> &x_data,
              const std::vector<double> &y_data,
              const std::vector<double> &z_data,
-             const std::string &line_spec = "");
+             std::string_view line_spec = "");
 
         /// If we receive an axes_handle, we can convert it to a raw
         /// pointer because there is no ownership involved here
@@ -37,7 +37,7 @@ namespace matplot {
         void run_draw_commands() override;
 
         std::string plot_string() override;
-        std::string legend_string(const std::string &title) override;
+        std::string legend_string(std::string_view title) override;
         std::string data_string() override;
         double xmax() override;
         double xmin() override;
@@ -47,7 +47,7 @@ namespace matplot {
         bool requires_colormap() override;
 
       public /* getters and setters */:
-        class line &line_style(const std::string &line_spec);
+        class line &line_style(std::string_view line_spec);
 
         const matplot::line_spec &line_spec() const;
         matplot::line_spec &line_spec();

--- a/source/matplot/axes_objects/network.cpp
+++ b/source/matplot/axes_objects/network.cpp
@@ -18,7 +18,7 @@ namespace matplot {
     network::network(class axes_type *parent,
                      const std::vector<std::pair<size_t, size_t>> &edges,
                      const vector_1d &weights, size_t n_vertices,
-                     const std::string &line_spec)
+                     std::string_view line_spec)
         : axes_object(parent), edges_(edges), weights_(weights),
           n_vertices_(n_vertices), line_spec_(this, line_spec) {
         line_spec_.marker_face(true);
@@ -85,7 +85,7 @@ namespace matplot {
         return res;
     }
 
-    std::string network::legend_string(const std::string &title) {
+    std::string network::legend_string(std::string_view title) {
         if (line_spec_.has_line() && line_spec_.has_non_custom_marker()) {
             return " keyentry " +
                    line_spec_.plot_string(
@@ -444,7 +444,7 @@ namespace matplot {
         }
     }
 
-    class network &network::line_style(const std::string &str) {
+    class network &network::line_style(std::string_view str) {
         line_spec_.parse_string(str);
         touch();
         return *this;

--- a/source/matplot/axes_objects/network.h
+++ b/source/matplot/axes_objects/network.h
@@ -25,7 +25,7 @@ namespace matplot {
         network(class axes_type *parent,
                 const std::vector<std::pair<size_t, size_t>> &edges,
                 const std::vector<double> &weights, size_t n_vertices,
-                const std::string &line_spec = "");
+                std::string_view line_spec = "");
 
         /// If we receive an axes_handle, we can convert it to a raw
         /// pointer because there is no ownership involved here
@@ -35,7 +35,7 @@ namespace matplot {
 
       public /* mandatory virtual functions */:
         std::string plot_string() override;
-        std::string legend_string(const std::string &title) override;
+        std::string legend_string(std::string_view title) override;
         std::string data_string() override;
         double xmax() override;
         double xmin() override;
@@ -44,7 +44,7 @@ namespace matplot {
         enum axes_object::axes_category axes_category() override;
 
       public /* getters and setters */:
-        class network &line_style(const std::string &line_spec);
+        class network &line_style(std::string_view line_spec);
 
         const matplot::line_spec &line_spec() const;
         matplot::line_spec &line_spec();

--- a/source/matplot/axes_objects/parallel_lines.cpp
+++ b/source/matplot/axes_objects/parallel_lines.cpp
@@ -15,7 +15,7 @@ namespace matplot {
 
     parallel_lines::parallel_lines(class axes_type *parent,
                                    const std::vector<std::vector<double>> &data,
-                                   const std::string &line_spec)
+                                   std::string_view line_spec)
         : axes_object(parent), data_(data), line_spec_(this, line_spec) {
         for (size_t i = 0; i < data.size(); ++i) {
             axis_.emplace_back(parent_, true);
@@ -122,7 +122,7 @@ namespace matplot {
         }
     }
 
-    std::string parallel_lines::legend_string(const std::string &title) {
+    std::string parallel_lines::legend_string(std::string_view title) {
         return " keyentry " +
                line_spec_.plot_string(
                    line_spec::style_to_plot::plot_line_only) +

--- a/source/matplot/axes_objects/parallel_lines.h
+++ b/source/matplot/axes_objects/parallel_lines.h
@@ -20,7 +20,7 @@ namespace matplot {
         explicit parallel_lines(class axes_type *parent);
         parallel_lines(class axes_type *parent,
                        const std::vector<std::vector<double>> &data,
-                       const std::string &line_spec = "");
+                       std::string_view line_spec = "");
 
         /// If we receive an axes_handle, we can convert it to a raw
         /// pointer because there is no ownership involved here
@@ -31,7 +31,7 @@ namespace matplot {
       public /* mandatory virtual functions */:
         std::string set_variables_string() override;
         std::string plot_string() override;
-        std::string legend_string(const std::string &title) override;
+        std::string legend_string(std::string_view title) override;
         std::string data_string() override;
         std::string unset_variables_string() override;
         enum axes_object::axes_category axes_category() override;

--- a/source/matplot/axes_objects/stair.cpp
+++ b/source/matplot/axes_objects/stair.cpp
@@ -10,12 +10,12 @@ namespace matplot {
     stair::stair(class axes_type *parent) : line(parent) {}
 
     stair::stair(class axes_type *parent, const std::vector<double> &y_data,
-                 const std::string &line_spec)
+                 std::string_view line_spec)
         : line(parent, y_data, line_spec) {}
 
     stair::stair(class axes_type *parent, const std::vector<double> &x_data,
                  const std::vector<double> &y_data,
-                 const std::string &line_spec)
+                 std::string_view line_spec)
         : line(parent, x_data, y_data, line_spec) {}
 
     std::vector<line_spec::style_to_plot> stair::styles_to_plot() {

--- a/source/matplot/axes_objects/stair.h
+++ b/source/matplot/axes_objects/stair.h
@@ -29,10 +29,10 @@ namespace matplot {
       public:
         explicit stair(class axes_type *parent);
         stair(class axes_type *parent, const std::vector<double> &y_data,
-              const std::string &line_spec = "");
+              std::string_view line_spec = "");
         stair(class axes_type *parent, const std::vector<double> &x_data,
               const std::vector<double> &y_data,
-              const std::string &line_spec = "");
+              std::string_view line_spec = "");
 
         /// If we receive an axes_handle, we can convert it to a raw
         /// pointer because there is no ownership involved here

--- a/source/matplot/axes_objects/string_function.cpp
+++ b/source/matplot/axes_objects/string_function.cpp
@@ -10,8 +10,8 @@ namespace matplot {
         : string_function(parent, "x", "") {}
 
     string_function::string_function(class axes_type *parent,
-                                     const std::string &equation,
-                                     const std::string &line_spec)
+                                     std::string_view equation,
+                                     std::string_view line_spec)
         : line(parent, {}, line_spec), equation_(equation) {}
 
     std::string string_function::plot_string() {
@@ -71,7 +71,7 @@ namespace matplot {
     const std::string &string_function::equation() const { return equation_; }
 
     class string_function &
-    string_function::equation(const std::string &equation) {
+    string_function::equation(std::string_view equation) {
         equation_ = equation;
         parent()->draw();
         return *this;

--- a/source/matplot/axes_objects/string_function.h
+++ b/source/matplot/axes_objects/string_function.h
@@ -14,8 +14,8 @@ namespace matplot {
     class string_function : public line {
       public:
         explicit string_function(class axes_type *parent);
-        string_function(class axes_type *parent, const std::string &equation,
-                        const std::string &line_spec = "");
+        string_function(class axes_type *parent, std::string_view equation,
+                        std::string_view line_spec = "");
 
         /// If we receive an axes_handle, we can convert it to a raw
         /// pointer because there is no ownership involved here
@@ -34,7 +34,7 @@ namespace matplot {
 
       public:
         const std::string &equation() const;
-        class string_function &equation(const std::string &equation);
+        class string_function &equation(std::string_view equation);
 
       private:
         std::string equation_;

--- a/source/matplot/axes_objects/surface.cpp
+++ b/source/matplot/axes_objects/surface.cpp
@@ -14,7 +14,7 @@ namespace matplot {
 
     surface::surface(class axes_type *parent, const vector_2d &X,
                      const vector_2d &Y, const vector_2d &Z, const vector_2d &C,
-                     const std::string &line_spec)
+                     std::string_view line_spec)
         : axes_object(parent), X_data_(X), Y_data_(Y), Z_data_(Z), C_data_(C),
           line_spec_(this, line_spec), contour_line_spec_(this, ""),
           is_parametric_(false) {
@@ -336,7 +336,7 @@ namespace matplot {
         return ss.str();
     }
 
-    std::string surface::legend_string(const std::string &title) {
+    std::string surface::legend_string(std::string_view title) {
         return " keyentry " +
                line_spec_.plot_string(
                    line_spec::style_to_plot::plot_line_only) +
@@ -581,7 +581,7 @@ namespace matplot {
         }
     }
 
-    class surface &surface::line_style(const std::string &str) {
+    class surface &surface::line_style(std::string_view str) {
         line_spec_.parse_string(str);
         touch();
         return *this;
@@ -788,7 +788,7 @@ namespace matplot {
         }
     }
 
-    class surface &surface::font(const std::string &font) {
+    class surface &surface::font(std::string_view font) {
         font_ = font;
         touch();
         return *this;
@@ -796,7 +796,7 @@ namespace matplot {
 
     const std::string &surface::font_weight() const { return font_weight_; }
 
-    class surface &surface::font_weight(const std::string &font_weight) {
+    class surface &surface::font_weight(std::string_view font_weight) {
         font_weight_ = font_weight;
         touch();
         return *this;
@@ -810,7 +810,7 @@ namespace matplot {
         return *this;
     }
 
-    class surface &surface::font_color(const std::string &fc) {
+    class surface &surface::font_color(std::string_view fc) {
         font_color(to_array(fc));
         return *this;
     }

--- a/source/matplot/axes_objects/surface.h
+++ b/source/matplot/axes_objects/surface.h
@@ -28,7 +28,7 @@ namespace matplot {
         /// Grid surface
         surface(class axes_type *parent, const vector_2d &X, const vector_2d &Y,
                 const vector_2d &Z, const vector_2d &C,
-                const std::string &line_spec = "");
+                std::string_view line_spec = "");
 
         /// Parametric surface
         //        surface(class xlim* parent, const vector_1d& x, const
@@ -44,7 +44,7 @@ namespace matplot {
       public /* mandatory virtual functions */:
         std::string set_variables_string() override;
         std::string plot_string() override;
-        std::string legend_string(const std::string &title) override;
+        std::string legend_string(std::string_view title) override;
         std::string data_string() override;
         double xmax() override;
         double xmin() override;
@@ -53,7 +53,7 @@ namespace matplot {
         enum axes_object::axes_category axes_category() override;
 
       public /* getters and setters */:
-        class surface &line_style(const std::string &line_spec);
+        class surface &line_style(std::string_view line_spec);
 
         const matplot::line_spec &line_spec() const;
         matplot::line_spec &line_spec();
@@ -118,14 +118,14 @@ namespace matplot {
         class surface &font_size(const float &font_size);
 
         const std::string font() const;
-        class surface &font(const std::string &font);
+        class surface &font(std::string_view font);
 
         const std::string &font_weight() const;
-        class surface &font_weight(const std::string &font_weight);
+        class surface &font_weight(std::string_view font_weight);
 
         const color_array &font_color() const;
         class surface &font_color(const color_array &font_color);
-        class surface &font_color(const std::string &font_color);
+        class surface &font_color(std::string_view font_color);
 
         bool depthorder() const;
 

--- a/source/matplot/axes_objects/vectors.cpp
+++ b/source/matplot/axes_objects/vectors.cpp
@@ -13,19 +13,19 @@ namespace matplot {
     vectors::vectors(class axes_type *parent) : axes_object(parent) {}
 
     vectors::vectors(class axes_type *parent, const std::vector<double> &v_data,
-                     const std::string &line_spec)
+                     std::string_view line_spec)
         : axes_object(parent), v_data_(v_data), line_spec_(this, line_spec) {}
 
     vectors::vectors(class axes_type *parent, const std::vector<double> &u_data,
                      const std::vector<double> &v_data,
-                     const std::string &line_spec)
+                     std::string_view line_spec)
         : axes_object(parent), u_data_(u_data), v_data_(v_data),
           line_spec_(this, line_spec) {}
 
     vectors::vectors(class axes_type *parent, const std::vector<double> &u_data,
                      const std::vector<double> &v_data,
                      const std::vector<double> &w_data,
-                     const std::string &line_spec)
+                     std::string_view line_spec)
         : axes_object(parent), u_data_(u_data), v_data_(v_data),
           w_data_(w_data), line_spec_(this, line_spec) {}
 
@@ -33,7 +33,7 @@ namespace matplot {
                      const std::vector<double> &y_data,
                      const std::vector<double> &u_data,
                      const std::vector<double> &v_data,
-                     const std::string &line_spec)
+                     std::string_view line_spec)
         : axes_object(parent), x_data_(x_data), y_data_(y_data),
           u_data_(u_data), v_data_(v_data), line_spec_(this, line_spec) {}
 
@@ -43,7 +43,7 @@ namespace matplot {
                      const std::vector<double> &u_data,
                      const std::vector<double> &v_data,
                      const std::vector<double> &w_data,
-                     const std::string &line_spec)
+                     std::string_view line_spec)
         : axes_object(parent), x_data_(x_data), y_data_(y_data),
           z_data_(z_data), u_data_(u_data), v_data_(v_data), w_data_(w_data),
           line_spec_(this, line_spec) {}
@@ -60,7 +60,7 @@ namespace matplot {
         return ss.str();
     }
 
-    std::string vectors::legend_string(const std::string &title) {
+    std::string vectors::legend_string(std::string_view title) {
         return " keyentry with vectors " +
                line_spec_.plot_string(line_spec::style_to_plot::plot_line_only,
                                       false) +
@@ -243,7 +243,7 @@ namespace matplot {
         }
     }
 
-    class vectors &vectors::line_style(const std::string &str) {
+    class vectors &vectors::line_style(std::string_view str) {
         line_spec_.parse_string(str);
         touch();
         return *this;

--- a/source/matplot/axes_objects/vectors.h
+++ b/source/matplot/axes_objects/vectors.h
@@ -21,24 +21,24 @@ namespace matplot {
 
         /// Origin xy = (0,0), u = {1,...n}, v = {v_data}
         vectors(class axes_type *parent, const std::vector<double> &v_data,
-                const std::string &line_spec = "");
+                std::string_view line_spec = "");
 
         /// Origin xy = (0,0), u = {u_data}, v = {v_data}
         vectors(class axes_type *parent, const std::vector<double> &u_data,
                 const std::vector<double> &v_data,
-                const std::string &line_spec = "");
+                std::string_view line_spec = "");
 
         /// Origin xy = (0,0,0), u = {u_data}, v = {v_data}, w = {w_data}
         vectors(class axes_type *parent, const std::vector<double> &u_data,
                 const std::vector<double> &v_data,
                 const std::vector<double> &w_data,
-                const std::string &line_spec = "");
+                std::string_view line_spec = "");
 
         vectors(class axes_type *parent, const std::vector<double> &x_data,
                 const std::vector<double> &y_data,
                 const std::vector<double> &u_data,
                 const std::vector<double> &v_data,
-                const std::string &line_spec = "");
+                std::string_view line_spec = "");
 
         vectors(class axes_type *parent, const std::vector<double> &x_data,
                 const std::vector<double> &y_data,
@@ -46,7 +46,7 @@ namespace matplot {
                 const std::vector<double> &u_data,
                 const std::vector<double> &v_data,
                 const std::vector<double> &w_data,
-                const std::string &line_spec = "");
+                std::string_view line_spec = "");
 
         /// If we receive an axes_handle, we can convert it to a raw
         /// pointer because there is no ownership involved here
@@ -56,7 +56,7 @@ namespace matplot {
 
       public /* mandatory virtual functions */:
         std::string plot_string() override;
-        std::string legend_string(const std::string &title) override;
+        std::string legend_string(std::string_view title) override;
         std::string data_string() override;
         double xmax() override;
         double xmin() override;
@@ -65,7 +65,7 @@ namespace matplot {
         enum axes_object::axes_category axes_category() override;
 
       public /* getters and setters */:
-        class vectors &line_style(const std::string &line_spec);
+        class vectors &line_style(std::string_view line_spec);
 
         const matplot::line_spec &line_spec() const;
         matplot::line_spec &line_spec();

--- a/source/matplot/core/axes_object.cpp
+++ b/source/matplot/core/axes_object.cpp
@@ -36,7 +36,7 @@ namespace matplot {
 
     std::string axes_object::set_variables_string() { return ""; }
 
-    std::string axes_object::legend_string(const std::string &title) {
+    std::string axes_object::legend_string(std::string_view title) {
         return "keyentry with boxes title \"" + escape(title) + "\"";
     }
 
@@ -79,7 +79,7 @@ namespace matplot {
 
     std::string axes_object::tag() { return tag_; }
 
-    void axes_object::tag(const std::string &tag_name) { tag_ = tag_name; }
+    void axes_object::tag(std::string_view tag_name) { tag_ = tag_name; }
 
     bool axes_object::is_2d() {
         return axes_category() == axes_category::two_dimensional;
@@ -102,7 +102,7 @@ namespace matplot {
         return display_name_;
     }
 
-    void axes_object::display_name(const std::string &display_name) {
+    void axes_object::display_name(std::string_view display_name) {
         display_name_ = display_name;
         touch();
     }

--- a/source/matplot/core/axes_object.h
+++ b/source/matplot/core/axes_object.h
@@ -38,7 +38,7 @@ namespace matplot {
         virtual axes_category axes_category();
         virtual bool requires_colormap();
         virtual std::string tag();
-        virtual void tag(const std::string &);
+        virtual void tag(std::string_view);
         bool is_3d();
         bool is_3d_map();
         bool is_2d();
@@ -55,7 +55,7 @@ namespace matplot {
 
         // Create a legend string for this object
         // https://stackoverflow.com/questions/60617211/how-to-put-a-rectangle-in-the-key-with-same-hue-as-a-shaded-area-in-gnuplot/60624922#60624922
-        virtual std::string legend_string(const std::string &legend);
+        virtual std::string legend_string(std::string_view legend);
 
         // Take a number of legends from the range [legends_begin, legends_end]
         // and advance the legends_begin iterator.
@@ -79,7 +79,7 @@ namespace matplot {
         // In this case, we use the display name for legends
         // instead of the strings in the legends object
         const std::string &display_name() const;
-        void display_name(const std::string &display_name);
+        void display_name(std::string_view display_name);
 
       protected:
         std::string tag_{"axes_object"};

--- a/source/matplot/core/axes_type.cpp
+++ b/source/matplot/core/axes_type.cpp
@@ -1196,21 +1196,21 @@ namespace matplot {
 
     const std::string &axes_type::xlabel() const { return x_axis_.label(); }
 
-    void axes_type::xlabel(const std::string &str) {
+    void axes_type::xlabel(std::string_view str) {
         x_axis_.label(str);
         touch();
     }
 
     const std::string &axes_type::x2label() const { return x2_axis_.label(); }
 
-    void axes_type::x2label(const std::string &str) {
+    void axes_type::x2label(std::string_view str) {
         x2_axis_.label(str);
         touch();
     }
 
     const std::string &axes_type::ylabel() const { return y_axis_.label(); }
 
-    void axes_type::ylabel(const std::string &str) {
+    void axes_type::ylabel(std::string_view str) {
         y_axis_.label(str);
         touch();
     }
@@ -1219,7 +1219,7 @@ namespace matplot {
         return x_axis_.tick_label_format();
     }
 
-    void axes_type::xtickformat(const std::string &str) {
+    void axes_type::xtickformat(std::string_view str) {
         x_axis_.tick_label_format(str);
     }
 
@@ -1227,7 +1227,7 @@ namespace matplot {
         return x2_axis_.tick_label_format();
     }
 
-    void axes_type::x2tickformat(const std::string &str) {
+    void axes_type::x2tickformat(std::string_view str) {
         x2_axis_.tick_label_format(str);
     }
 
@@ -1235,7 +1235,7 @@ namespace matplot {
         return y_axis_.tick_label_format();
     }
 
-    void axes_type::ytickformat(const std::string &str) {
+    void axes_type::ytickformat(std::string_view str) {
         y_axis_.tick_label_format(str);
     }
 
@@ -1243,7 +1243,7 @@ namespace matplot {
         return y2_axis_.tick_label_format();
     }
 
-    void axes_type::y2tickformat(const std::string &str) {
+    void axes_type::y2tickformat(std::string_view str) {
         y2_axis_.tick_label_format(str);
     }
 
@@ -1251,7 +1251,7 @@ namespace matplot {
         return z_axis_.tick_label_format();
     }
 
-    void axes_type::ztickformat(const std::string &str) {
+    void axes_type::ztickformat(std::string_view str) {
         z_axis_.tick_label_format(str);
     }
 
@@ -1259,27 +1259,27 @@ namespace matplot {
         return r_axis_.tick_label_format();
     }
 
-    void axes_type::rtickformat(const std::string &str) {
+    void axes_type::rtickformat(std::string_view str) {
         r_axis_.tick_label_format(str);
     }
 
     const std::string &axes_type::y2label() const { return y2_axis_.label(); }
 
-    void axes_type::y2label(const std::string &str) {
+    void axes_type::y2label(std::string_view str) {
         y2_axis_.label(str);
         touch();
     }
 
     const std::string &axes_type::zlabel() const { return z_axis_.label(); }
 
-    void axes_type::zlabel(const std::string &str) {
+    void axes_type::zlabel(std::string_view str) {
         z_axis_.label(str);
         touch();
     }
 
     const std::string &axes_type::rlabel() const { return r_axis_.label(); }
 
-    void axes_type::rlabel(const std::string &str) {
+    void axes_type::rlabel(std::string_view str) {
         r_axis_.label(str);
         touch();
     }
@@ -1362,7 +1362,7 @@ namespace matplot {
         }
     }
 
-    void axes_type::font(const std::string &font) {
+    void axes_type::font(std::string_view font) {
         font_ = font;
         touch();
     }
@@ -1382,7 +1382,7 @@ namespace matplot {
 
     const std::string &axes_type::font_weight() const { return font_weight_; }
 
-    void axes_type::font_weight(const std::string &font_weight) {
+    void axes_type::font_weight(std::string_view font_weight) {
         font_weight_ = font_weight;
         touch();
     }
@@ -1401,7 +1401,7 @@ namespace matplot {
         return title_font_weight_;
     }
 
-    void axes_type::title_font_weight(const std::string &title_font_weight) {
+    void axes_type::title_font_weight(std::string_view title_font_weight) {
         title_font_weight_ = title_font_weight;
         touch();
     }
@@ -1418,7 +1418,7 @@ namespace matplot {
         touch();
     }
 
-    void axes_type::color(const std::string &c) { color(string_to_color(c)); }
+    void axes_type::color(std::string_view c) { color(string_to_color(c)); }
 
     void axes_type::color(const enum color &c) { color(to_array(c)); }
 
@@ -1508,7 +1508,7 @@ namespace matplot {
         return line_style_order_;
     }
 
-    void axes_type::line_style_order(const std::string &line_style_order) {
+    void axes_type::line_style_order(std::string_view line_style_order) {
         line_style_order_ = line_style_order;
         touch();
     }
@@ -1581,7 +1581,7 @@ namespace matplot {
 
     const std::string &axes_type::title() const { return title_; }
 
-    void axes_type::title(const std::string &title) {
+    void axes_type::title(std::string_view title) {
         title_ = title;
         title_visible_ = !title.empty();
         if (parent_->children_.size() == 1 && !parent_->quiet_mode()) {
@@ -2224,13 +2224,13 @@ namespace matplot {
 
     const std::string &axes_type::cblabel() const { return cb_axis_.label(); }
 
-    void axes_type::cblabel(const std::string &str) { cb_axis_.label(); }
+    void axes_type::cblabel(std::string_view str) { cb_axis_.label(); }
 
     const std::string &axes_type::cbtickformat() const {
         return cb_axis_.tick_label_format();
     }
 
-    void axes_type::cbtickformat(const std::string &str) {
+    void axes_type::cbtickformat(std::string_view str) {
         cb_axis_.tick_label_format(str);
     }
 
@@ -2300,7 +2300,7 @@ namespace matplot {
 
     line_handle axes_type::plot(const std::vector<double> &x,
                                 const std::vector<double> &y,
-                                const std::string &line_spec) {
+                                std::string_view line_spec) {
         axes_silencer s{this};
         line_handle l = std::make_shared<class line>(this, x, y, line_spec);
         this->emplace_object(l);
@@ -2308,7 +2308,7 @@ namespace matplot {
     }
 
     line_handle axes_type::plot(const std::vector<double> &y,
-                                const std::string &line_spec) {
+                                std::string_view line_spec) {
         axes_silencer s{this};
         line_handle l = std::make_shared<class line>(this, y, line_spec);
         this->emplace_object(l);
@@ -2318,7 +2318,7 @@ namespace matplot {
     std::vector<line_handle>
     axes_type::plot(const std::vector<double> &x,
                     const std::vector<std::vector<double>> &Y,
-                    const std::string &line_spec) {
+                    std::string_view line_spec) {
         axes_silencer s{this};
         std::vector<line_handle> hs;
         bool previous_replace_status = this->next_plot_replace();
@@ -2332,7 +2332,7 @@ namespace matplot {
 
     std::vector<line_handle>
     axes_type::plot(const std::vector<std::vector<double>> &Y,
-                    const std::string &line_spec) {
+                    std::string_view line_spec) {
         axes_silencer s{this};
         std::vector<line_handle> hs;
         bool previous_replace_status = this->next_plot_replace();
@@ -2370,7 +2370,7 @@ namespace matplot {
     line_handle axes_type::plot3(const std::vector<double> &x,
                                  const std::vector<double> &y,
                                  const std::vector<double> &z,
-                                 const std::string &line_spec) {
+                                 std::string_view line_spec) {
         axes_silencer s{this};
         line_handle l = std::make_shared<class line>(this, x, y, z, line_spec);
         this->emplace_object(l);
@@ -2381,7 +2381,7 @@ namespace matplot {
     axes_type::plot3(const std::vector<std::vector<double>> &X,
                      const std::vector<std::vector<double>> &Y,
                      const std::vector<double> &z,
-                     const std::string &line_spec) {
+                     std::string_view line_spec) {
         axes_silencer s{this};
         auto it_x = X.begin();
         auto it_y = Y.begin();
@@ -2401,7 +2401,7 @@ namespace matplot {
     axes_type::plot3(const std::vector<std::vector<double>> &X,
                      const std::vector<std::vector<double>> &Y,
                      const std::vector<std::vector<double>> &Z,
-                     const std::string &line_spec) {
+                     std::string_view line_spec) {
         axes_silencer temp_silencer_{this};
         auto it_x = X.begin();
         auto it_y = Y.begin();
@@ -2421,7 +2421,7 @@ namespace matplot {
 
     stair_handle axes_type::stairs(const std::vector<double> &x,
                                    const std::vector<double> &y,
-                                   const std::string &line_spec) {
+                                   std::string_view line_spec) {
         axes_silencer temp_silencer_{this};
         stair_handle l = std::make_shared<class stair>(this, x, y, line_spec);
         this->emplace_object(l);
@@ -2429,7 +2429,7 @@ namespace matplot {
     }
 
     stair_handle axes_type::stairs(const std::vector<double> &y,
-                                   const std::string &line_spec) {
+                                   std::string_view line_spec) {
         axes_silencer temp_silencer_{this};
         stair_handle l = std::make_shared<class stair>(this, y, line_spec);
         this->emplace_object(l);
@@ -2439,7 +2439,7 @@ namespace matplot {
     std::vector<stair_handle>
     axes_type::stairs(const std::vector<std::vector<double>> &X,
                       const std::vector<std::vector<double>> &Y,
-                      const std::string &line_spec) {
+                      std::string_view line_spec) {
         axes_silencer temp_silencer_{this};
         std::vector<stair_handle> hs;
         bool previous_replace_status = this->next_plot_replace();
@@ -2455,7 +2455,7 @@ namespace matplot {
 
     std::vector<stair_handle>
     axes_type::stairs(const std::vector<std::vector<double>> &Y,
-                      const std::string &line_spec) {
+                      std::string_view line_spec) {
         axes_silencer temp_silencer_{this};
         std::vector<stair_handle> hs;
         bool previous_replace_status = this->next_plot_replace();
@@ -2470,7 +2470,7 @@ namespace matplot {
     std::vector<stair_handle>
     axes_type::stairs(const std::vector<double> &x,
                       const std::vector<std::vector<double>> &Y,
-                      const std::string &line_spec) {
+                      std::string_view line_spec) {
         axes_silencer temp_silencer_{this};
         std::vector<stair_handle> hs;
         bool previous_replace_status = this->next_plot_replace();
@@ -2486,7 +2486,7 @@ namespace matplot {
                                          const std::vector<double> &y,
                                          const std::vector<double> &error,
                                          error_bar::type type,
-                                         const std::string &line_spec) {
+                                         std::string_view line_spec) {
         axes_silencer temp_silencer_{this};
         error_bar_handle l = std::make_shared<class error_bar>(
             this, x, y, error, type, line_spec);
@@ -2500,7 +2500,7 @@ namespace matplot {
                                          const std::vector<double> &y_pos_delta,
                                          const std::vector<double> &x_neg_delta,
                                          const std::vector<double> &x_pos_delta,
-                                         const std::string &line_spec) {
+                                         std::string_view line_spec) {
         axes_silencer temp_silencer_{this};
         error_bar_handle l = std::make_shared<class error_bar>(
             this, x, y, y_neg_delta, y_pos_delta, x_neg_delta, x_pos_delta,
@@ -2512,7 +2512,7 @@ namespace matplot {
     error_bar_handle axes_type::errorbar(const std::vector<double> &x,
                                          const std::vector<double> &y,
                                          const std::vector<double> &y_error,
-                                         const std::string &line_spec) {
+                                         std::string_view line_spec) {
         axes_silencer temp_silencer_{this};
         return this->errorbar(x, y, y_error, error_bar::type::vertical,
                               line_spec);
@@ -2520,7 +2520,7 @@ namespace matplot {
 
     std::vector<filled_area_handle> axes_type::area(
         const std::vector<double> &x, const std::vector<std::vector<double>> &Y,
-        double base_value, bool stacked, const std::string &line_spec) {
+        double base_value, bool stacked, std::string_view line_spec) {
         axes_silencer temp_silencer_{this};
         std::vector<filled_area_handle> hs;
         bool previous_state = this->next_plot_replace();
@@ -2555,7 +2555,7 @@ namespace matplot {
     filled_area_handle axes_type::area(const std::vector<double> &x,
                                        const std::vector<double> &y,
                                        double base_value, bool stacked,
-                                       const std::string &line_spec) {
+                                       std::string_view line_spec) {
         axes_silencer temp_silencer_{this};
         auto as =
             this->area(x, std::vector({y}), base_value, stacked, line_spec);
@@ -2565,7 +2565,7 @@ namespace matplot {
     std::vector<filled_area_handle>
     axes_type::area(const std::vector<std::vector<double>> &Y,
                     double base_value, bool stacked,
-                    const std::string &line_spec) {
+                    std::string_view line_spec) {
         axes_silencer temp_silencer_{this};
         return this->area(iota(1., static_cast<double>(Y.begin()->size())), Y, base_value, stacked,
                           line_spec);
@@ -2573,7 +2573,7 @@ namespace matplot {
 
     std::vector<filled_area_handle>
     axes_type::area(const std::vector<std::vector<double>> &Y, bool stacked,
-                    const std::string &line_spec) {
+                    std::string_view line_spec) {
         axes_silencer temp_silencer_{this};
         return this->area(iota(1., static_cast<double>(Y.begin()->size())), Y, 0., stacked,
                           line_spec);
@@ -2581,7 +2581,7 @@ namespace matplot {
 
     filled_area_handle axes_type::area(const std::vector<double> &y,
                                        double base_value, bool stacked,
-                                       const std::string &line_spec) {
+                                       std::string_view line_spec) {
         axes_silencer temp_silencer_{this};
         return this->area(iota(1., static_cast<double>(y.size())), {y},
                           base_value, stacked, line_spec);
@@ -2589,7 +2589,7 @@ namespace matplot {
 
     line_handle axes_type::fimplicit(axes_type::implicit_function_type equation,
                                      const std::array<double, 4> &xy_interval,
-                                     const std::string &line_spec) {
+                                     std::string_view line_spec) {
         axes_silencer temp_silencer_{this};
         auto [X, Y] = meshgrid(linspace(xy_interval[0], xy_interval[1]),
                                linspace(xy_interval[2], xy_interval[3]));
@@ -2605,13 +2605,13 @@ namespace matplot {
     }
 
     line_handle axes_type::fimplicit(axes_type::implicit_function_type equation,
-                                     const std::string &line_spec) {
+                                     std::string_view line_spec) {
         axes_silencer temp_silencer_{this};
         return this->fimplicit(equation, {-5, 5, -5, 5}, line_spec);
     }
 
-    string_function_handle axes_type::fplot(const std::string &equation,
-                                            const std::string &line_spec) {
+    string_function_handle axes_type::fplot(std::string_view equation,
+                                            std::string_view line_spec) {
         axes_silencer temp_silencer_{this};
         string_function_handle obj =
             std::make_shared<class string_function>(this, equation, line_spec);
@@ -2639,7 +2639,7 @@ namespace matplot {
 
     function_line_handle axes_type::fplot(function_line::function_type equation,
                                           const std::array<double, 2> &x_range,
-                                          const std::string &line_spec) {
+                                          std::string_view line_spec) {
         axes_silencer temp_silencer_{this};
         function_line_handle obj = std::make_shared<class function_line>(
             this, equation, x_range, line_spec);
@@ -2649,7 +2649,7 @@ namespace matplot {
     }
 
     function_line_handle axes_type::fplot(function_line::function_type equation,
-                                          const std::string &line_spec) {
+                                          std::string_view line_spec) {
         axes_silencer temp_silencer_{this};
         function_line_handle obj = std::make_shared<class function_line>(
             this, equation, std::array<double, 2>({-5, 5}), line_spec);
@@ -2662,7 +2662,7 @@ namespace matplot {
     axes_type::fplot(function_line::function_type function_x,
                      function_line::function_type function_y,
                      const std::array<double, 2> &t_range,
-                     const std::string &line_spec) {
+                     std::string_view line_spec) {
         axes_silencer temp_silencer_{this};
         function_line_handle obj = std::make_shared<class function_line>(
             this, function_x, function_y, t_range, line_spec);
@@ -2702,7 +2702,7 @@ namespace matplot {
                       function_line::function_type function_y,
                       function_line::function_type function_z,
                       const std::array<double, 2> &t_range,
-                      const std::string &line_spec) {
+                      std::string_view line_spec) {
         axes_silencer temp_silencer_{this};
         function_line_handle obj = std::make_shared<class function_line>(
             this, function_x, function_y, function_z, t_range, line_spec);
@@ -3173,7 +3173,7 @@ namespace matplot {
     parallel_lines_handle
     axes_type::parallelplot(const std::vector<std::vector<double>> &X,
                             const std::vector<double> &colors,
-                            const std::string &line_spec) {
+                            std::string_view line_spec) {
         axes_silencer temp_silencer_{this};
         parallel_lines_handle l =
             std::make_shared<class parallel_lines>(this, X, line_spec);
@@ -3191,7 +3191,7 @@ namespace matplot {
     /// Parallel plot - default line colors
     parallel_lines_handle
     axes_type::parallelplot(const std::vector<std::vector<double>> &X,
-                            const std::string &line_spec) {
+                            std::string_view line_spec) {
         axes_silencer temp_silencer_{this};
         return this->parallelplot(X, std::vector<double>({}), line_spec);
     }
@@ -3335,7 +3335,7 @@ namespace matplot {
                                     const std::vector<double> &z,
                                     const std::vector<double> &sizes,
                                     const std::vector<double> &colors,
-                                    const std::string &line_spec) {
+                                    std::string_view line_spec) {
         axes_silencer temp_silencer_{this};
         line_handle l = this->plot3(x, y, z, line_spec);
         if (l->line_spec().marker_style() == line_spec::marker_style::none) {
@@ -3356,7 +3356,7 @@ namespace matplot {
     line_handle axes_type::scatter3(const std::vector<double> &x,
                                     const std::vector<double> &y,
                                     const std::vector<double> &z,
-                                    const std::string &line_spec) {
+                                    std::string_view line_spec) {
         axes_silencer temp_silencer_{this};
         return this->scatter3(x, y, z, {}, {}, line_spec);
     }
@@ -3473,9 +3473,9 @@ namespace matplot {
     }
 
     labels_handle
-    axes_type::wordcloud(const std::string &text,
+    axes_type::wordcloud(std::string_view text,
                          const std::vector<std::string> &black_list,
-                         const std::string &delimiters, size_t max_cloud_size,
+                         std::string_view delimiters, size_t max_cloud_size,
                          const std::vector<double> &custom_colors) {
         auto [tokens, count] =
             wordcount(text, black_list, delimiters, max_cloud_size);
@@ -3553,7 +3553,7 @@ namespace matplot {
     /// Core plot function
     line_handle axes_type::stem(const std::vector<double> &x,
                                 const std::vector<double> &y,
-                                const std::string &line_spec) {
+                                std::string_view line_spec) {
         axes_silencer temp_silencer_{this};
         line_handle l = this->plot(x, y, line_spec);
         l->impulse(true);
@@ -3563,7 +3563,7 @@ namespace matplot {
 
     /// Basic plot function with automatic x
     line_handle axes_type::stem(const std::vector<double> &y,
-                                const std::string &line_spec) {
+                                std::string_view line_spec) {
         axes_silencer temp_silencer_{this};
 
         line_handle l = this->stem(iota(1, y.size()), y, line_spec);
@@ -3577,7 +3577,7 @@ namespace matplot {
     std::vector<line_handle>
     axes_type::stem(const std::vector<double> &x,
                     const std::vector<std::vector<double>> &Y,
-                    const std::string &line_spec) {
+                    std::string_view line_spec) {
         axes_silencer temp_silencer_{this};
 
         std::vector<line_handle> hs = this->plot(x, Y, line_spec);
@@ -3592,7 +3592,7 @@ namespace matplot {
     /// Plot lists of lists with automatic x
     std::vector<line_handle>
     axes_type::stem(const std::vector<std::vector<double>> &Y,
-                    const std::string &line_spec) {
+                    std::string_view line_spec) {
         axes_silencer temp_silencer_{this};
 
         std::vector<line_handle> hs = this->plot(Y, line_spec);
@@ -3608,7 +3608,7 @@ namespace matplot {
     line_handle axes_type::stem3(const std::vector<double> &x,
                                  const std::vector<double> &y,
                                  const std::vector<double> &z,
-                                 const std::string &line_spec) {
+                                 std::string_view line_spec) {
         axes_silencer temp_silencer_{this};
         line_handle l = this->plot3(x, y, z, line_spec);
         l->impulse(true);
@@ -3620,7 +3620,7 @@ namespace matplot {
     axes_type::stem3(const std::vector<std::vector<double>> &X,
                      const std::vector<std::vector<double>> &Y,
                      const std::vector<double> &z,
-                     const std::string &line_spec) {
+                     std::string_view line_spec) {
         axes_silencer temp_silencer_{this};
         auto hs = this->plot3(X, Y, z, line_spec);
         for (auto &h : hs) {
@@ -3631,14 +3631,14 @@ namespace matplot {
 
     /// Stem 3d - Automatic x and y
     line_handle axes_type::stem3(const std::vector<double> &z,
-                                 const std::string &line_spec) {
+                                 std::string_view line_spec) {
         return this->stem3(iota(1, z.size()), std::vector<double>(z.size(), 1.),
                            z, line_spec);
     }
 
     /// Stem 3d - Automatic x and y - Many Zs
     line_handle axes_type::stem3(const std::vector<std::vector<double>> &Z,
-                                 const std::string &line_spec) {
+                                 std::string_view line_spec) {
         axes_silencer temp_silencer_{this};
         std::vector<double> x;
         std::vector<double> y;
@@ -3790,7 +3790,7 @@ namespace matplot {
     /// Core geoplot function - Plot lines on world map
     line_handle axes_type::geoplot(const std::vector<double> &latitude,
                                    const std::vector<double> &longitude,
-                                   const std::string &line_spec) {
+                                   std::string_view line_spec) {
         axes_silencer temp_silencer_{this};
         bool p2 = this->next_plot_replace();
         this->geoplot();
@@ -4064,7 +4064,7 @@ namespace matplot {
     /// Compass plot function
     vectors_handle axes_type::compass(const std::vector<double> &x,
                                       const std::vector<double> &y,
-                                      const std::string &line_spec) {
+                                      std::string_view line_spec) {
         axes_silencer temp_silencer_{this};
 
         auto theta = transform(
@@ -4090,8 +4090,8 @@ namespace matplot {
     }
 
     /// Ezpolar - Plot function on polar plot
-    string_function_handle axes_type::ezpolar(const std::string &equation,
-                                              const std::string &line_spec) {
+    string_function_handle axes_type::ezpolar(std::string_view equation,
+                                              std::string_view line_spec) {
         axes_silencer temp_silencer_{this};
         string_function_handle obj =
             std::make_shared<class string_function>(this, equation, line_spec);
@@ -4129,7 +4129,7 @@ namespace matplot {
     function_line_handle
     axes_type::ezpolar(function_line::function_type equation,
                        const std::array<double, 2> &t_range,
-                       const std::string &line_spec) {
+                       std::string_view line_spec) {
         axes_silencer temp_silencer_{this};
 
         function_line_handle obj = std::make_shared<class function_line>(
@@ -4150,7 +4150,7 @@ namespace matplot {
 
     function_line_handle
     axes_type::ezpolar(function_line::function_type equation,
-                       const std::string &line_spec) {
+                       std::string_view line_spec) {
         axes_silencer temp_silencer_{this};
 
         function_line_handle obj = std::make_shared<class function_line>(
@@ -4171,7 +4171,7 @@ namespace matplot {
     function_line_handle
     axes_type::ezpolar(function_line::function_type equation,
                        std::vector<double> x_range,
-                       const std::string &line_spec) {
+                       std::string_view line_spec) {
         return this->ezpolar(equation, to_array<2>(x_range), line_spec);
     }
 
@@ -4179,7 +4179,7 @@ namespace matplot {
     axes_type::ezpolar(function_line::function_type function_x,
                        function_line::function_type function_y,
                        const std::array<double, 2> &t_range,
-                       const std::string &line_spec) {
+                       std::string_view line_spec) {
         axes_silencer temp_silencer_{this};
 
         function_line_handle obj = std::make_shared<class function_line>(
@@ -4201,7 +4201,7 @@ namespace matplot {
     axes_type::ezpolar(function_line::function_type function_x,
                        function_line::function_type function_y,
                        std::vector<double> t_range,
-                       const std::string &line_spec) {
+                       std::string_view line_spec) {
         return this->ezpolar(function_x, function_y, to_array<2>(t_range),
                              line_spec);
     }
@@ -4257,7 +4257,7 @@ namespace matplot {
     /// Polar plot - Core function
     line_handle axes_type::polarplot(const std::vector<double> &theta,
                                      const std::vector<double> &rho,
-                                     const std::string &line_spec) {
+                                     std::string_view line_spec) {
         axes_silencer temp_silencer_{this};
 
         line_handle l = this->plot(theta, rho, line_spec);
@@ -4276,13 +4276,13 @@ namespace matplot {
 
     /// Polar plot - Automatic theta
     line_handle axes_type::polarplot(const std::vector<double> &rho,
-                                     const std::string &line_spec) {
+                                     std::string_view line_spec) {
         return this->polarplot(linspace(0, 2 * pi, rho.size()), rho, line_spec);
     }
 
     /// Polar plot - Complex numbers
     line_handle axes_type::polarplot(const std::vector<std::complex<double>> &z,
-                                     const std::string &line_spec) {
+                                     std::string_view line_spec) {
         std::vector<double> theta;
         std::vector<double> rho;
         for (size_t i = 0; i < z.size(); ++i) {
@@ -4297,7 +4297,7 @@ namespace matplot {
                                         const std::vector<double> &rho,
                                         const std::vector<double> &sizes,
                                         const std::vector<double> &colors,
-                                        const std::string &line_spec) {
+                                        std::string_view line_spec) {
         axes_silencer temp_silencer_{this};
 
         line_handle l = this->scatter(theta, rho, sizes, colors);
@@ -4319,7 +4319,7 @@ namespace matplot {
     line_handle axes_type::polarscatter(const std::vector<double> &theta,
                                         const std::vector<double> &rho,
                                         double size,
-                                        const std::string &line_spec) {
+                                        std::string_view line_spec) {
         return this->polarscatter(theta, rho, std::vector(theta.size(), size),
                                   {}, line_spec);
     }
@@ -4327,7 +4327,7 @@ namespace matplot {
     /// Polar scatter - Default size and colors
     line_handle axes_type::polarscatter(const std::vector<double> &theta,
                                         const std::vector<double> &rho,
-                                        const std::string &line_spec) {
+                                        std::string_view line_spec) {
         return this->polarscatter(theta, rho, {}, {}, line_spec);
     }
 
@@ -4336,7 +4336,7 @@ namespace matplot {
     axes_type::contour(const std::vector<std::vector<double>> &X,
                        const std::vector<std::vector<double>> &Y,
                        const std::vector<std::vector<double>> &Z,
-                       std::vector<double> levels, const std::string &line_spec,
+                       std::vector<double> levels, std::string_view line_spec,
                        size_t n_levels) {
         axes_silencer temp_silencer_{this};
 
@@ -4361,7 +4361,7 @@ namespace matplot {
     axes_type::contour(const std::vector<std::vector<double>> &X,
                        const std::vector<std::vector<double>> &Y,
                        const std::vector<std::vector<double>> &Z,
-                       size_t n_levels, const std::string &line_spec) {
+                       size_t n_levels, std::string_view line_spec) {
         return this->contour(X, Y, Z, {}, line_spec, n_levels);
     }
 
@@ -4370,7 +4370,7 @@ namespace matplot {
     axes_type::contour(const std::vector<std::vector<double>> &X,
                        const std::vector<std::vector<double>> &Y,
                        const std::vector<std::vector<double>> &Z,
-                       const std::string &line_spec) {
+                       std::string_view line_spec) {
         return this->contour(X, Y, Z, 0, line_spec);
     }
 
@@ -4380,7 +4380,7 @@ namespace matplot {
                         const std::vector<std::vector<double>> &Y,
                         const std::vector<std::vector<double>> &Z,
                         std::vector<double> levels,
-                        const std::string &line_spec, size_t n_levels) {
+                        std::string_view line_spec, size_t n_levels) {
         axes_silencer temp_silencer_{this};
 
         contours_handle l = this->contour(X, Y, Z, levels, line_spec, n_levels);
@@ -4396,7 +4396,7 @@ namespace matplot {
     axes_type::contourf(const std::vector<std::vector<double>> &X,
                         const std::vector<std::vector<double>> &Y,
                         const std::vector<std::vector<double>> &Z,
-                        size_t n_levels, const std::string &line_spec) {
+                        size_t n_levels, std::string_view line_spec) {
         return this->contourf(X, Y, Z, {}, line_spec, n_levels);
     }
 
@@ -4405,7 +4405,7 @@ namespace matplot {
     axes_type::contourf(const std::vector<std::vector<double>> &X,
                         const std::vector<std::vector<double>> &Y,
                         const std::vector<std::vector<double>> &Z,
-                        const std::string &line_spec) {
+                        std::string_view line_spec) {
         return this->contourf(X, Y, Z, 0, line_spec);
     }
 
@@ -4416,7 +4416,7 @@ namespace matplot {
     contours_handle axes_type::fcontour(fcontour_function_type fn,
                                         const std::array<double, 4> &xy_range,
                                         std::vector<double> levels,
-                                        const std::string &line_spec,
+                                        std::string_view line_spec,
                                         size_t n_levels) {
         axes_silencer temp_silencer_{this};
 
@@ -4438,21 +4438,21 @@ namespace matplot {
     /// Lambda function contour - Manual number of levels (default = 9)
     contours_handle axes_type::fcontour(fcontour_function_type fn,
                                         size_t n_levels,
-                                        const std::string &line_spec) {
+                                        std::string_view line_spec) {
         return this->fcontour(fn, std::array<double, 4>{-5, +5, -5, +5},
                               std::vector<double>{}, line_spec, n_levels);
     }
 
     /// Lambda function contour - Automatic number of levels and levels
     contours_handle axes_type::fcontour(fcontour_function_type fn,
-                                        const std::string &line_spec) {
+                                        std::string_view line_spec) {
         return this->fcontour(fn, 9, line_spec);
     }
 
     /// Feather - Core function
     vectors_handle axes_type::feather(const std::vector<double> &u,
                                       const std::vector<double> &v,
-                                      const std::string &line_spec) {
+                                      std::string_view line_spec) {
         axes_silencer temp_silencer_{this};
 
         vectors_handle l =
@@ -4478,7 +4478,7 @@ namespace matplot {
                                      const std::vector<double> &y,
                                      const std::vector<double> &u,
                                      const std::vector<double> &v, double scale,
-                                     const std::string &line_spec) {
+                                     std::string_view line_spec) {
         axes_silencer temp_silencer_{this};
 
         auto x_copy = x;
@@ -4525,7 +4525,7 @@ namespace matplot {
                                      const std::vector<std::vector<double>> &u,
                                      const std::vector<std::vector<double>> &v,
                                      double scale,
-                                     const std::string &line_spec) {
+                                     std::string_view line_spec) {
         return this->quiver(flatten(x), flatten(y), flatten(u), flatten(v),
                             scale, line_spec);
     }
@@ -4535,7 +4535,7 @@ namespace matplot {
         const std::vector<double> &x, const std::vector<double> &y,
         const std::vector<double> &z, const std::vector<double> &u,
         const std::vector<double> &v, const std::vector<double> &w,
-        double scale, const std::string &line_spec) {
+        double scale, std::string_view line_spec) {
         axes_silencer temp_silencer_{this};
 
         auto x_copy = x;
@@ -4599,7 +4599,7 @@ namespace matplot {
                                       const std::vector<std::vector<double>> &v,
                                       const std::vector<std::vector<double>> &w,
                                       double scale,
-                                      const std::string &line_spec) {
+                                      std::string_view line_spec) {
         return this->quiver3(flatten(x), flatten(y), flatten(z), flatten(u),
                              flatten(v), flatten(w), scale, line_spec);
     }
@@ -4610,7 +4610,7 @@ namespace matplot {
                                       const std::vector<std::vector<double>> &v,
                                       const std::vector<std::vector<double>> &w,
                                       double scale,
-                                      const std::string &line_spec) {
+                                      std::string_view line_spec) {
         auto [n, m] = size(z);
         vector_1d x = iota(1, m);
         vector_1d y = iota(1, n);
@@ -4724,7 +4724,7 @@ namespace matplot {
     surface_handle axes_type::fsurf(fcontour_function_type fn,
                                     const std::array<double, 2> &x_range,
                                     const std::array<double, 2> &y_range,
-                                    std::string line_spec,
+                                    std::string_view line_spec,
                                     double mesh_density) {
         axes_silencer temp_silencer_{this};
 
@@ -4746,7 +4746,7 @@ namespace matplot {
                                     fcontour_function_type funz,
                                     const std::array<double, 2> &u_range,
                                     const std::array<double, 2> &v_range,
-                                    std::string line_spec,
+                                    std::string_view line_spec,
                                     double mesh_density) {
         axes_silencer temp_silencer_{this};
 
@@ -4767,7 +4767,7 @@ namespace matplot {
     /// Grid / Both ranges in the same array size 4
     surface_handle axes_type::fsurf(fcontour_function_type fn,
                                     const std::array<double, 4> &xy_range,
-                                    std::string line_spec,
+                                    std::string_view line_spec,
                                     double mesh_density) {
         return this->fsurf(fn, {xy_range[0], xy_range[1]},
                            {xy_range[2], xy_range[3]}, line_spec,
@@ -4779,7 +4779,7 @@ namespace matplot {
                                     fcontour_function_type funy,
                                     fcontour_function_type funz,
                                     const std::array<double, 4> &uv_range,
-                                    std::string line_spec,
+                                    std::string_view line_spec,
                                     double mesh_density) {
         return this->fsurf(funx, funy, funz, {uv_range[0], uv_range[1]},
                            {uv_range[2], uv_range[3]}, line_spec,
@@ -4790,7 +4790,7 @@ namespace matplot {
     /// Grid / Both ranges in the same array size 2
     surface_handle axes_type::fsurf(fcontour_function_type fn,
                                     const std::array<double, 2> &xy_range,
-                                    std::string line_spec,
+                                    std::string_view line_spec,
                                     double mesh_density) {
         return this->fsurf(fn, xy_range, xy_range, line_spec,
                            static_cast<size_t>(mesh_density));
@@ -4802,7 +4802,7 @@ namespace matplot {
                                     fcontour_function_type funy,
                                     fcontour_function_type funz,
                                     const std::array<double, 2> &uv_range,
-                                    std::string line_spec,
+                                    std::string_view line_spec,
                                     double mesh_density) {
         return this->fsurf(funx, funy, funz, uv_range, uv_range, line_spec,
                            static_cast<size_t>(mesh_density));
@@ -4874,7 +4874,7 @@ namespace matplot {
                                    const std::vector<std::vector<double>> &Y,
                                    const std::vector<std::vector<double>> &Z,
                                    const std::vector<std::vector<double>> &C,
-                                   std::string line_spec) {
+                                   std::string_view line_spec) {
         axes_silencer temp_silencer_{this};
 
         surface_handle l =
@@ -4917,7 +4917,7 @@ namespace matplot {
     network_handle
     axes_type::graph(const std::vector<std::pair<size_t, size_t>> &edges,
                      const std::vector<double> &weights, size_t n_vertices,
-                     std::string line_spec) {
+                     std::string_view line_spec) {
         axes_silencer temp_silencer_{this};
 
         network_handle l = std::make_shared<class network>(
@@ -4937,7 +4937,7 @@ namespace matplot {
 
     network_handle
     axes_type::graph(const std::vector<std::pair<size_t, size_t>> &edges,
-                     std::string line_spec) {
+                     std::string_view line_spec) {
         return this->graph(edges, vector_1d{}, 0, line_spec);
     }
 
@@ -5134,14 +5134,14 @@ namespace matplot {
     }
 
     /// Annotate plot with single text
-    labels_handle axes_type::text(double x, double y, const std::string &str) {
-        return this->text(std::vector{x}, std::vector{y}, std::vector{str});
+    labels_handle axes_type::text(double x, double y, std::string_view str) {
+        return this->text(std::vector{x}, std::vector{y}, std::vector{std::string(str)});
     }
 
     /// Annotate plot with same text at many positions
     labels_handle axes_type::text(const vector_1d &x, const vector_1d &y,
-                                  const std::string &str) {
-        return this->text(x, y, std::vector<std::string>(x.size(), str));
+                                  std::string_view str) {
+        return this->text(x, y, std::vector<std::string>(x.size(), std::string(str)));
     }
 
     /// Annotate plot with arrow
@@ -5179,7 +5179,7 @@ namespace matplot {
     /// Annotate plot with text and arrow
     std::pair<labels_handle, vectors_handle>
     axes_type::textarrow(double x1, double y1, double x2, double y2,
-                         const std::string &str) {
+                         std::string_view str) {
         axes_silencer temp_silencer_{this};
         bool p2 = this->next_plot_replace();
         this->next_plot_replace(false);
@@ -5253,7 +5253,7 @@ namespace matplot {
 
     std::pair<labels_handle, line_handle>
     axes_type::textbox(double x, double y, double w, double h,
-                       const std::string &str) {
+                       std::string_view str) {
         axes_silencer temp_silencer_{this};
         bool p2 = this->next_plot_replace();
         this->next_plot_replace(false);
@@ -5267,7 +5267,7 @@ namespace matplot {
     }
 
     line_handle axes_type::fill(const vector_1d &x, const vector_1d &y,
-                                const std::string &line_spec) {
+                                std::string_view line_spec) {
         axes_silencer temp_silencer_{this};
         bool p2 = this->next_plot_replace();
         this->next_plot_replace(false);

--- a/source/matplot/core/axes_type.h
+++ b/source/matplot/core/axes_type.h
@@ -158,11 +158,11 @@ namespace matplot {
 
         const std::string &xlabel() const;
 
-        void xlabel(const std::string &str);
+        void xlabel(std::string_view str);
 
         const std::string &xtickformat() const;
 
-        void xtickformat(const std::string &str);
+        void xtickformat(std::string_view str);
 
         const std::vector<double> &xticks() const;
 
@@ -190,11 +190,11 @@ namespace matplot {
 
         const std::string &x2label() const;
 
-        void x2label(const std::string &str);
+        void x2label(std::string_view str);
 
         const std::string &x2tickformat() const;
 
-        void x2tickformat(const std::string &str);
+        void x2tickformat(std::string_view str);
 
         const std::vector<double> &x2ticks() const;
 
@@ -222,11 +222,11 @@ namespace matplot {
 
         const std::string &ylabel() const;
 
-        void ylabel(const std::string &str);
+        void ylabel(std::string_view str);
 
         const std::string &ytickformat() const;
 
-        void ytickformat(const std::string &str);
+        void ytickformat(std::string_view str);
 
         const std::vector<double> &yticks() const;
 
@@ -254,11 +254,11 @@ namespace matplot {
 
         const std::string &y2label() const;
 
-        void y2label(const std::string &str);
+        void y2label(std::string_view str);
 
         const std::string &y2tickformat() const;
 
-        void y2tickformat(const std::string &str);
+        void y2tickformat(std::string_view str);
 
         const std::vector<double> &y2ticks() const;
 
@@ -286,11 +286,11 @@ namespace matplot {
 
         const std::string &zlabel() const;
 
-        void zlabel(const std::string &str);
+        void zlabel(std::string_view str);
 
         const std::string &ztickformat() const;
 
-        void ztickformat(const std::string &str);
+        void ztickformat(std::string_view str);
 
         const std::vector<double> &zticks() const;
 
@@ -318,11 +318,11 @@ namespace matplot {
 
         const std::string &cblabel() const;
 
-        void cblabel(const std::string &str);
+        void cblabel(std::string_view str);
 
         const std::string &cbtickformat() const;
 
-        void cbtickformat(const std::string &str);
+        void cbtickformat(std::string_view str);
 
         const std::vector<double> &cbticks() const;
 
@@ -362,11 +362,11 @@ namespace matplot {
 
         const std::string &rlabel() const;
 
-        void rlabel(const std::string &str);
+        void rlabel(std::string_view str);
 
         const std::string &rtickformat() const;
 
-        void rtickformat(const std::string &str);
+        void rtickformat(std::string_view str);
 
         const std::vector<double> &rticks() const;
 
@@ -416,7 +416,7 @@ namespace matplot {
 
         const std::string &title() const;
 
-        void title(const std::string &title);
+        void title(std::string_view title);
 
         bool title_enhanced() const;
 
@@ -432,7 +432,7 @@ namespace matplot {
 
         const std::string &font() const;
 
-        void font(const std::string &font);
+        void font(std::string_view font);
 
         float font_size() const;
 
@@ -440,7 +440,7 @@ namespace matplot {
 
         const std::string &font_weight() const;
 
-        void font_weight(const std::string &font_weight);
+        void font_weight(std::string_view font_weight);
 
         bool clipping() const;
 
@@ -456,7 +456,7 @@ namespace matplot {
 
         const std::string &title_font_weight() const;
 
-        void title_font_weight(const std::string &title_font_weight);
+        void title_font_weight(std::string_view title_font_weight);
 
         const color_array &title_color() const;
 
@@ -468,7 +468,7 @@ namespace matplot {
 
         void color(const std::array<float, 3> &color);
 
-        void color(const std::string &c);
+        void color(std::string_view c);
 
         void color(const enum color &c);
 
@@ -566,7 +566,7 @@ namespace matplot {
 
         const std::string &line_style_order() const;
 
-        void line_style_order(const std::string &line_style_order);
+        void line_style_order(std::string_view line_style_order);
 
         size_t line_style_order_index() const;
 
@@ -644,11 +644,11 @@ namespace matplot {
         /// Create simple line plot
         line_handle plot(const std::vector<double> &x,
                          const std::vector<double> &y,
-                         const std::string &line_spec = "");
+                         std::string_view line_spec = "");
 
         /// Create line plot with automatic x = 1,2,...,n
         line_handle plot(const std::vector<double> &y,
-                         const std::string &line_spec = "");
+                         std::string_view line_spec = "");
 
         /// \brief Create many line plots at once with parameter pack
         /// First two parameters are always 1) x and y or 2) y and line spec
@@ -662,7 +662,7 @@ namespace matplot {
         /// is a divider between plots
         template <class... Args>
         auto plot(const std::vector<double> &x, const std::vector<double> &y,
-                  const std::string &line_spec, Args&&... args) {
+                  std::string_view line_spec, Args&&... args) {
             std::vector<line_handle> result;
             std::vector<line_handle> result_a =
                 vectorize(this->plot(x, y, line_spec));
@@ -711,7 +711,7 @@ namespace matplot {
         /// This function represents the case 2, where 2nd parameter line spec
         /// is a divider between plots
         template <class... Args>
-        auto plot(const std::vector<double> &y, const std::string &line_spec,
+        auto plot(const std::vector<double> &y, std::string_view line_spec,
                   Args&&... args) {
             std::vector<line_handle> result;
             std::vector<line_handle> result_a =
@@ -728,11 +728,11 @@ namespace matplot {
         /// Plot lists of lists
         std::vector<line_handle> plot(const std::vector<double> &x,
                                       const std::vector<std::vector<double>> &Y,
-                                      const std::string &line_spec = "");
+                                      std::string_view line_spec = "");
 
         /// Plot lists of lists with automatic x
         std::vector<line_handle> plot(const std::vector<std::vector<double>> &Y,
-                                      const std::string &line_spec = "");
+                                      std::string_view line_spec = "");
 
         /// Plot lines representing a colormap
         std::vector<line_handle>
@@ -742,20 +742,20 @@ namespace matplot {
         line_handle plot3(const std::vector<double> &x,
                           const std::vector<double> &y,
                           const std::vector<double> &z,
-                          const std::string &line_spec = "");
+                          std::string_view line_spec = "");
 
         /// Plot 3d line plot - lists of Xs and Ys
         std::vector<line_handle>
         plot3(const std::vector<std::vector<double>> &X,
               const std::vector<std::vector<double>> &Y,
-              const std::vector<double> &z, const std::string &line_spec = "");
+              const std::vector<double> &z, std::string_view line_spec = "");
 
         /// 3d-plot lists of Xs, Ys, and Zs
         std::vector<line_handle>
         plot3(const std::vector<std::vector<double>> &X,
               const std::vector<std::vector<double>> &Y,
               const std::vector<std::vector<double>> &Z,
-              const std::string &line_spec = "");
+              std::string_view line_spec = "");
 
         /// \brief Create many 3d line plots at once with parameter pack
         /// The logic is the analogous to the plot function:
@@ -765,7 +765,7 @@ namespace matplot {
         /// This function represents case 1a
         template <class... Args>
         auto plot3(const std::vector<double> &x, const std::vector<double> &y,
-                   const std::vector<double> &z, const std::string &line_spec,
+                   const std::vector<double> &z, std::string_view line_spec,
                    Args&&... args) {
             std::vector<line_handle> result;
             std::vector<line_handle> result_a =
@@ -804,28 +804,28 @@ namespace matplot {
         /// Create stairs line plot
         stair_handle stairs(const std::vector<double> &x,
                             const std::vector<double> &y,
-                            const std::string &line_spec = "");
+                            std::string_view line_spec = "");
 
         /// Basic stairs function with automatic x
         stair_handle stairs(const std::vector<double> &y,
-                            const std::string &line_spec = "");
+                            std::string_view line_spec = "");
 
         /// Stairs with lists of lists (same x for all Y)
         std::vector<stair_handle>
         stairs(const std::vector<double> &x,
                const std::vector<std::vector<double>> &Y,
-               const std::string &line_spec = "");
+               std::string_view line_spec = "");
 
         /// Stairs with lists of lists (one X per Y)
         std::vector<stair_handle>
         stairs(const std::vector<std::vector<double>> &X,
                const std::vector<std::vector<double>> &Y,
-               const std::string &line_spec = "");
+               std::string_view line_spec = "");
 
         /// Stairs with lists of lists with automatic x
         std::vector<stair_handle>
         stairs(const std::vector<std::vector<double>> &Y,
-               const std::string &line_spec = "");
+               std::string_view line_spec = "");
 
         /// \brief Create many stairs at once with parameter pack
         /// The logic is analogous to the plot function:
@@ -835,7 +835,7 @@ namespace matplot {
         /// This function represents case 1a
         template <class... Args>
         auto stairs(const std::vector<double> &x, const std::vector<double> &y,
-                    const std::string &line_spec, Args&&... args) {
+                    std::string_view line_spec, Args&&... args) {
             std::vector<stair_handle> result;
             std::vector<stair_handle> result_a =
                 vectorize(this->stairs(x, y, line_spec));
@@ -877,7 +877,7 @@ namespace matplot {
         ///     Case 2 : y, line_spec, next_x
         /// This function represents case 2
         template <class... Args>
-        auto stairs(const std::vector<double> &y, const std::string &line_spec,
+        auto stairs(const std::vector<double> &y, std::string_view line_spec,
                     Args&&... args) {
             std::vector<stair_handle> result;
             std::vector<stair_handle> result_a =
@@ -897,7 +897,7 @@ namespace matplot {
         errorbar(const std::vector<double> &x, const std::vector<double> &y,
                  const std::vector<double> &error,
                  error_bar::type type = error_bar::type::vertical,
-                 const std::string &line_spec = "");
+                 std::string_view line_spec = "");
 
         /// Core errorbar function with different values on both directions
         error_bar_handle errorbar(const std::vector<double> &x,
@@ -906,45 +906,45 @@ namespace matplot {
                                   const std::vector<double> &y_pos_delta,
                                   const std::vector<double> &x_neg_delta,
                                   const std::vector<double> &x_pos_delta,
-                                  const std::string &line_spec = "");
+                                  std::string_view line_spec = "");
 
         /// If there is a string instead of a type the first version, we default
         /// to vertical
         error_bar_handle errorbar(const std::vector<double> &x,
                                   const std::vector<double> &y,
                                   const std::vector<double> &y_error,
-                                  const std::string &line_spec);
+                                  std::string_view line_spec);
 
         /// Core area function (x is a vector, y is a matrix)
         std::vector<filled_area_handle>
         area(const std::vector<double> &x,
              const std::vector<std::vector<double>> &Y, double base_value = 0.,
-             bool stacked = true, const std::string &line_spec = "k-");
+             bool stacked = true, std::string_view line_spec = "k-");
 
         /// Area: x is a vector, y is a vector
         filled_area_handle area(const std::vector<double> &x,
                                 const std::vector<double> &y,
                                 double base_value = 0., bool stacked = true,
-                                const std::string &line_spec = "k-");
+                                std::string_view line_spec = "k-");
 
         /// Area: Automatic x, y is a matrix
         std::vector<filled_area_handle>
         area(const std::vector<std::vector<double>> &Y, double base_value = 0.,
-             bool stacked = true, const std::string &line_spec = "k-");
+             bool stacked = true, std::string_view line_spec = "k-");
 
         /// Area: Skip the base value
         std::vector<filled_area_handle>
         area(const std::vector<std::vector<double>> &Y, bool stacked,
-             const std::string &line_spec = "k-");
+             std::string_view line_spec = "k-");
 
         /// Area: Automatic x, y is a vector
         filled_area_handle area(const std::vector<double> &y,
                                 double base_value = 0., bool stacked = true,
-                                const std::string &line_spec = "k-");
+                                std::string_view line_spec = "k-");
 
         /// String function line plot
-        string_function_handle fplot(const std::string &equation,
-                                     const std::string &line_spec = "");
+        string_function_handle fplot(std::string_view equation,
+                                     std::string_view line_spec = "");
 
         /// String function line plots
         std::vector<string_function_handle>
@@ -955,18 +955,18 @@ namespace matplot {
         function_line_handle fplot(function_line::function_type equation,
                                    const std::array<double, 2> &x_range = {-5,
                                                                            5},
-                                   const std::string &line_spec = "");
+                                   std::string_view line_spec = "");
 
         /// Lambda function line plot - automatic limits
         function_line_handle fplot(function_line::function_type equation,
-                                   const std::string &line_spec);
+                                   std::string_view line_spec);
 
         /// Lambda function line plot - two functions (x/y)
         function_line_handle fplot(function_line::function_type function_x,
                                    function_line::function_type function_y,
                                    const std::array<double, 2> &t_range = {-5,
                                                                            5},
-                                   const std::string &line_spec = "");
+                                   std::string_view line_spec = "");
 
         /// Lambda function line plot - list of functions
         std::vector<function_line_handle>
@@ -986,11 +986,11 @@ namespace matplot {
         line_handle
         fimplicit(implicit_function_type equation,
                   const std::array<double, 4> &xy_interval = {-5, 5, -5, 5},
-                  const std::string &line_spec = "");
+                  std::string_view line_spec = "");
 
         /// Implicit lambda function line plot - automatic xy_interval
         line_handle fimplicit(implicit_function_type equation,
-                              const std::string &line_spec);
+                              std::string_view line_spec);
 
         /// Lambda function plot 3D
         function_line_handle fplot3(function_line::function_type function_x,
@@ -998,7 +998,7 @@ namespace matplot {
                                     function_line::function_type function_z,
                                     const std::array<double, 2> &t_range = {-5,
                                                                             5},
-                                    const std::string &line_spec = "");
+                                    std::string_view line_spec = "");
 
         /// Histogram - Choose binning algorithm and normalization algorithm
         histogram_handle hist(const std::vector<double> &data,
@@ -1111,12 +1111,12 @@ namespace matplot {
         parallel_lines_handle
         parallelplot(const std::vector<std::vector<double>> &X,
                      const std::vector<double> &colors,
-                     const std::string &line_spec = "");
+                     std::string_view line_spec = "");
 
         /// Parallel plot - default line colors
         parallel_lines_handle
         parallelplot(const std::vector<std::vector<double>> &X,
-                     const std::string &line_spec = "");
+                     std::string_view line_spec = "");
 
         /// Core pie function with explode values and labels
         circles_handle pie(const std::vector<double> &x,
@@ -1144,13 +1144,13 @@ namespace matplot {
                              const std::vector<double> &z,
                              const std::vector<double> &sizes = {},
                              const std::vector<double> &colors = {},
-                             const std::string &line_spec = "o");
+                             std::string_view line_spec = "o");
 
         /// Scatter3 - Default sizes and colors
         line_handle scatter3(const std::vector<double> &x,
                              const std::vector<double> &y,
                              const std::vector<double> &z,
-                             const std::string &line_spec);
+                             std::string_view line_spec);
 
         /// Core wordcloud function - Wordcloud from words
         labels_handle wordcloud(const std::vector<std::string> &words,
@@ -1164,9 +1164,9 @@ namespace matplot {
 
         /// Wordcloud from text
         labels_handle
-        wordcloud(const std::string &text,
+        wordcloud(std::string_view text,
                   const std::vector<std::string> &black_list,
-                  const std::string &delimiters = " ',\n\r\t\".!?:;",
+                  std::string_view delimiters = " ',\n\r\t\".!?:;",
                   size_t max_cloud_size = 100,
                   const std::vector<double> &custom_colors = {});
 
@@ -1179,41 +1179,41 @@ namespace matplot {
         /// Core plot function
         line_handle stem(const std::vector<double> &x,
                          const std::vector<double> &y,
-                         const std::string &line_spec = "-o");
+                         std::string_view line_spec = "-o");
 
         /// Basic plot function with automatic x
         line_handle stem(const std::vector<double> &y,
-                         const std::string &line_spec = "-o");
+                         std::string_view line_spec = "-o");
 
         /// Stem - Plot lists of lists
         std::vector<line_handle> stem(const std::vector<double> &x,
                                       const std::vector<std::vector<double>> &Y,
-                                      const std::string &line_spec = "-o");
+                                      std::string_view line_spec = "-o");
 
         /// Plot lists of lists with automatic x
         std::vector<line_handle> stem(const std::vector<std::vector<double>> &Y,
-                                      const std::string &line_spec = "-o");
+                                      std::string_view line_spec = "-o");
 
         /// Stem 3d - Core function
         line_handle stem3(const std::vector<double> &x,
                           const std::vector<double> &y,
                           const std::vector<double> &z,
-                          const std::string &line_spec = "-o");
+                          std::string_view line_spec = "-o");
 
         /// 3d-stem lists of Xs and Ys
         std::vector<line_handle>
         stem3(const std::vector<std::vector<double>> &X,
               const std::vector<std::vector<double>> &Y,
               const std::vector<double> &z,
-              const std::string &line_spec = "-o");
+              std::string_view line_spec = "-o");
 
         /// Stem 3d - Automatic x and y
         line_handle stem3(const std::vector<double> &z,
-                          const std::string &line_spec = "-o");
+                          std::string_view line_spec = "-o");
 
         /// Stem 3d - Automatic x and y - Many Zs
         line_handle stem3(const std::vector<std::vector<double>> &Z,
-                          const std::string &line_spec = "-o");
+                          std::string_view line_spec = "-o");
 
         /// Core geoplot function
         circles_handle geobubble(const std::vector<double> &latitude,
@@ -1232,7 +1232,7 @@ namespace matplot {
         /// Core geoplot function - Plot lines on world map
         line_handle geoplot(const std::vector<double> &latitude,
                             const std::vector<double> &longitude,
-                            const std::string &line_spec = "");
+                            std::string_view line_spec = "");
 
         /// Adjust limits and reload that region of the world map in the proper
         /// resolution
@@ -1258,11 +1258,11 @@ namespace matplot {
         /// Compass plot function
         vectors_handle compass(const std::vector<double> &x,
                                const std::vector<double> &y,
-                               const std::string &line_spec = "");
+                               std::string_view line_spec = "");
 
         /// Ezpolar - Plot function on polar plot
-        string_function_handle ezpolar(const std::string &equation,
-                                       const std::string &line_spec = "");
+        string_function_handle ezpolar(std::string_view equation,
+                                       std::string_view line_spec = "");
 
         std::vector<string_function_handle>
         ezpolar(std::vector<std::string> equations,
@@ -1270,24 +1270,24 @@ namespace matplot {
 
         function_line_handle ezpolar(function_line::function_type equation,
                                      const std::array<double, 2> &t_range,
-                                     const std::string &line_spec = "");
+                                     std::string_view line_spec = "");
 
         function_line_handle ezpolar(function_line::function_type equation,
-                                     const std::string &line_spec = "");
+                                     std::string_view line_spec = "");
 
         function_line_handle ezpolar(function_line::function_type equation,
                                      std::vector<double> x_range,
-                                     const std::string &line_spec = "");
+                                     std::string_view line_spec = "");
 
         function_line_handle ezpolar(function_line::function_type function_x,
                                      function_line::function_type function_y,
                                      const std::array<double, 2> &t_range,
-                                     const std::string &line_spec = "");
+                                     std::string_view line_spec = "");
 
         function_line_handle ezpolar(function_line::function_type function_x,
                                      function_line::function_type function_y,
                                      std::vector<double> t_range,
-                                     const std::string &line_spec = "");
+                                     std::string_view line_spec = "");
 
         std::vector<function_line_handle>
         ezpolar(std::vector<function_line::function_type> equations,
@@ -1306,15 +1306,15 @@ namespace matplot {
         /// Polar plot - Core function
         line_handle polarplot(const std::vector<double> &theta,
                               const std::vector<double> &rho,
-                              const std::string &line_spec = "");
+                              std::string_view line_spec = "");
 
         /// Polar plot - Automatic theta
         line_handle polarplot(const std::vector<double> &rho,
-                              const std::string &line_spec = "");
+                              std::string_view line_spec = "");
 
         /// Polar plot - Complex numbers
         line_handle polarplot(const std::vector<std::complex<double>> &z,
-                              const std::string &line_spec = "*");
+                              std::string_view line_spec = "*");
 
         /// Polar scatter - Core function
         line_handle
@@ -1322,24 +1322,24 @@ namespace matplot {
                      const std::vector<double> &rho,
                      const std::vector<double> &sizes = std::vector<double>{},
                      const std::vector<double> &colors = std::vector<double>{},
-                     const std::string &line_spec = "o");
+                     std::string_view line_spec = "o");
 
         /// Polar scatter - Single size - Default colors
         line_handle polarscatter(const std::vector<double> &theta,
                                  const std::vector<double> &rho, double size,
-                                 const std::string &line_spec = "o");
+                                 std::string_view line_spec = "o");
 
         /// Polar scatter - Default size and colors
         line_handle polarscatter(const std::vector<double> &theta,
                                  const std::vector<double> &rho,
-                                 const std::string &line_spec);
+                                 std::string_view line_spec);
 
         /// Contour - Core function - Manual levels
         contours_handle contour(const std::vector<std::vector<double>> &X,
                                 const std::vector<std::vector<double>> &Y,
                                 const std::vector<std::vector<double>> &Z,
                                 std::vector<double> levels,
-                                const std::string &line_spec = "",
+                                std::string_view line_spec = "",
                                 size_t n_levels = 0);
 
         /// Contour - Manual number of levels (or 0 for automatic number of
@@ -1348,20 +1348,20 @@ namespace matplot {
                                 const std::vector<std::vector<double>> &Y,
                                 const std::vector<std::vector<double>> &Z,
                                 size_t n_levels = 0,
-                                const std::string &line_spec = "");
+                                std::string_view line_spec = "");
 
         /// Contour - Automatic levels and number of levels
         contours_handle contour(const std::vector<std::vector<double>> &X,
                                 const std::vector<std::vector<double>> &Y,
                                 const std::vector<std::vector<double>> &Z,
-                                const std::string &line_spec);
+                                std::string_view line_spec);
 
         /// Contour filled - Manual levels
         contours_handle contourf(const std::vector<std::vector<double>> &X,
                                  const std::vector<std::vector<double>> &Y,
                                  const std::vector<std::vector<double>> &Z,
                                  std::vector<double> levels,
-                                 const std::string &line_spec = "",
+                                 std::string_view line_spec = "",
                                  size_t n_levels = 0);
 
         /// Contour filled - Manual number of levels
@@ -1369,13 +1369,13 @@ namespace matplot {
                                  const std::vector<std::vector<double>> &Y,
                                  const std::vector<std::vector<double>> &Z,
                                  size_t n_levels = 0,
-                                 const std::string &line_spec = "");
+                                 std::string_view line_spec = "");
 
         /// Contour filled - Automatic number of levels
         contours_handle contourf(const std::vector<std::vector<double>> &X,
                                  const std::vector<std::vector<double>> &Y,
                                  const std::vector<std::vector<double>> &Z,
-                                 const std::string &line_spec);
+                                 std::string_view line_spec);
 
         using fcontour_function_type = std::function<double(double, double)>;
 
@@ -1384,28 +1384,28 @@ namespace matplot {
         contours_handle fcontour(fcontour_function_type fn,
                                  const std::array<double, 4> &xy_range,
                                  std::vector<double> levels = {},
-                                 const std::string &line_spec = "",
+                                 std::string_view line_spec = "",
                                  size_t n_levels = 0);
 
         /// Lambda function contour - Manual number of levels (default = 9)
         contours_handle fcontour(fcontour_function_type fn, size_t n_levels = 9,
-                                 const std::string &line_spec = "");
+                                 std::string_view line_spec = "");
 
         /// Lambda function contour - Automatic number of levels and levels
         contours_handle fcontour(fcontour_function_type fn,
-                                 const std::string &line_spec);
+                                 std::string_view line_spec);
 
         /// Feather - Core function
         vectors_handle feather(const std::vector<double> &u,
                                const std::vector<double> &v,
-                               const std::string &line_spec = "");
+                               std::string_view line_spec = "");
 
         /// Quiver - Core function
         vectors_handle quiver(const std::vector<double> &x,
                               const std::vector<double> &y,
                               const std::vector<double> &u,
                               const std::vector<double> &v, double scale = 1.0,
-                              const std::string &line_spec = "");
+                              std::string_view line_spec = "");
 
         /// Quiver - 2d x,y,u,v
         vectors_handle quiver(const std::vector<std::vector<double>> &x,
@@ -1413,14 +1413,14 @@ namespace matplot {
                               const std::vector<std::vector<double>> &u,
                               const std::vector<std::vector<double>> &v,
                               double scale = 1.0,
-                              const std::string &line_spec = "");
+                              std::string_view line_spec = "");
 
         /// Quiver 3d - Core function
         vectors_handle
         quiver3(const std::vector<double> &x, const std::vector<double> &y,
                 const std::vector<double> &z, const std::vector<double> &u,
                 const std::vector<double> &v, const std::vector<double> &w,
-                double scale = 1.0, const std::string &line_spec = "");
+                double scale = 1.0, std::string_view line_spec = "");
 
         /// Quiver 3d - 2d vectors
         vectors_handle quiver3(const std::vector<std::vector<double>> &x,
@@ -1430,7 +1430,7 @@ namespace matplot {
                                const std::vector<std::vector<double>> &v,
                                const std::vector<std::vector<double>> &w,
                                double scale = 1.0,
-                               const std::string &line_spec = "");
+                               std::string_view line_spec = "");
 
         /// Quiver 3d - Automatic x and y - 2d vectors
         vectors_handle quiver3(const std::vector<std::vector<double>> &z,
@@ -1438,7 +1438,7 @@ namespace matplot {
                                const std::vector<std::vector<double>> &v,
                                const std::vector<std::vector<double>> &w,
                                double scale = 1.0,
-                               const std::string &line_spec = "");
+                               std::string_view line_spec = "");
 
         /// Fence - Core function
         surface_handle fence(const std::vector<std::vector<double>> &X,
@@ -1496,21 +1496,21 @@ namespace matplot {
         surface_handle fsurf(fcontour_function_type fn,
                              const std::array<double, 2> &x_range,
                              const std::array<double, 2> &y_range,
-                             std::string line_spec = "",
+                             std::string_view line_spec = "",
                              double mesh_density = 40);
 
         /// Function surf - Parametric
         surface_handle
         fsurf(fcontour_function_type funx, fcontour_function_type funy,
               fcontour_function_type funz, const std::array<double, 2> &u_range,
-              const std::array<double, 2> &v_range, std::string line_spec = "",
+              const std::array<double, 2> &v_range, std::string_view line_spec = "",
               double mesh_density = 40);
 
         /// Function surf
         /// Grid / Both ranges in the same array size 4
         surface_handle fsurf(fcontour_function_type fn,
                              const std::array<double, 4> &xy_range,
-                             std::string line_spec = "",
+                             std::string_view line_spec = "",
                              double mesh_density = 40);
 
         /// Parametric / Both ranges in the same array size 4
@@ -1518,14 +1518,14 @@ namespace matplot {
                              fcontour_function_type funy,
                              fcontour_function_type funz,
                              const std::array<double, 4> &uv_range,
-                             std::string line_spec = "",
+                             std::string_view line_spec = "",
                              double mesh_density = 40);
 
         /// Function surf
         /// Grid / Both ranges in the same array size 2
         surface_handle fsurf(fcontour_function_type fn,
                              const std::array<double, 2> &xy_range = {-5, +5},
-                             std::string line_spec = "",
+                             std::string_view line_spec = "",
                              double mesh_density = 40);
 
         /// Function surf
@@ -1534,14 +1534,14 @@ namespace matplot {
                              fcontour_function_type funy,
                              fcontour_function_type funz,
                              const std::array<double, 2> &uv_range = {-5, +5},
-                             std::string line_spec = "",
+                             std::string_view line_spec = "",
                              double mesh_density = 40);
 
         /// Function surf
         /// Grid / Both ranges in the same array size 2
         surface_handle fsurf(fcontour_function_type fn,
                              std::initializer_list<double> &xy_range,
-                             std::string line_spec = "",
+                             std::string_view line_spec = "",
                              double mesh_density = 40) {
             if (xy_range.size() == 2) {
                 return fsurf(fn, to_array<2>(xy_range), line_spec,
@@ -1562,7 +1562,7 @@ namespace matplot {
                                     fcontour_function_type funy,
                                     fcontour_function_type funz,
                                     std::initializer_list<double> &uv_range,
-                                    std::string line_spec = "",
+                                    std::string_view line_spec = "",
                                     double mesh_density = 40) {
             if (uv_range.size() == 2) {
                 return fsurf(funx, funy, funz, to_array<2>(uv_range), line_spec,
@@ -1608,7 +1608,7 @@ namespace matplot {
                             const std::vector<std::vector<double>> &Y,
                             const std::vector<std::vector<double>> &Z,
                             const std::vector<std::vector<double>> &C = {},
-                            std::string line_spec = "");
+                            std::string_view line_spec = "");
 
         /// Surf with contour - Core function
         surface_handle surfc(const std::vector<std::vector<double>> &X,
@@ -1627,11 +1627,11 @@ namespace matplot {
         network_handle
         graph(const std::vector<std::pair<size_t, size_t>> &edges,
               const std::vector<double> &weights = {}, size_t n_vertices = 0,
-              std::string line_spec = "-o");
+              std::string_view line_spec = "-o");
 
         network_handle
         graph(const std::vector<std::pair<size_t, size_t>> &edges,
-              std::string line_spec);
+              std::string_view line_spec);
 
         /// B&W image show - Core function
         matrix_handle
@@ -1683,12 +1683,12 @@ namespace matplot {
                            const std::vector<std::string> &texts);
 
         /// Annotate plot with single text
-        labels_handle text(double x, double y, const std::string &str);
+        labels_handle text(double x, double y, std::string_view str);
 
         /// Annotate plot with same text at many positions
         labels_handle text(const std::vector<double> &x,
                            const std::vector<double> &y,
-                           const std::string &str);
+                           std::string_view str);
 
         /// Annotate plot with arrow
         vectors_handle arrow(double x1, double y1, double x2, double y2);
@@ -1699,7 +1699,7 @@ namespace matplot {
         /// Annotate plot with text and arrow
         std::pair<labels_handle, vectors_handle>
         textarrow(double x1, double y1, double x2, double y2,
-                  const std::string &str);
+                  std::string_view str);
 
         /// Annotate plot with rectangle
         line_handle rectangle(double x, double y, double w, double h,
@@ -1707,12 +1707,12 @@ namespace matplot {
 
         /// Annotate plot with text in a box
         std::pair<labels_handle, line_handle>
-        textbox(double x, double y, double w, double h, const std::string &str);
+        textbox(double x, double y, double w, double h, std::string_view str);
 
         /// Annotate plot with a filled polygon
         line_handle fill(const std::vector<double> &x,
                          const std::vector<double> &y,
-                         const std::string &line_spec = "");
+                         std::string_view line_spec = "");
 
         line_handle ellipse(double x, double y, double w, double h);
 
@@ -1722,19 +1722,19 @@ namespace matplot {
         template <class T1, class T2>
         line_handle plot(const IterableValues<T1> &x,
                          const IterableValues<T2> &y,
-                         const std::string &line_spec = "") {
+                         std::string_view line_spec = "") {
             return plot(to_vector_1d(x), to_vector_1d(y), line_spec);
         }
 
         template <class T1>
         line_handle plot(const IterableValues<T1> &y,
-                         const std::string &line_spec = "") {
+                         std::string_view line_spec = "") {
             return plot(to_vector_1d(y), line_spec);
         }
 
         template <class T1, class T2, class... Args>
         auto plot(const IterableValues<T1> &x, const IterableValues<T2> &y,
-                  const std::string &line_spec, Args&&... args) {
+                  std::string_view line_spec, Args&&... args) {
             return plot(to_vector_1d(x), to_vector_1d(y), line_spec, std::forward<Args>(args)...);
         }
 
@@ -1746,7 +1746,7 @@ namespace matplot {
         }
 
         template <class T1, class... Args>
-        auto plot(const IterableValues<T1> &y, const std::string &line_spec,
+        auto plot(const IterableValues<T1> &y, std::string_view line_spec,
                   Args&&... args) {
             return plot(to_vector_1d(y), line_spec, std::forward<Args>(args)...);
         }
@@ -1754,13 +1754,13 @@ namespace matplot {
         template <class T1, class T2>
         std::vector<line_handle> plot(const IterableValues<T1> &x,
                                       const IterableIterables<T2> &Y,
-                                      const std::string &line_spec = "") {
+                                      std::string_view line_spec = "") {
             return plot(to_vector_1d(x), to_vector_2d(Y), line_spec);
         }
 
         template <class T1>
         std::vector<line_handle> plot(const IterableIterables<T1> &Y,
-                                      const std::string &line_spec = "") {
+                                      std::string_view line_spec = "") {
             return plot(to_vector_2d(Y), line_spec);
         }
 
@@ -1773,7 +1773,7 @@ namespace matplot {
         template <class T1, class T2, class T3>
         line_handle
         plot3(const IterableValues<T1> &x, const IterableValues<T2> &y,
-              const IterableValues<T3> &z, const std::string &line_spec = "") {
+              const IterableValues<T3> &z, std::string_view line_spec = "") {
             return plot3(to_vector_1d(x), to_vector_1d(y), to_vector_1d(z),
                          line_spec);
         }
@@ -1781,7 +1781,7 @@ namespace matplot {
         template <class T1, class T2, class T3>
         std::enable_if_t<is_iterable_value_v<T3>, std::vector<line_handle>>
         plot3(const IterableIterables<T1> &X, const IterableIterables<T2> &Y,
-              const IterableValues<T3> &z, const std::string &line_spec = "") {
+              const IterableValues<T3> &z, std::string_view line_spec = "") {
             return plot3(to_vector_2d(X), to_vector_2d(Y), to_vector_1d(z),
                          line_spec);
         }
@@ -1790,14 +1790,14 @@ namespace matplot {
         std::enable_if_t<is_iterable_iterable_v<T3>, std::vector<line_handle>>
         plot3(const IterableIterables<T1> &X, const IterableIterables<T2> &Y,
               const IterableIterables<T3> &Z,
-              const std::string &line_spec = "") {
+              std::string_view line_spec = "") {
             return plot3(to_vector_2d(X), to_vector_2d(Y), to_vector_2d(Z),
                          line_spec);
         }
 
         template <class T1, class T2, class T3, class... Args>
         auto plot3(const IterableValues<T1> &x, const IterableValues<T2> &y,
-                   const IterableValues<T3> &z, const std::string &line_spec,
+                   const IterableValues<T3> &z, std::string_view line_spec,
                    Args&&... args) {
             return plot3(to_vector_1d(x), to_vector_1d(y), to_vector_1d(z),
                          line_spec, std::forward<Args>(args)...);
@@ -1812,7 +1812,7 @@ namespace matplot {
         }
 
         template <class T1, class... Args>
-        auto plot3(const IterableValues<T1> &z, const std::string &line_spec,
+        auto plot3(const IterableValues<T1> &z, std::string_view line_spec,
                    Args&&... args) {
             return plot3(to_vector_1d(z), line_spec, std::forward<Args>(args)...);
         }
@@ -1820,39 +1820,39 @@ namespace matplot {
         template <class T1, class T2>
         stair_handle stairs(const IterableValues<T1> &x,
                             const IterableValues<T2> &y,
-                            const std::string &line_spec = "") {
+                            std::string_view line_spec = "") {
             return stairs(to_vector_1d(x), to_vector_1d(y), line_spec);
         }
 
         template <class T1>
         stair_handle stairs(const IterableValues<T1> &y,
-                            const std::string &line_spec = "") {
+                            std::string_view line_spec = "") {
             return stairs(to_vector_1d(y), line_spec);
         }
 
         template <class T1, class T2>
         std::enable_if_t<is_iterable_value_v<T1>, std::vector<stair_handle>>
         stairs(const IterableValues<T1> &x, const IterableIterables<T2> &Y,
-               const std::string &line_spec = "") {
+               std::string_view line_spec = "") {
             return stairs(to_vector_1d(x), to_vector_2d(Y), line_spec);
         }
 
         template <class T1, class T2>
         std::enable_if_t<is_iterable_iterable_v<T1>, std::vector<stair_handle>>
         stairs(const IterableIterables<T1> &X, const IterableIterables<T2> &Y,
-               const std::string &line_spec = "") {
+               std::string_view line_spec = "") {
             return stairs(to_vector_2d(X), to_vector_2d(Y), line_spec);
         }
 
         template <class T1>
         std::vector<stair_handle> stairs(const IterableIterables<T1> &Y,
-                                         const std::string &line_spec = "") {
+                                         std::string_view line_spec = "") {
             return stairs(to_vector_2d(Y), line_spec);
         }
 
         template <class T1, class T2, class... Args>
         auto stairs(const IterableValues<T1> &x, const IterableValues<T2> &y,
-                    const std::string &line_spec, Args&&... args) {
+                    std::string_view line_spec, Args&&... args) {
             return stairs(to_vector_1d(x), to_vector_1d(y), line_spec, std::forward<Args>(args)...);
         }
 
@@ -1864,7 +1864,7 @@ namespace matplot {
         }
 
         template <class T1, class... Args>
-        auto stairs(const IterableValues<T1> &y, const std::string &line_spec,
+        auto stairs(const IterableValues<T1> &y, std::string_view line_spec,
                     Args&&... args) {
             return stairs(to_vector_1d(y), line_spec, std::forward<Args>(args)...);
         }
@@ -1874,7 +1874,7 @@ namespace matplot {
         errorbar(const IterableValues<T1> &x, const IterableValues<T2> &y,
                  const IterableValues<T3> &error,
                  error_bar::type type = error_bar::type::vertical,
-                 const std::string &line_spec = "") {
+                 std::string_view line_spec = "") {
             return errorbar(to_vector_1d(x), to_vector_1d(y),
                             to_vector_1d(error), type, line_spec);
         }
@@ -1886,7 +1886,7 @@ namespace matplot {
                                   const IterableValues<T4> &y_pos_delta,
                                   const IterableValues<T5> &x_neg_delta,
                                   const IterableValues<T6> &x_pos_delta,
-                                  const std::string &line_spec = "") {
+                                  std::string_view line_spec = "") {
             return errorbar(
                 to_vector_1d(x), to_vector_1d(y), to_vector_1d(y_neg_delta),
                 to_vector_1d(y_pos_delta), to_vector_1d(x_neg_delta),
@@ -1897,7 +1897,7 @@ namespace matplot {
         error_bar_handle errorbar(const IterableValues<T1> &x,
                                   const IterableValues<T2> &y,
                                   const IterableValues<T3> &y_error,
-                                  const std::string &line_spec) {
+                                  std::string_view line_spec) {
             return errorbar(to_vector_1d(x), to_vector_1d(y),
                             to_vector_1d(y_error), line_spec);
         }
@@ -1906,7 +1906,7 @@ namespace matplot {
         std::vector<filled_area_handle>
         area(const IterableValues<T1> &x, const IterableIterables<T2> &Y,
              double base_value = 0., bool stacked = true,
-             const std::string &line_spec = "k-") {
+             std::string_view line_spec = "k-") {
             return area(to_vector_1d(x), to_vector_2d(Y), base_value, stacked,
                         line_spec);
         }
@@ -1915,7 +1915,7 @@ namespace matplot {
         filled_area_handle area(const IterableValues<T1> &x,
                                 const IterableValues<T2> &y,
                                 double base_value = 0., bool stacked = true,
-                                const std::string &line_spec = "k-") {
+                                std::string_view line_spec = "k-") {
             return area(to_vector_1d(x), to_vector_1d(y), base_value, stacked,
                         line_spec);
         }
@@ -1923,21 +1923,21 @@ namespace matplot {
         template <class T1>
         std::vector<filled_area_handle>
         area(const IterableIterables<T1> &Y, double base_value = 0.,
-             bool stacked = true, const std::string &line_spec = "k-") {
+             bool stacked = true, std::string_view line_spec = "k-") {
             return area(to_vector_2d(Y), base_value, stacked, line_spec);
         }
 
         template <class T1>
         std::vector<filled_area_handle>
         area(const IterableIterables<T1> &Y, bool stacked,
-             const std::string &line_spec = "k-") {
+             std::string_view line_spec = "k-") {
             return area(to_vector_2d(Y), stacked, line_spec);
         }
 
         template <class T1>
         filled_area_handle area(const IterableValues<T1> &y,
                                 double base_value = 0., bool stacked = true,
-                                const std::string &line_spec = "k-") {
+                                std::string_view line_spec = "k-") {
             return area(to_vector_1d(y), base_value, stacked, line_spec);
         }
 
@@ -2092,14 +2092,14 @@ namespace matplot {
         template <class T1, class T2>
         parallel_lines_handle parallelplot(const IterableIterables<T1> &X,
                                            const IterableValues<T2> &colors,
-                                           const std::string &line_spec = "") {
+                                           std::string_view line_spec = "") {
             return parallelplot(to_vector_2d(X), to_vector_1d(colors),
                                 line_spec);
         }
 
         template <class T1>
         parallel_lines_handle parallelplot(const IterableIterables<T1> &X,
-                                           const std::string &line_spec = "") {
+                                           std::string_view line_spec = "") {
             return parallelplot(to_vector_2d(X), line_spec);
         }
 
@@ -2139,7 +2139,7 @@ namespace matplot {
                              const IterableValues<T3> &z,
                              const IterableValues<T4> &sizes = {},
                              const IterableValues<T5> &colors = {},
-                             const std::string &line_spec = "o") {
+                             std::string_view line_spec = "o") {
             return scatter3(to_vector_1d(x), to_vector_1d(y), to_vector_1d(z),
                             to_vector_1d(sizes), to_vector_1d(colors),
                             line_spec);
@@ -2148,7 +2148,7 @@ namespace matplot {
         template <class T1, class T2, class T3>
         line_handle
         scatter3(const IterableValues<T1> &x, const IterableValues<T2> &y,
-                 const IterableValues<T3> &z, const std::string &line_spec) {
+                 const IterableValues<T3> &z, std::string_view line_spec) {
             return scatter3(to_vector_1d(x), to_vector_1d(y), to_vector_1d(z),
                             line_spec);
         }
@@ -2163,9 +2163,9 @@ namespace matplot {
 
         template <class T1, class T2>
         labels_handle
-        wordcloud(const std::string &text,
+        wordcloud(std::string_view text,
                   const std::vector<std::string> &black_list,
-                  const std::string &delimiters = " ',\n\r\t\".!?:;",
+                  std::string_view delimiters = " ',\n\r\t\".!?:;",
                   size_t max_cloud_size = 100,
                   const IterableValues<T1> &custom_colors = {}) {
             return wordcloud(text, black_list, delimiters, max_cloud_size,
@@ -2183,26 +2183,26 @@ namespace matplot {
         template <class T1, class T2>
         line_handle stem(const IterableValues<T1> &x,
                          const IterableValues<T2> &y,
-                         const std::string &line_spec = "-o") {
+                         std::string_view line_spec = "-o") {
             return stem(to_vector_1d(x), to_vector_1d(y), line_spec);
         }
 
         template <class T1>
         line_handle stem(const IterableValues<T1> &y,
-                         const std::string &line_spec = "-o") {
+                         std::string_view line_spec = "-o") {
             return stem(to_vector_1d(y), line_spec);
         }
 
         template <class T1, class T2>
         std::vector<line_handle> stem(const IterableValues<T1> &x,
                                       const IterableIterables<T2> &Y,
-                                      const std::string &line_spec = "-o") {
+                                      std::string_view line_spec = "-o") {
             return stem(to_vector_1d(x), to_vector_2d(Y), line_spec);
         }
 
         template <class T1>
         std::vector<line_handle> stem(const IterableIterables<T1> &Y,
-                                      const std::string &line_spec = "-o") {
+                                      std::string_view line_spec = "-o") {
             return stem(to_vector_2d(Y), line_spec);
         }
 
@@ -2210,7 +2210,7 @@ namespace matplot {
         line_handle stem3(const IterableValues<T1> &x,
                           const IterableValues<T2> &y,
                           const IterableValues<T3> &z,
-                          const std::string &line_spec = "-o") {
+                          std::string_view line_spec = "-o") {
             return stem3(to_vector_1d(x), to_vector_1d(y), to_vector_1d(z),
                          line_spec);
         }
@@ -2219,20 +2219,20 @@ namespace matplot {
         std::vector<line_handle> stem3(const IterableIterables<T1> &X,
                                        const IterableIterables<T2> &Y,
                                        const IterableValues<T3> &z,
-                                       const std::string &line_spec = "-o") {
+                                       std::string_view line_spec = "-o") {
             return stem3(to_vector_2d(X), to_vector_2d(Y), to_vector_1d(z),
                          line_spec);
         }
 
         template <class T1>
         line_handle stem3(const IterableValues<T1> &z,
-                          const std::string &line_spec = "-o") {
+                          std::string_view line_spec = "-o") {
             return stem3(to_vector_1d(z), line_spec);
         }
 
         template <class T1, class T2>
         line_handle stem3(const IterableIterables<T1> &Z,
-                          const std::string &line_spec = "-o") {
+                          std::string_view line_spec = "-o") {
             return stem3(to_vector_2d(Z), line_spec);
         }
 
@@ -2257,7 +2257,7 @@ namespace matplot {
         template <class T1, class T2>
         line_handle geoplot(const IterableValues<T1> &latitude,
                             const IterableValues<T2> &longitude,
-                            const std::string &line_spec = "") {
+                            std::string_view line_spec = "") {
             return geoplot(to_vector_1d(latitude), to_vector_1d(longitude),
                            line_spec);
         }
@@ -2274,7 +2274,7 @@ namespace matplot {
         template <class T1, class T2>
         vectors_handle compass(const IterableValues<T1> &x,
                                const IterableValues<T2> &y,
-                               const std::string &line_spec = "") {
+                               std::string_view line_spec = "") {
             return compass(to_vector_1d(x), to_vector_1d(y), line_spec);
         }
 
@@ -2287,7 +2287,7 @@ namespace matplot {
         template <class T1, class T2>
         line_handle polarplot(const IterableValues<T1> &theta,
                               const IterableValues<T2> &rho,
-                              const std::string &line_spec = "") {
+                              std::string_view line_spec = "") {
             return polarplot(to_vector_1d(theta), to_vector_1d(rho), line_spec);
         }
 
@@ -2297,7 +2297,7 @@ namespace matplot {
                      const IterableValues<T2> &rho,
                      const IterableValues<T3> &sizes = std::vector<double>{},
                      const IterableValues<T4> &colors = std::vector<double>{},
-                     const std::string &line_spec = "o") {
+                     std::string_view line_spec = "o") {
             return polarscatter(to_vector_1d(theta), to_vector_1d(rho),
                                 to_vector_1d(sizes), to_vector_1d(colors),
                                 line_spec);
@@ -2306,7 +2306,7 @@ namespace matplot {
         template <class T1, class T2>
         line_handle polarscatter(const IterableValues<T1> &theta,
                                  const IterableValues<T2> &rho, double size,
-                                 const std::string &line_spec = "o") {
+                                 std::string_view line_spec = "o") {
             return polarscatter(to_vector_1d(theta), to_vector_1d(rho), size,
                                 line_spec);
         }
@@ -2314,7 +2314,7 @@ namespace matplot {
         template <class T1, class T2>
         line_handle polarscatter(const IterableValues<T1> &theta,
                                  const IterableValues<T2> &rho,
-                                 const std::string &line_spec) {
+                                 std::string_view line_spec) {
             return polarscatter(to_vector_1d(theta), to_vector_1d(rho), size,
                                 line_spec);
         }
@@ -2324,7 +2324,7 @@ namespace matplot {
         contour(const IterableIterables<T1> &X, const IterableIterables<T2> &Y,
                 const IterableIterables<T3> &Z,
                 const IterableValues<T4> &levels,
-                const std::string &line_spec = "", size_t n_levels = 0) {
+                std::string_view line_spec = "", size_t n_levels = 0) {
             return contour(to_vector_2d(X), to_vector_2d(Y), to_vector_2d(Z),
                            to_vector_1d(levels), line_spec, n_levels);
         }
@@ -2333,7 +2333,7 @@ namespace matplot {
         contours_handle
         contour(const IterableIterables<T1> &X, const IterableIterables<T2> &Y,
                 const IterableIterables<T3> &Z, size_t n_levels = 0,
-                const std::string &line_spec = "") {
+                std::string_view line_spec = "") {
             return contour(to_vector_2d(X), to_vector_2d(Y), to_vector_2d(Z),
                            n_levels, line_spec);
         }
@@ -2341,7 +2341,7 @@ namespace matplot {
         template <class T1, class T2, class T3>
         contours_handle
         contour(const IterableIterables<T1> &X, const IterableIterables<T1> &Y,
-                const IterableIterables<T1> &Z, const std::string &line_spec) {
+                const IterableIterables<T1> &Z, std::string_view line_spec) {
             return contour(to_vector_2d(X), to_vector_2d(Y), to_vector_2d(Z),
                            line_spec);
         }
@@ -2351,7 +2351,7 @@ namespace matplot {
         contourf(const IterableIterables<T1> &X, const IterableIterables<T2> &Y,
                  const IterableIterables<T3> &Z,
                  const IterableValues<T4> &levels,
-                 const std::string &line_spec = "", size_t n_levels = 0) {
+                 std::string_view line_spec = "", size_t n_levels = 0) {
             return contourf(to_vector_2d(X), to_vector_2d(Y), to_vector_2d(Z),
                             to_vector_1d(levels), line_spec, n_levels);
         }
@@ -2360,7 +2360,7 @@ namespace matplot {
         contours_handle
         contourf(const IterableIterables<T1> &X, const IterableIterables<T2> &Y,
                  const IterableIterables<T3> &Z, size_t n_levels = 0,
-                 const std::string &line_spec = "") {
+                 std::string_view line_spec = "") {
             return contourf(to_vector_2d(X), to_vector_2d(Y), to_vector_2d(Z),
                             n_levels, line_spec);
         }
@@ -2368,7 +2368,7 @@ namespace matplot {
         template <class T1, class T2, class T3>
         contours_handle
         contourf(const IterableIterables<T1> &X, const IterableIterables<T2> &Y,
-                 const IterableIterables<T3> &Z, const std::string &line_spec) {
+                 const IterableIterables<T3> &Z, std::string_view line_spec) {
             return contourf(to_vector_2d(X), to_vector_2d(Y), to_vector_2d(Z),
                             line_spec);
         }
@@ -2377,7 +2377,7 @@ namespace matplot {
         contours_handle fcontour(fcontour_function_type fn,
                                  const std::array<double, 4> &xy_range,
                                  IterableValues<T1> levels = {},
-                                 const std::string &line_spec = "",
+                                 std::string_view line_spec = "",
                                  size_t n_levels = 0) {
             return fcontour(fn, xy_range, to_vector_1d(levels), line_spec,
                             n_levels);
@@ -2386,7 +2386,7 @@ namespace matplot {
         template <class T1, class T2>
         vectors_handle feather(const IterableValues<T1> &u,
                                const IterableValues<T2> &v,
-                               const std::string &line_spec = "") {
+                               std::string_view line_spec = "") {
             return feather(to_vector_1d(u), to_vector_1d(v), line_spec);
         }
 
@@ -2396,7 +2396,7 @@ namespace matplot {
                          vectors_handle>
         quiver(const IterableValues<T1> &x, const IterableValues<T2> &y,
                const IterableValues<T3> &u, const IterableValues<T4> &v,
-               double scale = 1.0, const std::string &line_spec = "") {
+               double scale = 1.0, std::string_view line_spec = "") {
             return quiver(to_vector_1d(x), to_vector_1d(y), to_vector_1d(u),
                           to_vector_1d(v), scale, line_spec);
         }
@@ -2408,7 +2408,7 @@ namespace matplot {
             vectors_handle>
         quiver(const IterableIterables<T1> &x, const IterableIterables<T2> &y,
                const IterableIterables<T3> &u, const IterableIterables<T4> &v,
-               double scale = 1.0, const std::string &line_spec = "") {
+               double scale = 1.0, std::string_view line_spec = "") {
             return quiver(to_vector_2d(x), to_vector_2d(y), to_vector_2d(u),
                           to_vector_2d(v), scale, line_spec);
         }
@@ -2422,7 +2422,7 @@ namespace matplot {
         quiver3(const IterableValues<T1> &x, const IterableValues<T2> &y,
                 const IterableValues<T3> &z, const IterableValues<T4> &u,
                 const IterableValues<T5> &v, const IterableValues<T6> &w,
-                double scale = 1.0, const std::string &line_spec = "") {
+                double scale = 1.0, std::string_view line_spec = "") {
             return quiver3(to_vector_1d(x), to_vector_1d(y), to_vector_1d(z),
                            to_vector_1d(u), to_vector_1d(v), to_vector_1d(w),
                            scale, line_spec);
@@ -2437,7 +2437,7 @@ namespace matplot {
         quiver3(const IterableIterables<T1> &x, const IterableIterables<T2> &y,
                 const IterableIterables<T3> &z, const IterableIterables<T4> &u,
                 const IterableIterables<T5> &v, const IterableIterables<T6> &w,
-                double scale = 1.0, const std::string &line_spec = "") {
+                double scale = 1.0, std::string_view line_spec = "") {
             return quiver3(to_vector_2d(x), to_vector_2d(y), to_vector_2d(z),
                            to_vector_2d(u), to_vector_2d(v), to_vector_2d(w),
                            scale, line_spec);
@@ -2447,7 +2447,7 @@ namespace matplot {
         vectors_handle
         quiver3(const IterableIterables<T1> &z, const IterableIterables<T2> &u,
                 const IterableIterables<T3> &v, const IterableIterables<T4> &w,
-                double scale = 1.0, const std::string &line_spec = "") {
+                double scale = 1.0, std::string_view line_spec = "") {
             return quiver3(to_vector_2d(z), to_vector_2d(u), to_vector_2d(v),
                            to_vector_2d(w), scale, line_spec);
         }
@@ -2501,7 +2501,7 @@ namespace matplot {
         surface_handle
         surf(const IterableIterables<T1> &X, const IterableIterables<T2> &Y,
              const IterableIterables<T3> &Z,
-             const IterableIterables<T4> &C = {}, std::string line_spec = "") {
+             const IterableIterables<T4> &C = {}, std::string_view line_spec = "") {
             return IterableIterables<T1>(to_vector_2d(X), to_vector_2d(Y),
                                          to_vector_2d(Z), to_vector_2d(C),
                                          line_spec);
@@ -2529,14 +2529,14 @@ namespace matplot {
         network_handle graph(const IterableValues<T1> &edges,
                              const IterableValues<T2> &weights = {},
                              size_t n_vertices = 0,
-                             std::string line_spec = "-o") {
+                             std::string_view line_spec = "-o") {
             return graph(to_vector_1d<T1, std::pair<size_t, size_t>>(edges),
                          to_vector_1d(weights), n_vertices, line_spec);
         }
 
         template <class T1>
         network_handle graph(const IterableValues<T1> &edges,
-                             const std::string &line_spec) {
+                             std::string_view line_spec) {
             return graph(to_vector_1d<T1, std::pair<size_t, size_t>>(edges),
                          line_spec);
         }
@@ -2614,14 +2614,14 @@ namespace matplot {
         template <class T1, class T2>
         labels_handle text(const IterableValues<T1> &x,
                            const IterableValues<T2> &y,
-                           const std::string &str) {
+                           std::string_view str) {
             return text(to_vector_1d(x), to_vector_1d(y), str);
         }
 
         template <class T1, class T2>
         line_handle fill(const IterableValues<T1> &x,
                          const IterableValues<T2> &y,
-                         const std::string &line_spec = "") {
+                         std::string_view line_spec = "") {
             return fill(to_vector_1d(x), to_vector_1d(y), line_spec);
         }
 

--- a/source/matplot/core/axis_type.cpp
+++ b/source/matplot/core/axis_type.cpp
@@ -106,7 +106,7 @@ namespace matplot {
         return *this;
     }
 
-    class axis_type &axis_type::color(const std::string &c) {
+    class axis_type &axis_type::color(std::string_view c) {
         color(string_to_color(c));
         return *this;
     }
@@ -117,7 +117,7 @@ namespace matplot {
 
     const std::string &axis_type::label() const { return label_; }
 
-    class axis_type &axis_type::label(const std::string &label) {
+    class axis_type &axis_type::label(std::string_view label) {
         label_ = label;
         touch();
         return *this;
@@ -152,7 +152,7 @@ namespace matplot {
     }
 
     class axis_type &
-    axis_type::tick_label_format(const std::string &tick_label_format) {
+    axis_type::tick_label_format(std::string_view tick_label_format) {
         if (tick_label_format == "usd") {
             tick_label_format_ = "$%.2f";
         } else if (tick_label_format == "degrees") {
@@ -324,7 +324,7 @@ namespace matplot {
 
     const std::string &axis_type::label_weight() const { return label_weight_; }
 
-    class axis_type &axis_type::label_weight(const std::string &label_weight) {
+    class axis_type &axis_type::label_weight(std::string_view label_weight) {
         label_weight_ = label_weight;
         touch();
         return *this;

--- a/source/matplot/core/axis_type.h
+++ b/source/matplot/core/axis_type.h
@@ -45,14 +45,14 @@ namespace matplot {
 
         const color_array &color() const;
         class axis_type &color(const color_array &color);
-        class axis_type &color(const std::string &color);
+        class axis_type &color(std::string_view color);
         class axis_type &color(const enum color &color);
 
         const std::string &label() const;
-        class axis_type &label(const std::string &label);
+        class axis_type &label(std::string_view label);
 
         const std::string &tick_label_format() const;
-        class axis_type &tick_label_format(const std::string &tick_label_format);
+        class axis_type &tick_label_format(std::string_view tick_label_format);
 
         bool tick_values_automatic() const;
         class axis_type &tick_values_automatic(bool tick_values_automatic);
@@ -94,7 +94,7 @@ namespace matplot {
         class axis_type &on_axis(bool on_axis);
 
         const std::string &label_weight() const;
-        class axis_type &label_weight(const std::string &label_weight);
+        class axis_type &label_weight(std::string_view label_weight);
 
         float label_font_size() const;
         class axis_type &label_font_size(float label_font_size);

--- a/source/matplot/core/figure_type.cpp
+++ b/source/matplot/core/figure_type.cpp
@@ -178,7 +178,7 @@ namespace matplot {
         run_command("plot 2 with lines");
     }
 
-    void figure_type::name(const std::string &name) {
+    void figure_type::name(std::string_view name) {
         name_ = name;
         touch();
     }
@@ -196,7 +196,7 @@ namespace matplot {
         touch();
     }
 
-    void figure_type::color(const std::string &c) {
+    void figure_type::color(std::string_view c) {
         color(to_array(string_to_color(c)));
     }
 
@@ -677,7 +677,7 @@ namespace matplot {
 
     const std::string &figure_type::font() const { return font_; }
 
-    void figure_type::font(const std::string &font) {
+    void figure_type::font(std::string_view font) {
         font_ = font;
         touch();
     }
@@ -691,7 +691,7 @@ namespace matplot {
 
     const std::string &figure_type::title() const { return title_; }
 
-    void figure_type::title(const std::string &title) {
+    void figure_type::title(std::string_view title) {
         title_ = title;
         touch();
     }
@@ -749,7 +749,7 @@ namespace matplot {
                std::vector<std::vector<axes_handle>>>
     figure_type::plotmatrix(const std::vector<std::vector<double>> &X,
                             const std::vector<std::vector<double>> &Y,
-                            const std::string &line_spec,
+                            std::string_view line_spec,
                             bool histogram_on_diagonals) {
         bool p = this->quiet_mode();
         this->quiet_mode(true);

--- a/source/matplot/core/figure_type.h
+++ b/source/matplot/core/figure_type.h
@@ -190,12 +190,12 @@ namespace matplot {
                    std::vector<std::vector<axes_handle>>>
         plotmatrix(const std::vector<std::vector<double>> &X,
                    const std::vector<std::vector<double>> &Y,
-                   const std::string &line_spec = "of",
+                   std::string_view line_spec = "of",
                    bool histogram_on_diagonals = false);
 
         /// Create matrix of axes with scatter plots - X / X
         auto plotmatrix(const std::vector<std::vector<double>> &X,
-                        const std::string &line_spec = "of",
+                        std::string_view line_spec = "of",
                         bool histogram_on_diagonals = false) {
             return this->plotmatrix(X, X, line_spec, true);
         }
@@ -205,14 +205,14 @@ namespace matplot {
         void
         backend(const std::shared_ptr<backend::backend_interface> &new_backend);
 
-        void name(const std::string &name);
+        void name(std::string_view name);
         std::string name() const;
 
         size_t number() const;
 
         void color(const color_array &c);
         void color(const std::array<float, 3> &c);
-        void color(const std::string &c);
+        void color(std::string_view c);
         void color(const enum color &c);
         color_array color() const;
 
@@ -238,13 +238,13 @@ namespace matplot {
         bool number_title() const;
 
         const std::string &font() const;
-        void font(const std::string &font);
+        void font(std::string_view font);
 
         float font_size() const;
         void font_size(float font_size);
 
         const std::string &title() const;
-        void title(const std::string &title);
+        void title(std::string_view title);
 
         const color_array &title_color() const;
         void title_color(const color_array &title_color);

--- a/source/matplot/core/legend.cpp
+++ b/source/matplot/core/legend.cpp
@@ -241,14 +241,14 @@ namespace matplot {
 
     const std::string &legend::title() const { return title_; }
 
-    void legend::title(const std::string &title) {
+    void legend::title(std::string_view title) {
         title_ = title;
         touch();
     }
 
     const std::string &legend::font_name() const { return font_name_; }
 
-    void legend::font_name(const std::string &font_name) {
+    void legend::font_name(std::string_view font_name) {
         font_name_ = font_name;
         touch();
     }
@@ -262,14 +262,14 @@ namespace matplot {
 
     const std::string &legend::font_angle() const { return font_angle_; }
 
-    void legend::font_angle(const std::string &font_angle) {
+    void legend::font_angle(std::string_view font_angle) {
         font_angle_ = font_angle;
         touch();
     }
 
     const std::string &legend::font_weight() const { return font_weight_; }
 
-    void legend::font_weight(const std::string &font_weight) {
+    void legend::font_weight(std::string_view font_weight) {
         font_weight_ = font_weight;
         touch();
     }

--- a/source/matplot/core/legend.h
+++ b/source/matplot/core/legend.h
@@ -105,19 +105,19 @@ namespace matplot {
         void visible(bool visible);
 
         const std::string &title() const;
-        void title(const std::string &title);
+        void title(std::string_view title);
 
         const std::string &font_name() const;
-        void font_name(const std::string &font_name);
+        void font_name(std::string_view font_name);
 
         float font_size() const;
         void font_size(float font_size);
 
         const std::string &font_angle() const;
-        void font_angle(const std::string &font_angle);
+        void font_angle(std::string_view font_angle);
 
         const std::string &font_weight() const;
-        void font_weight(const std::string &font_weight);
+        void font_weight(std::string_view font_weight);
 
         const color_array &text_color() const;
         void text_color(const color_array &text_color);

--- a/source/matplot/core/line_spec.cpp
+++ b/source/matplot/core/line_spec.cpp
@@ -12,12 +12,12 @@
 namespace matplot {
     line_spec::line_spec() = default;
 
-    line_spec::line_spec(const std::string &expr)
+    line_spec::line_spec(std::string_view expr)
         : marker_style_(marker_style::none) {
         parse_string(expr);
     }
 
-    void line_spec::parse_string(const std::string &expr) {
+    void line_spec::parse_string(std::string_view expr) {
         for (size_t expr_pos = 0; expr_pos != expr.size(); ++expr_pos) {
             size_t chars_left = expr.size() - expr_pos;
             switch (expr[expr_pos]) {
@@ -310,7 +310,7 @@ namespace matplot {
         }
     }
 
-    void line_spec::color(const std::string &c) {
+    void line_spec::color(std::string_view c) {
         color(to_array(string_to_color(c)));
     }
 
@@ -353,7 +353,7 @@ namespace matplot {
         touch();
     }
 
-    void line_spec::marker_style(const std::string &marker_style) {
+    void line_spec::marker_style(std::string_view marker_style) {
         switch (marker_style[0]) {
         case '+':
             marker_style_ = marker_style::plus_sign;
@@ -417,7 +417,7 @@ namespace matplot {
         return custom_marker_;
     }
 
-    void line_spec::custom_marker(const std::string &custom_marker) {
+    void line_spec::custom_marker(std::string_view custom_marker) {
         custom_marker_ = custom_marker;
         touch();
     }
@@ -460,7 +460,7 @@ namespace matplot {
         }
     }
 
-    void line_spec::marker_color(const std::string &m) {
+    void line_spec::marker_color(std::string_view m) {
         marker_color_ = to_array(string_to_color(m));
         touch();
     }
@@ -499,7 +499,7 @@ namespace matplot {
         }
     }
 
-    void line_spec::marker_face_color(const std::string &color) {
+    void line_spec::marker_face_color(std::string_view color) {
         marker_face_color(to_array(color));
     }
 

--- a/source/matplot/core/line_spec.h
+++ b/source/matplot/core/line_spec.h
@@ -53,10 +53,10 @@ namespace matplot {
 
       public:
         line_spec();
-        explicit line_spec(const std::string &expr);
+        explicit line_spec(std::string_view expr);
 
         template <class T>
-        line_spec(Pointer<T> parent, const std::string &expr)
+        line_spec(Pointer<T> parent, std::string_view expr)
             : line_spec(expr) {
             touch_function_ = [parent]() { parent->touch(); };
         }
@@ -70,7 +70,7 @@ namespace matplot {
                     bool include_style = true);
 
         /// Get line_spec properties from a string
-        void parse_string(const std::string &expr);
+        void parse_string(std::string_view expr);
 
         /// \brief True if we can plot line and marker with only one plot
         /// command We can plot them together "with linespoints" if:
@@ -101,7 +101,7 @@ namespace matplot {
         void color(const std::array<float, 3> &color);
         void color(const std::array<float, 4> &color);
         void color(std::initializer_list<float> color);
-        void color(const std::string &color);
+        void color(std::string_view color);
         void color(enum color marker_color);
         void alpha(float alpha);
         [[nodiscard]] bool user_color() const;
@@ -115,12 +115,12 @@ namespace matplot {
 
         [[nodiscard]] enum marker_style marker_style() const;
         void marker_style(enum marker_style marker_style);
-        void marker_style(const std::string &marker_style);
+        void marker_style(std::string_view marker_style);
         [[nodiscard]] enum marker_style marker() const;
         template <class T> void marker(T marker) { marker_style(marker); }
 
         [[nodiscard]] const std::string &custom_marker() const;
-        void custom_marker(const std::string &custom_marker);
+        void custom_marker(std::string_view custom_marker);
 
         [[nodiscard]] float marker_size() const;
         void marker_size(float marker_size);
@@ -130,7 +130,7 @@ namespace matplot {
         void marker_color(const std::array<float, 3> &color);
         void marker_color(const std::array<float, 4> &color);
         void marker_color(std::initializer_list<float> color);
-        void marker_color(const std::string &color);
+        void marker_color(std::string_view color);
         void marker_color(enum color marker_color);
         void marker_alpha(float alpha);
         bool marker_user_color() const;
@@ -141,7 +141,7 @@ namespace matplot {
         void marker_face_color(const std::array<float, 3> &color);
         void marker_face_color(const std::array<float, 4> &color);
         void marker_face_color(std::initializer_list<float> color);
-        void marker_face_color(const std::string &color);
+        void marker_face_color(std::string_view color);
         void marker_face_color(enum color marker_face_color);
         void marker_face_alpha(float alpha);
         bool marker_face_user_color() const;

--- a/source/matplot/freestanding/axes_functions.cpp
+++ b/source/matplot/freestanding/axes_functions.cpp
@@ -183,71 +183,71 @@ namespace matplot {
 
     std::pair<float, float> view(axes_handle ax) { return ax->view(); }
 
-    void title(const std::string &str) { title(gca(), str); }
+    void title(std::string_view str) { title(gca(), str); }
 
-    void title(axes_handle ax, const std::string &str) { ax->title(str); }
+    void title(axes_handle ax, std::string_view str) { ax->title(str); }
 
-    void title(const std::string &str, const color_array &c) {
+    void title(std::string_view str, const color_array &c) {
         auto ax = gca();
         title(ax, str);
         ax->title_color(c);
     }
 
-    void title(axes_handle ax, const std::string &str, const color_array &c) {
+    void title(axes_handle ax, std::string_view str, const color_array &c) {
         title(ax, str);
         ax->title_color(c);
     }
 
-    void title(legend_handle lgd, const std::string &str) { lgd->title(str); }
+    void title(legend_handle lgd, std::string_view str) { lgd->title(str); }
 
-    void sgtitle(const std::string &str) { sgtitle(gca(), str); }
+    void sgtitle(std::string_view str) { sgtitle(gca(), str); }
 
-    void sgtitle(axes_handle ax, const std::string &str) {
+    void sgtitle(axes_handle ax, std::string_view str) {
         ax->parent()->title(str);
     }
 
-    void sgtitle(const std::string &str, const color_array &c) {
+    void sgtitle(std::string_view str, const color_array &c) {
         auto ax = gca();
         sgtitle(ax, str);
         ax->parent()->title_color(c);
     }
 
-    void sgtitle(axes_handle ax, const std::string &str, const color_array &c) {
+    void sgtitle(axes_handle ax, std::string_view str, const color_array &c) {
         sgtitle(ax, str);
         ax->parent()->title_color(c);
     }
 
-    void xlabel(const std::string &str) { xlabel(gca(), str); }
+    void xlabel(std::string_view str) { xlabel(gca(), str); }
 
-    void xlabel(axes_handle ax, const std::string &str) { ax->xlabel(str); }
+    void xlabel(axes_handle ax, std::string_view str) { ax->xlabel(str); }
 
-    void ylabel(const std::string &str) { ylabel(gca(), str); }
+    void ylabel(std::string_view str) { ylabel(gca(), str); }
 
-    void ylabel(axes_handle ax, const std::string &str) { ax->ylabel(str); }
+    void ylabel(axes_handle ax, std::string_view str) { ax->ylabel(str); }
 
-    void y2label(const std::string &str) { y2label(gca(), str); }
+    void y2label(std::string_view str) { y2label(gca(), str); }
 
-    void y2label(axes_handle ax, const std::string &str) { ax->y2label(str); }
+    void y2label(axes_handle ax, std::string_view str) { ax->y2label(str); }
 
-    void zlabel(const std::string &str) { zlabel(gca(), str); }
+    void zlabel(std::string_view str) { zlabel(gca(), str); }
 
-    void zlabel(axes_handle ax, const std::string &str) { ax->zlabel(str); }
+    void zlabel(axes_handle ax, std::string_view str) { ax->zlabel(str); }
 
-    void xtickformat(const std::string &str) { xtickformat(gca(), str); }
+    void xtickformat(std::string_view str) { xtickformat(gca(), str); }
 
-    void xtickformat(axes_handle ax, const std::string &str) {
+    void xtickformat(axes_handle ax, std::string_view str) {
         ax->xtickformat(str);
     }
 
-    void ytickformat(const std::string &str) { ytickformat(gca(), str); }
+    void ytickformat(std::string_view str) { ytickformat(gca(), str); }
 
-    void ytickformat(axes_handle ax, const std::string &str) {
+    void ytickformat(axes_handle ax, std::string_view str) {
         ax->ytickformat(str);
     }
 
-    void ztickformat(const std::string &str) { ztickformat(gca(), str); }
+    void ztickformat(std::string_view str) { ztickformat(gca(), str); }
 
-    void ztickformat(axes_handle ax, const std::string &str) {
+    void ztickformat(axes_handle ax, std::string_view str) {
         ax->ztickformat(str);
     }
 

--- a/source/matplot/freestanding/axes_functions.h
+++ b/source/matplot/freestanding/axes_functions.h
@@ -94,55 +94,55 @@ namespace matplot {
     axes_handle nexttile();
     axes_handle nexttile(size_t index);
 
-    void title(const std::string &str);
-    void title(const std::string &str, const color_array &c);
+    void title(std::string_view str);
+    void title(std::string_view str, const color_array &c);
 
     template <class COLOR_TYPE>
-    void title(const std::string &str, COLOR_TYPE c) {
+    void title(std::string_view str, COLOR_TYPE c) {
         title(str, to_array(c));
     }
 
-    void title(axes_handle ax, const std::string &str);
-    void title(axes_handle ax, const std::string &str, const color_array &c);
+    void title(axes_handle ax, std::string_view str);
+    void title(axes_handle ax, std::string_view str, const color_array &c);
 
     template <class COLOR_TYPE>
-    void title(axes_handle ax, const std::string &str, COLOR_TYPE c) {
+    void title(axes_handle ax, std::string_view str, COLOR_TYPE c) {
         title(ax, str, to_array(c));
     }
 
-    void title(legend_handle lgd, const std::string &str);
+    void title(legend_handle lgd, std::string_view str);
 
-    void sgtitle(const std::string &str);
-    void sgtitle(const std::string &str, const color_array &c);
+    void sgtitle(std::string_view str);
+    void sgtitle(std::string_view str, const color_array &c);
 
     template <class COLOR_TYPE>
-    void sgtitle(const std::string &str, COLOR_TYPE c) {
+    void sgtitle(std::string_view str, COLOR_TYPE c) {
         sgtitle(str, to_array(c));
     }
 
-    void sgtitle(axes_handle ax, const std::string &str);
-    void sgtitle(axes_handle ax, const std::string &str, const color_array &c);
+    void sgtitle(axes_handle ax, std::string_view str);
+    void sgtitle(axes_handle ax, std::string_view str, const color_array &c);
 
     template <class COLOR_TYPE>
-    void sgtitle(axes_handle ax, const std::string &str, COLOR_TYPE c) {
+    void sgtitle(axes_handle ax, std::string_view str, COLOR_TYPE c) {
         sgtitle(ax, str, to_array(c));
     }
 
-    void xlabel(const std::string &str);
-    void xlabel(axes_handle ax, const std::string &str);
-    void ylabel(const std::string &str);
-    void ylabel(axes_handle ax, const std::string &str);
-    void y2label(const std::string &str);
-    void y2label(axes_handle ax, const std::string &str);
-    void zlabel(const std::string &str);
-    void zlabel(axes_handle ax, const std::string &str);
+    void xlabel(std::string_view str);
+    void xlabel(axes_handle ax, std::string_view str);
+    void ylabel(std::string_view str);
+    void ylabel(axes_handle ax, std::string_view str);
+    void y2label(std::string_view str);
+    void y2label(axes_handle ax, std::string_view str);
+    void zlabel(std::string_view str);
+    void zlabel(axes_handle ax, std::string_view str);
 
-    void xtickformat(const std::string &str);
-    void xtickformat(axes_handle ax, const std::string &str);
-    void ytickformat(const std::string &str);
-    void ytickformat(axes_handle ax, const std::string &str);
-    void ztickformat(const std::string &str);
-    void ztickformat(axes_handle ax, const std::string &str);
+    void xtickformat(std::string_view str);
+    void xtickformat(axes_handle ax, std::string_view str);
+    void ytickformat(std::string_view str);
+    void ytickformat(axes_handle ax, std::string_view str);
+    void ztickformat(std::string_view str);
+    void ztickformat(axes_handle ax, std::string_view str);
 
     std::string xtickformat();
     std::string xtickformat(axes_handle ax);
@@ -245,14 +245,14 @@ namespace matplot {
     // Hackfix for a compiler bug in MSVC
     namespace {
         template <typename... Args>
-        legend_handle legend(axes_handle ax, const std::string &name,
+        legend_handle legend(axes_handle ax, std::string_view name,
                              Args const &... next_name) {
-            std::vector<std::string> legends = {name, next_name...};
+            std::vector<std::string> legends = {std::string(name), std::string(next_name)...};
             return ::matplot::legend(ax, legends);
         }
 
         template <typename... Args>
-        legend_handle legend(const std::string &name,
+        legend_handle legend(std::string_view name,
                              Args const &... next_name) {
             return legend(gca(), name, next_name...);
         }

--- a/source/matplot/freestanding/plot.h
+++ b/source/matplot/freestanding/plot.h
@@ -43,18 +43,18 @@ namespace matplot {
 
     inline line_handle plot(const std::vector<double> &x,
                             const std::vector<double> &y,
-                            const std::string &line_spec = "") {
+                            std::string_view line_spec = "") {
         return gca()->plot(x, y, line_spec);
     }
 
     inline line_handle plot(const std::vector<double> &y,
-                            const std::string &line_spec = "") {
+                            std::string_view line_spec = "") {
         return gca()->plot(y, line_spec);
     }
 
     template <class... Args>
     auto plot(const std::vector<double> &x, const std::vector<double> &y,
-              const std::string &line_spec, Args&&... args) {
+              std::string_view line_spec, Args&&... args) {
         return gca()->plot(x, y, line_spec, std::forward<Args>(args)...);
     }
 
@@ -65,25 +65,25 @@ namespace matplot {
     }
 
     template <class... Args>
-    auto plot(const std::vector<double> &y, const std::string &line_spec,
+    auto plot(const std::vector<double> &y, std::string_view line_spec,
               Args&&... args) {
         return gca()->plot(y, line_spec, std::forward<Args>(args)...);
     }
 
     inline line_handle plot(axes_handle ax, const std::vector<double> &x,
                             const std::vector<double> &y,
-                            const std::string &line_spec = "") {
+                            std::string_view line_spec = "") {
         return ax->plot(x, y, line_spec);
     }
 
     inline line_handle plot(axes_handle ax, const std::vector<double> &y,
-                            const std::string &line_spec = "") {
+                            std::string_view line_spec = "") {
         return ax->plot(y, line_spec);
     }
 
     template <class... Args>
     auto plot(axes_handle ax, const std::vector<double> &x,
-              const std::vector<double> &y, const std::string &line_spec,
+              const std::vector<double> &y, std::string_view line_spec,
               Args&&... args) {
         return ax->plot(x, y, line_spec, std::forward<Args>(args)...);
     }
@@ -97,7 +97,7 @@ namespace matplot {
 
     template <class... Args>
     auto plot(axes_handle ax, const std::vector<double> &y,
-              const std::string &line_spec, Args&&... args) {
+              std::string_view line_spec, Args&&... args) {
         return ax->plot(y, line_spec, std::forward<Args>(args)...);
     }
 
@@ -501,12 +501,12 @@ namespace matplot {
     inline contours_handle fcontour(axes_type::fcontour_function_type fn,
                                     const std::array<double, 4> &xy_range,
                                     std::vector<double> levels,
-                                    const std::string &line_spec = "") {
+                                    std::string_view line_spec = "") {
         return gca()->fcontour(fn, xy_range, levels, line_spec);
     }
 
     inline contours_handle fcontour(axes_type::fcontour_function_type fn,
-                                    const std::string &line_spec) {
+                                    std::string_view line_spec) {
         return gca()->fcontour(fn, line_spec);
     }
 
@@ -514,13 +514,13 @@ namespace matplot {
                                     axes_type::fcontour_function_type fn,
                                     const std::array<double, 4> &xy_range,
                                     std::vector<double> levels,
-                                    const std::string &line_spec = "") {
+                                    std::string_view line_spec = "") {
         return ax->fcontour(fn, xy_range, levels, line_spec);
     }
 
     inline contours_handle fcontour(axes_handle ax,
                                     axes_type::fcontour_function_type fn,
-                                    const std::string &line_spec) {
+                                    std::string_view line_spec) {
         return ax->fcontour(fn, line_spec);
     }
 
@@ -581,7 +581,7 @@ namespace matplot {
     inline surface_handle fsurf(axes_type::fcontour_function_type fn,
                                 const std::array<double, 2> &x_range,
                                 const std::array<double, 2> &y_range,
-                                std::string line_spec = "",
+                                std::string_view line_spec = "",
                                 double mesh_density = 40) {
         return gca()->fsurf(fn, x_range, y_range, line_spec, mesh_density);
     }
@@ -591,7 +591,7 @@ namespace matplot {
                                 axes_type::fcontour_function_type funz,
                                 const std::array<double, 2> &u_range,
                                 const std::array<double, 2> &v_range,
-                                std::string line_spec = "",
+                                std::string_view line_spec = "",
                                 double mesh_density = 40) {
         return gca()->fsurf(funx, funy, funz, u_range, v_range, line_spec,
                             mesh_density);
@@ -601,7 +601,7 @@ namespace matplot {
     /// Grid / Both ranges in the same array size 4
     inline surface_handle fsurf(axes_type::fcontour_function_type fn,
                                 const std::array<double, 4> &xy_range,
-                                std::string line_spec = "",
+                                std::string_view line_spec = "",
                                 double mesh_density = 40) {
         return gca()->fsurf(fn, xy_range, line_spec, mesh_density);
     }
@@ -610,7 +610,7 @@ namespace matplot {
     /// Grid / Both ranges in the same array size 4
     inline surface_handle fsurf(axes_type::fcontour_function_type fn,
                                 std::initializer_list<double> xy_range,
-                                std::string line_spec = "",
+                                std::string_view line_spec = "",
                                 double mesh_density = 40) {
         return gca()->fsurf(fn, xy_range, line_spec, mesh_density);
     }
@@ -620,7 +620,7 @@ namespace matplot {
                                 axes_type::fcontour_function_type funy,
                                 axes_type::fcontour_function_type funz,
                                 const std::array<double, 4> &uv_range,
-                                std::string line_spec = "",
+                                std::string_view line_spec = "",
                                 double mesh_density = 40) {
         return gca()->fsurf(funx, funy, funz, uv_range, line_spec,
                             mesh_density);
@@ -631,7 +631,7 @@ namespace matplot {
     inline surface_handle
     fsurf(axes_type::fcontour_function_type fn,
           const std::array<double, 2> &xy_range = {-5, +5},
-          std::string line_spec = "", double mesh_density = 40) {
+          std::string_view line_spec = "", double mesh_density = 40) {
         return gca()->fsurf(fn, xy_range, line_spec, mesh_density);
     }
 
@@ -642,7 +642,7 @@ namespace matplot {
           axes_type::fcontour_function_type funy,
           axes_type::fcontour_function_type funz,
           const std::array<double, 2> &uv_range = {-5, +5},
-          std::string line_spec = "", double mesh_density = 40) {
+          std::string_view line_spec = "", double mesh_density = 40) {
         return gca()->fsurf(funx, funy, funz, uv_range, line_spec,
                             mesh_density);
     }
@@ -651,7 +651,7 @@ namespace matplot {
                                 axes_type::fcontour_function_type funy,
                                 axes_type::fcontour_function_type funz,
                                 std::initializer_list<double> &uv_range,
-                                std::string line_spec = "",
+                                std::string_view line_spec = "",
                                 double mesh_density = 40) {
         return gca()->fsurf(funx, funy, funz, uv_range, line_spec,
                             mesh_density);
@@ -662,7 +662,7 @@ namespace matplot {
                                 axes_type::fcontour_function_type fn,
                                 const std::array<double, 2> &x_range,
                                 const std::array<double, 2> &y_range,
-                                std::string line_spec = "",
+                                std::string_view line_spec = "",
                                 double mesh_density = 40) {
         return ax->fsurf(fn, x_range, y_range, line_spec, mesh_density);
     }
@@ -675,7 +675,7 @@ namespace matplot {
                                 axes_type::fcontour_function_type funz,
                                 const std::array<double, 2> &u_range,
                                 const std::array<double, 2> &v_range,
-                                std::string line_spec = "",
+                                std::string_view line_spec = "",
                                 double mesh_density = 40) {
         return ax->fsurf(funx, funy, funz, u_range, v_range, line_spec,
                          mesh_density);
@@ -686,7 +686,7 @@ namespace matplot {
     inline surface_handle fsurf(axes_handle ax,
                                 axes_type::fcontour_function_type fn,
                                 const std::array<double, 4> &xy_range,
-                                std::string line_spec = "",
+                                std::string_view line_spec = "",
                                 double mesh_density = 40) {
         return ax->fsurf(fn, xy_range, line_spec, mesh_density);
     }
@@ -697,7 +697,7 @@ namespace matplot {
                                 axes_type::fcontour_function_type funy,
                                 axes_type::fcontour_function_type funz,
                                 const std::array<double, 4> &uv_range,
-                                std::string line_spec = "",
+                                std::string_view line_spec = "",
                                 double mesh_density = 40) {
         return ax->fsurf(funx, funy, funz, uv_range, line_spec, mesh_density);
     }
@@ -707,7 +707,7 @@ namespace matplot {
     inline surface_handle
     fsurf(axes_handle ax, axes_type::fcontour_function_type fn,
           const std::array<double, 2> &xy_range = {-5, +5},
-          std::string line_spec = "", double mesh_density = 40) {
+          std::string_view line_spec = "", double mesh_density = 40) {
         return ax->fsurf(fn, xy_range, line_spec, mesh_density);
     }
 
@@ -718,7 +718,7 @@ namespace matplot {
           axes_type::fcontour_function_type funy,
           axes_type::fcontour_function_type funz,
           const std::array<double, 2> &uv_range = {-5, +5},
-          std::string line_spec = "", double mesh_density = 40) {
+          std::string_view line_spec = "", double mesh_density = 40) {
         return ax->fsurf(funx, funy, funz, uv_range, line_spec, mesh_density);
     }
 
@@ -727,7 +727,7 @@ namespace matplot {
                                 axes_type::fcontour_function_type funy,
                                 axes_type::fcontour_function_type funz,
                                 std::initializer_list<double> &uv_range,
-                                std::string line_spec = "",
+                                std::string_view line_spec = "",
                                 double mesh_density = 40) {
         return ax->fsurf(funx, funy, funz, uv_range, line_spec, mesh_density);
     }
@@ -839,7 +839,7 @@ namespace matplot {
 
     inline labels_handle text(const std::vector<double> &x,
                               const std::vector<double> &y,
-                              const std::string &str) {
+                              std::string_view str) {
         return gca()->text(x, y, str);
     }
 
@@ -851,7 +851,7 @@ namespace matplot {
 
     inline labels_handle text(axes_handle ax, const std::vector<double> &x,
                               const std::vector<double> &y,
-                              const std::string &str) {
+                              std::string_view str) {
         return ax->text(x, y, str);
     }
 

--- a/source/matplot/util/colors.cpp
+++ b/source/matplot/util/colors.cpp
@@ -34,7 +34,7 @@ namespace matplot {
         throw std::logic_error("colors::to_string: could not find a string for color");
     }
 
-    matplot::color string_to_color(const std::string &s) {
+    matplot::color string_to_color(std::string_view s) {
         if (s.size() == 1) {
             return char_to_color(s[0]);
         } else if (s == "blue") {
@@ -126,7 +126,7 @@ namespace matplot {
         throw std::logic_error("colors::to_array: could not find an array for color");
     }
 
-    std::array<float, 4> to_array(const std::string &s) {
+    std::array<float, 4> to_array(std::string_view s) {
         if (s.size() == 1) {
             return to_array(char_to_color(s[0]));
         } else if (s == "blue") {

--- a/source/matplot/util/colors.h
+++ b/source/matplot/util/colors.h
@@ -24,7 +24,7 @@ namespace matplot {
 
     std::string to_string(matplot::color c);
 
-    matplot::color string_to_color(const std::string &s);
+    matplot::color string_to_color(std::string_view s);
 
     matplot::color char_to_color(char c);
 
@@ -53,7 +53,7 @@ namespace matplot {
         return r;
     }
 
-    std::array<float, 4> to_array(const std::string &str_color);
+    std::array<float, 4> to_array(std::string_view str_color);
 
     std::string to_string(const std::array<float, 4> &c);
     std::string to_string(const std::array<float, 3> &c);

--- a/source/matplot/util/common.cpp
+++ b/source/matplot/util/common.cpp
@@ -27,7 +27,7 @@
 #endif
 
 namespace matplot {
-    bool iequals(const std::string &str1, const std::string &str2) {
+    bool iequals(std::string_view str1, std::string_view str2) {
         if (str1.size() != str2.size()) {
             return false;
         } else {
@@ -40,12 +40,12 @@ namespace matplot {
         return true;
     }
 
-    bool is_true(const std::string &str) {
+    bool is_true(std::string_view str) {
         return iequals(str, "on") || iequals(str, "true") ||
                iequals(str, "yes");
     }
 
-    bool is_false(const std::string &str) {
+    bool is_false(std::string_view str) {
         return iequals(str, "off") || iequals(str, "false") ||
                iequals(str, "no");
     }
@@ -64,8 +64,13 @@ namespace matplot {
         return result;
     }
 
-    std::string escape(const std::string &label) {
-        return std::regex_replace(label, std::regex("\""), "\\\"");
+    std::string escape(std::string_view label) {
+        std::string escaped;
+        escaped.reserve(label.size());
+
+        std::regex_replace(std::back_inserter(escaped), label.begin(), label.end(), std::regex("\""), "\\\"");
+
+        return escaped;
     }
 
     std::vector<double> linspace(double d1, double d2, size_t n) {
@@ -767,8 +772,8 @@ namespace matplot {
         return z2;
     }
 
-    std::vector<std::string> tokenize(const std::string &text,
-                                      std::string delimiters) {
+    std::vector<std::string> tokenize(std::string_view text,
+                                      std::string_view delimiters) {
         std::vector<std::string> tokens;
         size_t pos = 0;
         while ((pos = text.find_first_not_of(delimiters, pos)) !=
@@ -783,7 +788,7 @@ namespace matplot {
     std::pair<std::vector<std::string>, std::vector<size_t>>
     wordcount(const std::vector<std::string> &tokens,
               const std::vector<std::string> &black_list,
-              const std::string &delimiters, size_t max_cloud_size) {
+              std::string_view delimiters, size_t max_cloud_size) {
         // count the frequency of each token
         const bool bl_sorted =
             std::is_sorted(black_list.begin(), black_list.end());
@@ -828,9 +833,9 @@ namespace matplot {
     }
 
     std::pair<std::vector<std::string>, std::vector<size_t>>
-    wordcount(const std::string &text,
+    wordcount(std::string_view text,
               const std::vector<std::string> &black_list,
-              const std::string &delimiters, size_t max_cloud_size) {
+              std::string_view delimiters, size_t max_cloud_size) {
         auto tokens = tokenize(text);
         return wordcount(tokens, black_list, delimiters, max_cloud_size);
     }

--- a/source/matplot/util/common.h
+++ b/source/matplot/util/common.h
@@ -163,49 +163,51 @@ namespace matplot {
         return r;
     }
 
-    template <class T> std::vector<vector_2d> to_vector_3d(const T &v) {
-        std::vector<vector_2d> r(v.size());
-        size_t matrix_index = 0;
-        for (auto matrix_it = v.begin(); matrix_it != v.end();
-             ++matrix_it, ++matrix_index) {
-            r[matrix_index] = vector_2d(matrix_it->size());
-            size_t i = 0;
-            for (auto v_it = matrix_it->begin(); v_it != matrix_it->end();
-                 ++v_it, ++i) {
-                r[matrix_index][i] = vector_1d(v_it->size());
-                size_t j = 0;
-                for (auto vj_it = v_it->begin(); vj_it != v_it->end();
-                     ++vj_it, ++j) {
-                    r[matrix_index][i][j] = static_cast<double>(*vj_it);
-                }
-            }
-        }
-        return r;
+    namespace detail {
+        template <typename T, typename U>
+        using forward_or_copy =
+            std::conditional_t<std::is_same_v<T, U>, const U &, U>;
     }
 
-    template <class T, class DESTINATION_VALUE_TYPE = double>
-    vector_2d to_vector_2d(const T &v) {
-        std::vector<std::vector<DESTINATION_VALUE_TYPE>> r(v.size());
-        size_t i = 0;
-        for (auto v_it = v.begin(); v_it != v.end(); ++v_it, ++i) {
-            r[i] = std::vector<DESTINATION_VALUE_TYPE>(v_it->size());
-            size_t j = 0;
-            for (auto vj_it = v_it->begin(); vj_it != v_it->end();
-                 ++vj_it, ++j) {
-                r[i][j] = static_cast<DESTINATION_VALUE_TYPE>(*vj_it);
-            }
+    template <class T>
+    detail::forward_or_copy<T, vector_1d> to_vector_1d(const T &v) {
+        if constexpr (std::is_same_v<T, vector_1d>) {
+            return v;
+        } else {
+            using std::begin, std::end;
+
+            return vector_1d(begin(v), end(v));
         }
-        return r;
     }
 
-    template <class T, class DESTINATION_VALUE_TYPE = double>
-    vector_1d to_vector_1d(const T &v) {
-        std::vector<DESTINATION_VALUE_TYPE> r(v.size());
-        size_t i = 0;
-        for (auto v_it = v.begin(); v_it != v.end(); ++v_it, ++i) {
-            r[i] = static_cast<DESTINATION_VALUE_TYPE>(*v_it);
+    template <class T>
+    detail::forward_or_copy<T, vector_2d> to_vector_2d(const T &v) {
+        if constexpr (std::is_same_v<T, vector_2d>) {
+            return v;
+        } else {
+            using std::begin, std::end;
+
+            vector_2d r(std::distance(begin(v), end(v)));
+            std::transform(
+                begin(v), end(v), r.begin(),
+                [](auto &&e) -> vector_1d { return to_vector_1d(e); });
+            return r;
         }
-        return r;
+    }
+
+    template <class T>
+    detail::forward_or_copy<T, std::vector<vector_2d>> to_vector_3d(const T &v) {
+        if constexpr (std::is_same_v<T, std::vector<vector_2d>>) {
+            return v;
+        } else {
+            using std::begin, std::end;
+
+            std::vector<vector_2d> r(std::distance(begin(v), end(v)));
+            std::transform(
+                begin(v), end(v), r.begin(),
+                [](auto &&e) -> vector_2d { return to_vector_2d(e); });
+            return r;
+        }
     }
 
     template <class T> inline T norm(const std::vector<T> &v) {

--- a/source/matplot/util/common.h
+++ b/source/matplot/util/common.h
@@ -12,15 +12,16 @@
 #include <matplot/util/concepts.h>
 #include <sstream>
 #include <string>
+#include <string_view>
 #include <vector>
 #include <cctype>
 
 namespace matplot {
-    bool iequals(const std::string &str1, const std::string &str2);
-    bool is_true(const std::string &str);
-    bool is_false(const std::string &str);
+    bool iequals(std::string_view str1, std::string_view str2);
+    bool is_true(std::string_view str);
+    bool is_false(std::string_view str);
     std::string run_and_get_output(const std::string &command);
-    std::string escape(const std::string &label);
+    std::string escape(std::string_view label);
 
     inline void ltrim(std::string &s) {
         s.erase(s.begin(), std::find_if(s.begin(), s.end(), [](int ch) {
@@ -60,8 +61,8 @@ namespace matplot {
         }
     }
 
-    template <class T = double> T str2num(const std::string &Text) {
-        std::istringstream ss(Text);
+    template <class T = double> T str2num(std::string_view text) {
+        std::istringstream ss((std::string(text)));
         T result;
         return ss >> result ? result : 0;
     }
@@ -421,19 +422,18 @@ namespace matplot {
     vector_2d transpose(const vector_2d &z);
 
     std::vector<std::string>
-    tokenize(const std::string &text,
-             std::string delimiters = " ',\n\r\t\".!?:");
+    tokenize(std::string_view text, std::string_view delimiters = " ',\n\r\t\".!?:");
 
     std::pair<std::vector<std::string>, std::vector<size_t>>
     wordcount(const std::vector<std::string> &tokens,
               const std::vector<std::string> &black_list,
-              const std::string &delimiters = " ',\n\r\t\".!?:;",
+              std::string_view delimiters = " ',\n\r\t\".!?:;",
               size_t max_cloud_size = 100);
 
     std::pair<std::vector<std::string>, std::vector<size_t>>
-    wordcount(const std::string &text,
+    wordcount(std::string_view text,
               const std::vector<std::string> &black_list,
-              const std::string &delimiters = " ',\n\r\t\".!?:;",
+              std::string_view delimiters = " ',\n\r\t\".!?:;",
               size_t max_cloud_size = 100);
 
     // Distance from x to the next larger floating point number


### PR DESCRIPTION
Modify the `to_vector{1,2,3}d` functions so that no copy is performed if passed a parameter of type `const vector_{1,2,3}d&`, instead the reference itself is forwarded and returned.

Use `std::string_view` in place of `const std::string&` in parameters to avoid copying and allocating when passing C-style strings. This is also more flexible in the sense that the user can pass any type (even a user defined type) that is convertible to a `std::string_view` while using a `const std::string&` requires always constructing an `std::string` (which is more expensive since it has to allocate memory and copy data). I haven't touched parameters of type `std::vector<std::string>`.