### PR TITLE
Rewrite contour generation

### DIFF
--- a/source/matplot/axes_objects/contours.cpp
+++ b/source/matplot/axes_objects/contours.cpp
@@ -21,16 +21,14 @@ namespace matplot {
         : axes_object(parent), X_data_(X), Y_data_(Y), Z_data_(Z),
           line_spec_(this, line_spec) {
         initialize_preprocessed_data();
-        contour_generator_ = QuadContourGenerator(X_data_, Y_data_, Z_data_,
-                                                  _corner_mask, nchunk_);
+        contour_generator_ = detail::contour_generator(X_data_, Y_data_, Z_data_);
     }
 
     contours::contours(class axes_type *parent, const vector_2d &Z,
                        std::string_view line_spec)
         : axes_object(parent), Z_data_(Z), line_spec_(this, line_spec) {
         initialize_preprocessed_data();
-        contour_generator_ = QuadContourGenerator(X_data_, Y_data_, Z_data_,
-                                                  _corner_mask, nchunk_);
+        contour_generator_ = detail::contour_generator(X_data_, Y_data_, Z_data_);
     }
 
     std::string contours::set_variables_string() {

--- a/source/matplot/axes_objects/contours.cpp
+++ b/source/matplot/axes_objects/contours.cpp
@@ -110,7 +110,7 @@ namespace matplot {
 
                 if (filled) {
                     double ll = lower_levels[line_index],
-                        ul = upper_levels[line_index];
+                           ul = upper_levels[line_index];
 
                     double segment_z_level;
                     if (ll < zmin_ && ul < zmax_)

--- a/source/matplot/axes_objects/contours.cpp
+++ b/source/matplot/axes_objects/contours.cpp
@@ -1561,7 +1561,7 @@ namespace matplot {
                           double a1 = l1->b_box.area(), a2 = l2->b_box.area();
 
                           if (a1 == a2)
-                              return l1 < l2;
+                              return l1->line_index < l2->line_index;
                           else
                               return a1 > a2;
                       });

--- a/source/matplot/axes_objects/contours.h
+++ b/source/matplot/axes_objects/contours.h
@@ -205,7 +205,7 @@ namespace matplot {
 
       protected:
         /// Pre-processed contour lines
-        std::vector<QuadContourGenerator::vertices_list_type> lines_;
+        std::vector<detail::contour_generator::vertices_list_type> lines_;
 
         /// Pre-processed contour lines for filled plots
         /// This uses another algorithm for pairs of levels
@@ -213,14 +213,14 @@ namespace matplot {
         /// the closed polygons of filled plots are not good enough
         /// to represent everything.
         /// Also, this makes it much easier to label the unfilled lines.
-        std::vector<QuadContourGenerator::vertices_list_type> filled_lines_;
+        std::vector<detail::contour_generator::vertices_list_type> filled_lines_;
 
         /// These codes indicate what's happening in a filled line
         /// Starting a polygon, closing a polygon, or middle of a polygon
-        std::vector<QuadContourGenerator::codes_list_type> codes_;
+        std::vector<detail::contour_generator::codes_list_type> codes_;
 
         /// Object with the algorithm to generate contour lines
-        QuadContourGenerator contour_generator_;
+        detail::contour_generator contour_generator_;
 
         /// Segments of filled contours
         using level_index_type = size_t;
@@ -255,7 +255,6 @@ namespace matplot {
         bool filled_{false};
         vector_1d linewidths_ = {};
         bool antialiased_ = false;
-        bool _corner_mask = false;
         bool colormap_line_when_filled_ = false;
 
         /// Pre-processed data
@@ -267,7 +266,6 @@ namespace matplot {
         double vmin_ = NaN;
         double vmax_ = NaN;
         extend_option extend_ = extend_option::neither;
-        size_t nchunk_ = 0;
         double zmin_{NaN};
         double zmax_{NaN};
 

--- a/source/matplot/axes_objects/contours.h
+++ b/source/matplot/axes_objects/contours.h
@@ -154,6 +154,7 @@ namespace matplot {
             struct {
                 bool is_child : 1;
                 bool is_lower : 1;
+                bool is_boundary_crossing : 1;
             } flags;
             size_t line_index;
             struct b_box_type {
@@ -268,11 +269,11 @@ namespace matplot {
 
       protected:
         /// For `process_all_segs_and_all_kinds`
-        struct lower_and_upper_contours {
-            std::vector<line_segment*> lower, upper;
+        struct filled_contours {
+            std::vector<line_segment*> closed, boundary;
         };
-        lower_and_upper_contours
-        insert_lower_and_upper_contours(size_t line_index, double z_lower,
+        filled_contours
+        insert_contours(size_t line_index, double z_lower,
                                         double z_upper);
 
         /// Line style

--- a/source/matplot/axes_objects/contours.h
+++ b/source/matplot/axes_objects/contours.h
@@ -153,6 +153,7 @@ namespace matplot {
         struct line_segment {
             struct {
                 bool is_child : 1;
+                bool is_lower : 1;
             } flags;
             size_t line_index;
             struct b_box_type {
@@ -186,7 +187,9 @@ namespace matplot {
 
         void make_sure_data_is_preprocessed();
         void clear_preprocessed_data();
-        bool is_lower_level(const line_segment& l);
+        static bool is_lower_level(const line_segment& l) noexcept {
+            return l.flags.is_lower;
+        }
         std::pair<vector_1d, vector_1d>
         fill_border_jump(double start_x, double start_y, double end_x,
                          double end_y, double x_min, double x_max, double y_min,

--- a/source/matplot/axes_objects/contours.h
+++ b/source/matplot/axes_objects/contours.h
@@ -171,7 +171,7 @@ namespace matplot {
                 }
             } b_box;
             std::vector<double> x, y;
-            std::vector<const line_segment*> children;
+            std::vector<const line_segment *> children;
 
             void update_b_box() noexcept {
                 assert(!x.empty() && !y.empty());
@@ -188,7 +188,7 @@ namespace matplot {
 
         void make_sure_data_is_preprocessed();
         void clear_preprocessed_data();
-        static bool is_lower_level(const line_segment& l) noexcept {
+        static bool is_lower_level(const line_segment &l) noexcept {
             return l.flags.is_lower;
         }
         std::pair<vector_1d, vector_1d>
@@ -252,7 +252,7 @@ namespace matplot {
         /// to represent everything.
         /// Also, this makes it much easier to label the unfilled lines.
         std::list<line_segment> filled_lines_;
-        std::vector<const line_segment*> filled_line_parents_;
+        std::vector<const line_segment *> filled_line_parents_;
 
         /// Object with the algorithm to generate contour lines
         detail::contour_generator contour_generator_;
@@ -270,10 +270,9 @@ namespace matplot {
       protected:
         /// For `process_all_segs_and_all_kinds`
         struct filled_contours {
-            std::vector<line_segment*> closed, boundary;
+            std::vector<line_segment *> closed, boundary;
         };
-        filled_contours
-        insert_contours(size_t line_index, double z_lower,
+        filled_contours insert_contours(size_t line_index, double z_lower,
                                         double z_upper);
 
         /// Line style

--- a/source/matplot/util/contourc.cpp
+++ b/source/matplot/util/contourc.cpp
@@ -80,11 +80,19 @@ namespace matplot::detail {
         return vertices;
     }
 
-    std::pair<contour_generator::vertices_list_type,
-              contour_generator::codes_list_type>
+    contour_generator::vertices_list_type
     contour_generator::create_filled_contour(double lower_level,
                                              double upper_level) const {
-        return std::pair<vertices_list_type, codes_list_type>();
+        contour_generator::vertices_list_type vertices;
+        generate_contours(lower_level, vertices);
+
+        /* to demarcate upper contour lines and lower contour lines */
+        vertices.first.push_back(NaN);
+        vertices.second.push_back(NaN);
+
+        generate_contours(upper_level, vertices);
+
+        return vertices;
     }
 
     void contour_generator::generate_contours(double z, contour_generator::vertices_list_type &vertices) const {

--- a/source/matplot/util/contourc.cpp
+++ b/source/matplot/util/contourc.cpp
@@ -19,1811 +19,298 @@
 #include <matplot/axes_objects/contours.h>
 #include <matplot/util/contourc.h>
 
-namespace matplot {
+namespace matplot::detail {
+    namespace {
+        constexpr double k_Epsilon = 1e-5;
 
-// 'kind' codes.
-#define MOVETO 1
-#define LINETO 2
-#define CLOSEPOLY 79
+        inline array_2d<double> to_array_2d(const vector_2d &v) {
+            array_2d<double> a(v.size(), !v.empty() ? v[0].size() : 0);
 
-// Point indices from current quad index.
-#define POINT_SW (quad)
-#define POINT_SE (quad + 1)
-#define POINT_NW (quad + _nx)
-#define POINT_NE (quad + _nx + 1)
+            if (!a.empty()) {
+                assert(std::all_of(v.begin(), v.end(), [&a](const auto &v) {
+                    return v.size() == a.cols();
+                }));
 
-// CacheItem masks, only accessed directly to set.  To read, use accessors
-// detailed below.  1 and 2 refer to level indices (lower and upper).
-#define MASK_Z_LEVEL 0x0003 // Combines the following two.
-#define MASK_Z_LEVEL_1 0x0001 // z > lower_level.
-#define MASK_Z_LEVEL_2 0x0002 // z > upper_level.
-#define MASK_VISITED_1 0x0004 // Algorithm has visited this quad.
-#define MASK_VISITED_2 0x0008
-#define MASK_SADDLE_1 0x0010 // quad is a saddle quad.
-#define MASK_SADDLE_2 0x0020
-#define MASK_SADDLE_LEFT_1 0x0040 // Contours turn left at saddle quad.
-#define MASK_SADDLE_LEFT_2 0x0080
-#define MASK_SADDLE_START_SW_1 0x0100 // Next visit starts on S or W edge.
-#define MASK_SADDLE_START_SW_2 0x0200
-#define MASK_BOUNDARY_S 0x0400 // S edge of quad is a boundary.
-#define MASK_BOUNDARY_W 0x0800 // W edge of quad is a boundary.
-// EXISTS_QUAD bit is always used, but the 4 EXISTS_CORNER are only used if
-// _corner_mask is true.  Only one of EXISTS_QUAD or EXISTS_??_CORNER is ever
-// set per quad, hence not using unique bits for each; care is needed when
-// testing for these flags as they overlap.
-#define MASK_EXISTS_QUAD 0x1000 // All of quad exists (is not masked).
-#define MASK_EXISTS_SW_CORNER 0x2000 // SW corner exists, NE corner is masked.
-#define MASK_EXISTS_SE_CORNER 0x3000
-#define MASK_EXISTS_NW_CORNER 0x4000
-#define MASK_EXISTS_NE_CORNER 0x5000
-#define MASK_EXISTS 0x7000 // Combines all 5 EXISTS masks.
-
-// The following are only needed for filled contours.
-#define MASK_VISITED_S 0x10000 // Algorithm has visited S boundary.
-#define MASK_VISITED_W 0x20000 // Algorithm has visited W boundary.
-#define MASK_VISITED_CORNER 0x40000 // Algorithm has visited corner edge.
-
-// Accessors for various CacheItem masks.  li is shorthand for level_index.
-#define Z_LEVEL(quad) (_cache[quad] & MASK_Z_LEVEL)
-#define Z_NE Z_LEVEL(POINT_NE)
-#define Z_NW Z_LEVEL(POINT_NW)
-#define Z_SE Z_LEVEL(POINT_SE)
-#define Z_SW Z_LEVEL(POINT_SW)
-#define VISITED(quad, li)                                                      \
-    ((_cache[quad] & (li == 1 ? MASK_VISITED_1 : MASK_VISITED_2)) != 0)
-#define VISITED_S(quad) ((_cache[quad] & MASK_VISITED_S) != 0)
-#define VISITED_W(quad) ((_cache[quad] & MASK_VISITED_W) != 0)
-#define VISITED_CORNER(quad) ((_cache[quad] & MASK_VISITED_CORNER) != 0)
-#define SADDLE(quad, li)                                                       \
-    ((_cache[quad] & (li == 1 ? MASK_SADDLE_1 : MASK_SADDLE_2)) != 0)
-#define SADDLE_LEFT(quad, li)                                                  \
-    ((_cache[quad] & (li == 1 ? MASK_SADDLE_LEFT_1 : MASK_SADDLE_LEFT_2)) != 0)
-#define SADDLE_START_SW(quad, li)                                              \
-    ((_cache[quad] &                                                           \
-      (li == 1 ? MASK_SADDLE_START_SW_1 : MASK_SADDLE_START_SW_2)) != 0)
-#define BOUNDARY_S(quad) ((_cache[quad] & MASK_BOUNDARY_S) != 0)
-#define BOUNDARY_W(quad) ((_cache[quad] & MASK_BOUNDARY_W) != 0)
-#define BOUNDARY_N(quad) BOUNDARY_S(quad + _nx)
-#define BOUNDARY_E(quad) BOUNDARY_W(quad + 1)
-#define EXISTS_QUAD(quad) ((_cache[quad] & MASK_EXISTS) == MASK_EXISTS_QUAD)
-#define EXISTS_NONE(quad) ((_cache[quad] & MASK_EXISTS) == 0)
-// The following are only used if _corner_mask is true.
-#define EXISTS_SW_CORNER(quad)                                                 \
-    ((_cache[quad] & MASK_EXISTS) == MASK_EXISTS_SW_CORNER)
-#define EXISTS_SE_CORNER(quad)                                                 \
-    ((_cache[quad] & MASK_EXISTS) == MASK_EXISTS_SE_CORNER)
-#define EXISTS_NW_CORNER(quad)                                                 \
-    ((_cache[quad] & MASK_EXISTS) == MASK_EXISTS_NW_CORNER)
-#define EXISTS_NE_CORNER(quad)                                                 \
-    ((_cache[quad] & MASK_EXISTS) == MASK_EXISTS_NE_CORNER)
-#define EXISTS_ANY_CORNER(quad) (!EXISTS_NONE(quad) && !EXISTS_QUAD(quad))
-#define EXISTS_W_EDGE(quad)                                                    \
-    (EXISTS_QUAD(quad) || EXISTS_SW_CORNER(quad) || EXISTS_NW_CORNER(quad))
-#define EXISTS_E_EDGE(quad)                                                    \
-    (EXISTS_QUAD(quad) || EXISTS_SE_CORNER(quad) || EXISTS_NE_CORNER(quad))
-#define EXISTS_S_EDGE(quad)                                                    \
-    (EXISTS_QUAD(quad) || EXISTS_SW_CORNER(quad) || EXISTS_SE_CORNER(quad))
-#define EXISTS_N_EDGE(quad)                                                    \
-    (EXISTS_QUAD(quad) || EXISTS_NW_CORNER(quad) || EXISTS_NE_CORNER(quad))
-    // Note that EXISTS_NE_CORNER(quad) is equivalent to BOUNDARY_SW(quad), etc.
-
-    QuadEdge::QuadEdge() : quad(-1), edge(Edge_None) {}
-
-    QuadEdge::QuadEdge(long quad_, Edge edge_) : quad(quad_), edge(edge_) {}
-
-    bool QuadEdge::operator<(const QuadEdge &other) const {
-        if (quad != other.quad)
-            return quad < other.quad;
-        else
-            return edge < other.edge;
-    }
-
-    bool QuadEdge::operator==(const QuadEdge &other) const {
-        return quad == other.quad && edge == other.edge;
-    }
-
-    bool QuadEdge::operator!=(const QuadEdge &other) const {
-        return !operator==(other);
-    }
-
-    std::ostream &operator<<(std::ostream &os, const QuadEdge &quad_edge) {
-        return os << quad_edge.quad << ' ' << quad_edge.edge;
-    }
-
-    XY::XY() {}
-
-    XY::XY(const double &x_, const double &y_) : x(x_), y(y_) {}
-
-    bool XY::operator==(const XY &other) const {
-        return x == other.x && y == other.y;
-    }
-
-    bool XY::operator!=(const XY &other) const {
-        return x != other.x || y != other.y;
-    }
-
-    XY XY::operator*(const double &multiplier) const {
-        return XY(x * multiplier, y * multiplier);
-    }
-
-    const XY &XY::operator+=(const XY &other) {
-        x += other.x;
-        y += other.y;
-        return *this;
-    }
-
-    const XY &XY::operator-=(const XY &other) {
-        x -= other.x;
-        y -= other.y;
-        return *this;
-    }
-
-    XY XY::operator+(const XY &other) const {
-        return XY(x + other.x, y + other.y);
-    }
-
-    XY XY::operator-(const XY &other) const {
-        return XY(x - other.x, y - other.y);
-    }
-
-    std::ostream &operator<<(std::ostream &os, const XY &xy) {
-        return os << '(' << xy.x << ' ' << xy.y << ')';
-    }
-
-    ContourLine::ContourLine(bool is_hole)
-        : std::vector<XY>(), _is_hole(is_hole), _parent(0) {}
-
-    void ContourLine::add_child(ContourLine *child) {
-        assert(!_is_hole && "Cannot add_child to a hole");
-        assert(child != 0 && "Null child ContourLine");
-        _children.push_back(child);
-    }
-
-    void ContourLine::clear_parent() {
-        assert(is_hole() && "Cannot clear parent of non-hole");
-        assert(_parent != 0 && "Null parent ContourLine");
-        _parent = 0;
-    }
-
-    const ContourLine::Children &ContourLine::get_children() const {
-        assert(!_is_hole && "Cannot get_children of a hole");
-        return _children;
-    }
-
-    const ContourLine *ContourLine::get_parent() const {
-        assert(_is_hole && "Cannot get_parent of a non-hole");
-        return _parent;
-    }
-
-    ContourLine *ContourLine::get_parent() {
-        assert(_is_hole && "Cannot get_parent of a non-hole");
-        return _parent;
-    }
-
-    bool ContourLine::is_hole() const { return _is_hole; }
-
-    void ContourLine::push_back(const XY &point) {
-        if (empty() || point != back())
-            std::vector<XY>::push_back(point);
-    }
-
-    void ContourLine::set_parent(ContourLine *parent) {
-        assert(_is_hole && "Cannot set parent of a non-hole");
-        assert(parent != 0 && "Null parent ContourLine");
-        _parent = parent;
-    }
-
-    void ContourLine::write() const {
-        std::cout << "ContourLine " << this << " of " << size() << " points:";
-        for (const_iterator it = begin(); it != end(); ++it)
-            std::cout << ' ' << *it;
-        if (is_hole())
-            std::cout << " hole, parent=" << get_parent();
-        else {
-            std::cout << " not hole";
-            if (!_children.empty()) {
-                std::cout << ", children=";
-                for (Children::const_iterator it = _children.begin();
-                     it != _children.end(); ++it)
-                    std::cout << *it << ' ';
+                for (size_t rr = 0; rr < a.rows(); ++rr)
+                    std::copy_n(v[rr].begin(), a.cols(), &(a(rr, 0)));
             }
+
+            return a;
         }
-        std::cout << std::endl;
+    } // namespace
+
+    contour_generator::contour_generator(const matplot::vector_2d &x,
+                                         const matplot::vector_2d &y,
+                                         const matplot::vector_2d &z)
+        : x_(detail::to_array_2d(x)), y_(detail::to_array_2d(y)),
+          z_(detail::to_array_2d(z)) {
+        assert(x_.rows() == y_.rows() && x_.rows() == z_.rows());
+        assert(x_.cols() == y_.cols() && x_.cols() == z_.cols());
+        assert(!z_.empty());
+
+        calculate_minmax();
+        generate_edges_and_triangles();
     }
 
-    Contour::Contour() {}
+    size_t contour_generator::activate_edges(double z) const noexcept {
+        size_t num_active = 0;
 
-    Contour::~Contour() { delete_contour_lines(); }
-
-    void Contour::delete_contour_lines() {
-        for (iterator line_it = begin(); line_it != end(); ++line_it) {
-            delete *line_it;
-            *line_it = 0;
+        for (edge &e : edges_) {
+            if (activate_edge(z, e))
+                ++num_active;
         }
-        std::vector<ContourLine *>::clear();
+
+        return num_active;
     }
 
-    void Contour::write() const {
-        std::cout << "Contour of " << size() << " lines." << std::endl;
-        for (const_iterator it = begin(); it != end(); ++it)
-            (*it)->write();
+    void contour_generator::calculate_minmax() noexcept {
+        auto [x_min, x_max] = std::minmax_element(x_.begin(), x_.end());
+        x_min_ = *x_min;
+        x_max_ = *x_max;
+
+        auto [y_min, y_max] = std::minmax_element(y_.begin(), y_.end());
+        y_min_ = *y_min;
+        y_max_ = *y_max;
     }
 
-    ParentCache::ParentCache(long nx, long x_chunk_points, long y_chunk_points)
-        : _nx(nx), _x_chunk_points(x_chunk_points),
-          _y_chunk_points(y_chunk_points),
-          _lines(0), // Initialised when first needed.
-          _istart(0), _jstart(0) {
-        assert(_x_chunk_points > 0 && _y_chunk_points > 0 &&
-               "Chunk sizes must be positive");
-    }
+    std::pair<vector_1d, vector_1d>
+    contour_generator::create_contour(double level) const {
+        std::pair<vector_1d, vector_1d> vertices;
 
-    ContourLine *ParentCache::get_parent(long quad) {
-        long index = quad_to_index(quad);
-        ContourLine *parent = _lines[index];
-        while (parent == 0) {
-            index -= _x_chunk_points;
-            assert(index >= 0 && "Failed to find parent in chunk ParentCache");
-            parent = _lines[index];
-        }
-        assert(parent != 0 && "Failed to find parent in chunk ParentCache");
-        return parent;
-    }
+        auto fn_push_contour = [&vertices](const contour &c) {
+            vertices.first.reserve(vertices.first.size() + c.points.size());
+            vertices.second.reserve(vertices.second.size() + c.points.size());
 
-    long ParentCache::quad_to_index(long quad) const {
-        long i = quad % _nx;
-        long j = quad / _nx;
-        long index = (i - _istart) + (j - _jstart) * _x_chunk_points;
-
-        assert(i >= _istart && i < _istart + _x_chunk_points &&
-               "i-index outside chunk");
-        assert(j >= _jstart && j < _jstart + _y_chunk_points &&
-               "j-index outside chunk");
-        assert(index >= 0 && index < static_cast<long>(_lines.size()) &&
-               "ParentCache index outside chunk");
-
-        return index;
-    }
-
-    void ParentCache::set_chunk_starts(long istart, long jstart) {
-        assert(istart >= 0 && jstart >= 0 &&
-               "Chunk start indices cannot be negative");
-        _istart = istart;
-        _jstart = jstart;
-        if (_lines.empty())
-            _lines.resize(_x_chunk_points * _y_chunk_points, 0);
-        else
-            std::fill(_lines.begin(), _lines.end(), (ContourLine *)0);
-    }
-
-    void ParentCache::set_parent(long quad, ContourLine &contour_line) {
-        assert(!_lines.empty() &&
-               "Accessing ParentCache before it has been initialised");
-        long index = quad_to_index(quad);
-        if (_lines[index] == 0)
-            _lines[index] = (contour_line.is_hole() ? contour_line.get_parent()
-                                                    : &contour_line);
-    }
-
-    QuadContourGenerator::QuadContourGenerator(const CoordinateArray &x,
-                                               const CoordinateArray &y,
-                                               const CoordinateArray &z,
-                                               bool corner_mask,
-                                               long chunk_size)
-        : _x(x), _y(y), _z(z), _nx(static_cast<long>(_x[0].size())),
-          _ny(static_cast<long>(_x.size())), _n(_nx * _ny),
-          _corner_mask(corner_mask),
-          _chunk_size(chunk_size > 0
-                          ? std::min(chunk_size, std::max(_nx, _ny) - 1)
-                          : std::max(_nx, _ny) - 1),
-          _nxchunk(calc_chunk_count(_nx)), _nychunk(calc_chunk_count(_ny)),
-          _chunk_count(_nxchunk * _nychunk), _cache(std::vector<CacheItem>(_n)),
-          _parent_cache(_nx, chunk_size > 0 ? chunk_size + 1 : _nx,
-                        chunk_size > 0 ? chunk_size + 1 : _ny) {
-        assert(!_x.empty() && !_y.empty() && !_z.empty() && "Empty array");
-        assert(_y.size() == _x.size() && _y[0].size() == _x[0].size() &&
-               "Different-sized y and x arrays");
-        assert(_z.size() == _x.size() && _z[0].size() == _x[0].size() &&
-               "Different-sized z and x arrays");
-
-        init_cache_grid();
-    }
-
-    void QuadContourGenerator::append_contour_line_to_vertices(
-        ContourLine &contour_line, vertices_list_type &vertices_list) const {
-        double x_diff = std::abs(_x[0][1] - _x[0][0]);
-        double y_diff = std::abs(_y[1][0] - _y[0][0]);
-        // Convert ContourLine to vertices_list
-        size_t i = 0;
-        size_t inserted = 0;
-        for (ContourLine::const_iterator point = contour_line.begin();
-             point != contour_line.end(); ++point, ++i) {
-            bool is_origin = point->x == 0. && point->y == 0.;
-            bool is_x_jump_to_origin =
-                is_origin && inserted != 0 &&
-                std::abs(vertices_list.first.back()) > 3 * x_diff;
-            bool is_y_jump_to_origin =
-                is_origin && inserted != 0 &&
-                std::abs(vertices_list.second.back()) > 3 * y_diff;
-            bool is_end_of_segment = is_x_jump_to_origin && is_y_jump_to_origin;
-            if (!is_end_of_segment) {
-                vertices_list.first.emplace_back(point->x);
-                vertices_list.second.emplace_back(point->y);
-                ++inserted;
-            } else {
-                bool last_segment_is_not_empty =
-                    inserted > 0 && std::isfinite(vertices_list.first.back()) &&
-                    std::isfinite(vertices_list.first.back());
-                if (last_segment_is_not_empty) {
-                    vertices_list.first.emplace_back(NaN);
-                    vertices_list.second.emplace_back(NaN);
-                }
+            for (auto point : c.points) {
+                vertices.first.push_back(point.x);
+                vertices.second.push_back(point.y);
             }
+        };
+
+        generation_parameters p{};
+        p.flags.closed_contour = false;
+        p.index = 0;
+        p.num_active = activate_edges(level);
+
+        while (p.num_active) {
+            contour ctr = generate_contour(level, p);
+            if (!ctr.points.empty())
+                fn_push_contour(ctr);
         }
-        bool last_segment_is_not_empty =
-            inserted > 0 && std::isfinite(vertices_list.first.back()) &&
-            std::isfinite(vertices_list.first.back());
-        if (last_segment_is_not_empty) {
-            vertices_list.first.emplace_back(NaN);
-            vertices_list.second.emplace_back(NaN);
-        }
-        contour_line.clear();
+
+        return vertices;
     }
 
-    void QuadContourGenerator::append_contour_to_vertices_and_codes(
-        Contour &contour, vertices_list_type &vertices_list,
-        codes_list_type &codes_list) const {
-        // Convert Contour to vertices and clear it.
-        // For each line in the contour
-        for (Contour::iterator line_it = contour.begin();
-             line_it != contour.end(); ++line_it) {
-            ContourLine &line = **line_it;
-            if (line.is_hole()) {
-                // If hole has already been converted to python its parent will
-                // be set to 0 and it can be deleted.
-                if (line.get_parent() != 0) {
-                    delete *line_it;
-                    *line_it = 0;
-                }
-            } else {
-                // Non-holes are converted to python together with their child
-                // holes so that they are rendered correctly.
-                ContourLine::const_iterator point;
-                ContourLine::Children::const_iterator children_it;
+    std::pair<contour_generator::vertices_list_type,
+              contour_generator::codes_list_type>
+    contour_generator::create_filled_contour(double lower_level,
+                                             double upper_level) const {
+        return std::pair<vertices_list_type, codes_list_type>();
+    }
 
-                const ContourLine::Children &children = line.get_children();
-                // number of points in the line itself
-                size_t npoints = static_cast<size_t>(line.size() + 1);
-                // accumulate the number of points for each line child
-                for (children_it = children.begin();
-                     children_it != children.end(); ++children_it) {
-                    npoints += static_cast<size_t>((*children_it)->size() + 1);
-                }
+    contour_generator::contour
+    contour_generator::generate_contour(double z,
+                                        generation_parameters &p) const {
+        if (!p.flags.closed_contour) {
+            for (; p.index < edges_.size(); ++p.index) {
+                edge &e = edges_[p.index];
+                if (e.flags.on_boundary && e.flags.active)
+                    return trace_contour(z, p.num_active, e);
+            }
 
-                auto is_valid_point = [](double x, double y) {
-                    return std::isfinite(x) && std::isfinite(y) && x != 0. &&
-                           y != 0.;
-                };
+            p.flags.closed_contour = true;
+            p.index = 0;
+        }
 
-                // for each point in this line
-                bool first = true;
-                for (point = line.begin(); point != line.end(); ++point) {
-                    if (is_valid_point(point->x, point->y)) {
-                        vertices_list.first.emplace_back(point->x);
-                        vertices_list.second.emplace_back(point->y);
-                        codes_list.emplace_back((first ? MOVETO : LINETO));
-                        first = false;
-                    }
-                }
-
-                // Close polygon
-                // Emplace NaN instead of the first point again
-                // Because that's how gnuplot works.
-                // point = line.begin();
-                // vertices_list.first.emplace_back(point->x);
-                // vertices_list.second.emplace_back(point->y);
-                if (!first) {
-                    vertices_list.first.emplace_back(NaN);
-                    vertices_list.second.emplace_back(NaN);
-                    codes_list.emplace_back(CLOSEPOLY);
-                } else {
-                    // We inserted no points
-                    // ignore children (empty parents cannot have children)
-                    for (children_it = children.begin();
-                         children_it != children.end(); ++children_it) {
-                        ContourLine &child = **children_it;
-                        child.clear_parent();
-                    }
-                    // free parent
-                    delete *line_it;
-                    *line_it = 0;
-                    // and go to next line
-                    continue;
-                }
-
-                // Add the points from the children segments / holes
-                for (children_it = children.begin();
-                     children_it != children.end(); ++children_it) {
-                    ContourLine &child = **children_it;
-                    bool never_emplaced_anything = true;
-                    for (point = child.begin(); point != child.end(); ++point) {
-                        if (is_valid_point(point->x, point->y)) {
-                            vertices_list.first.emplace_back(point->x);
-                            vertices_list.second.emplace_back(point->y);
-                            codes_list.emplace_back(
-                                (never_emplaced_anything ? MOVETO : LINETO));
-                            never_emplaced_anything = false;
-                        }
-                    }
-
-                    // Close the polygon
-                    // Emplace NaN instead of the first point again
-                    // That's how gnuplot works
-                    // point = child.begin();
-                    // vertices_list.first.emplace_back(point->x);
-                    // vertices_list.second.emplace_back(point->y);
-                    if (!never_emplaced_anything) {
-                        vertices_list.first.emplace_back(NaN);
-                        vertices_list.second.emplace_back(NaN);
-                        codes_list.emplace_back(CLOSEPOLY);
-                    }
-
-                    // To indicate the parent can be deleted.
-                    child.clear_parent();
-                }
-
-                // Include extra NaNs after all children
-                // This indicates the children are over
-                // and that the next polygon is another parent
-                vertices_list.first.emplace_back(NaN);
-                vertices_list.second.emplace_back(NaN);
-                codes_list.emplace_back(CLOSEPOLY);
-
-                delete *line_it;
-                *line_it = 0;
+        if (p.flags.closed_contour) {
+            for (; p.index < edges_.size(); ++p.index) {
+                edge &e = edges_[p.index];
+                if (!e.flags.on_boundary && e.flags.active)
+                    return trace_contour(z, p.num_active, e);
             }
         }
 
-        // Delete remaining contour lines.
-        contour.delete_contour_lines();
+        return contour();
     }
 
-    long QuadContourGenerator::calc_chunk_count(long point_count) const {
-        assert(point_count > 0 && "point count must be positive");
-        assert(_chunk_size > 0 && "Chunk size must be positive");
+    void contour_generator::generate_edges_and_triangles() {
+        /*
+         * This function generates a mesh from the provided grid of values.
+         *
+         * Upper and lower triangles:
+         *          lower           upper
+         *                            1
+         *          |\              ----
+         *        0 | \ 1         0 \  | 2
+         *          |__\             \ |
+         *            2
+         *      numbers indicate the order in which edges
+         *      are stored in triangle
+         *
+         * Mesh:
+         *                1
+         *           -----------
+         *          | \   0     |
+         *          |   \       |
+         *         0|1   0\1   0|1
+         *          |       \   |
+         *          |    1    \ |
+         *           -----------
+         *                0
+         *      numbers indicate the order in which triangles
+         *      are stored in edge
+         */
 
-        if (_chunk_size > 0) {
-            long count = (point_count - 1) / _chunk_size;
-            if (count * _chunk_size < point_count - 1)
-                ++count;
+        auto fn_push_lower_triangle = [this](edge *e0, edge *e1,
+                                             edge *e2) -> triangle * {
+            triangle t{};
+            t.e[0] = e0;
+            t.e[1] = e1;
+            t.e[2] = e2;
 
-            assert(count >= 1 && "Invalid chunk count");
-            return count;
-        } else
-            return 1;
-    }
+            triangle *p_t = &triangles_.emplace_back(t);
+            e0->t[1] = p_t;
+            e1->t[0] = p_t;
+            e2->t[1] = p_t;
 
-    QuadContourGenerator::vertices_list_type
-    QuadContourGenerator::create_contour(const double &level) {
-        init_cache_levels(level, level);
+            return p_t;
+        };
+        auto fn_push_upper_triangle = [this](edge *e0, edge *e1,
+                                             edge *e2) -> triangle * {
+            triangle t{};
+            t.e[0] = e0;
+            t.e[1] = e1;
+            t.e[2] = e2;
 
-        vertices_list_type vertices_list;
+            triangle *p_t = &triangles_.emplace_back(t);
+            e0->t[1] = p_t;
+            e1->t[0] = p_t;
+            e2->t[0] = p_t;
 
-        // Lines that start and end on boundaries.
-        long ichunk, jchunk, istart, iend, jstart, jend;
-        for (long ijchunk = 0; ijchunk < _chunk_count; ++ijchunk) {
-            get_chunk_limits(ijchunk, ichunk, jchunk, istart, iend, jstart,
-                             jend);
+            return p_t;
+        };
+        auto fn_push_diagonal_edge = [this](size_t r, size_t c) -> edge * {
+            return &edges_.emplace_back(generate_diagonal_edge(r, c));
+        };
+        auto fn_push_horizontal_edge = [this](size_t r, size_t c) -> edge * {
+            return &edges_.emplace_back(generate_horizontal_edge(r, c));
+        };
+        auto fn_push_vertical_edge = [this](size_t r, size_t c) -> edge * {
+            return &edges_.emplace_back(generate_vertical_edge(r, c));
+        };
 
-            for (long j = jstart; j < jend; ++j) {
-                long quad_end = iend + j * _nx;
-                for (long quad = istart + j * _nx; quad < quad_end; ++quad) {
-                    if (EXISTS_NONE(quad) || VISITED(quad, 1))
-                        continue;
+        /* 2 triangles per vertex (except for vertices at bottom and
+         * right boundaries, which don't generate any triangles)*/
+        triangles_.reserve(2 * (z_.cols() - 1) * (z_.rows() - 1));
 
-                    if (BOUNDARY_S(quad) && Z_SW >= 1 && Z_SE < 1 &&
-                        start_line(vertices_list, quad, Edge_S, level))
-                        continue;
+        /* at most 3 edges per vertex */
+        edges_.reserve(3 * z_.size());
 
-                    if (BOUNDARY_W(quad) && Z_NW >= 1 && Z_SW < 1 &&
-                        start_line(vertices_list, quad, Edge_W, level))
-                        continue;
+        /* generate first horizontal edge */
+        edge *e_u = fn_push_horizontal_edge(0, 0);
 
-                    if (BOUNDARY_N(quad) && Z_NE >= 1 && Z_NW < 1 &&
-                        start_line(vertices_list, quad, Edge_N, level))
-                        continue;
+        /* generate first row of horizontal edges */
+        for (size_t cc = 1; cc < z_.cols() - 1; ++cc)
+            fn_push_horizontal_edge(0, cc);
 
-                    if (BOUNDARY_E(quad) && Z_SE >= 1 && Z_NE < 1 &&
-                        start_line(vertices_list, quad, Edge_E, level))
-                        continue;
+        for (size_t rr = 1; rr < z_.rows(); ++rr) {
+            /* generate first vertical edge */
+            edge *e_v = fn_push_vertical_edge(rr - 1, 0);
 
-                    if (_corner_mask) {
-                        // Equates to NE boundary.
-                        if (EXISTS_SW_CORNER(quad) && Z_SE >= 1 && Z_NW < 1 &&
-                            start_line(vertices_list, quad, Edge_NE, level))
-                            continue;
-
-                        // Equates to NW boundary.
-                        if (EXISTS_SE_CORNER(quad) && Z_NE >= 1 && Z_SW < 1 &&
-                            start_line(vertices_list, quad, Edge_NW, level))
-                            continue;
-
-                        // Equates to SE boundary.
-                        if (EXISTS_NW_CORNER(quad) && Z_SW >= 1 && Z_NE < 1 &&
-                            start_line(vertices_list, quad, Edge_SE, level))
-                            continue;
-
-                        // Equates to SW boundary.
-                        if (EXISTS_NE_CORNER(quad) && Z_NW >= 1 && Z_SE < 1 &&
-                            start_line(vertices_list, quad, Edge_SW, level))
-                            continue;
-                    }
-                }
-            }
-        }
-
-        // Internal loops.
-        ContourLine contour_line(false); // Reused for each contour line.
-        for (long ijchunk = 0; ijchunk < _chunk_count; ++ijchunk) {
-            get_chunk_limits(ijchunk, ichunk, jchunk, istart, iend, jstart,
-                             jend);
-
-            for (long j = jstart; j < jend; ++j) {
-                long quad_end = iend + j * _nx;
-                for (long quad = istart + j * _nx; quad < quad_end; ++quad) {
-                    if (EXISTS_NONE(quad) || VISITED(quad, 1))
-                        continue;
-
-                    Edge start_edge = get_start_edge(quad, 1);
-                    if (start_edge == Edge_None)
-                        continue;
-
-                    QuadEdge quad_edge(quad, start_edge);
-                    QuadEdge start_quad_edge(quad_edge);
-
-                    // To obtain output identical to that produced by legacy
-                    // code, sometimes need to ignore the first point and add it
-                    // on the end instead.
-                    bool ignore_first = (start_edge == Edge_N);
-                    follow_interior(contour_line, quad_edge, 1, level,
-                                    !ignore_first, &start_quad_edge, 1, false);
-                    if (ignore_first && !contour_line.empty())
-                        contour_line.push_back(contour_line.front());
-                    append_contour_line_to_vertices(contour_line,
-                                                    vertices_list);
-
-                    // Repeat if saddle point but not visited.
-                    if (SADDLE(quad, 1) && !VISITED(quad, 1))
-                        --quad;
-                }
-            }
-        }
-
-        return vertices_list;
-    }
-
-    std::pair<QuadContourGenerator::vertices_list_type,
-              QuadContourGenerator::codes_list_type>
-    QuadContourGenerator::create_filled_contour(const double &lower_level,
-                                                const double &upper_level) {
-        init_cache_levels(lower_level, upper_level);
-
-        Contour contour;
-
-        vertices_list_type vertices;
-        codes_list_type codes;
-
-        // for each chunk
-        long ichunk, jchunk, istart, iend, jstart, jend;
-        for (long ijchunk = 0; ijchunk < _chunk_count; ++ijchunk) {
-            get_chunk_limits(ijchunk, ichunk, jchunk, istart, iend, jstart,
-                             jend);
-            _parent_cache.set_chunk_starts(istart, jstart);
-
-            // iterate quads
-            for (long j = jstart; j < jend; ++j) {
-                long quad_end = iend + j * _nx;
-                for (long quad = istart + j * _nx; quad < quad_end; ++quad) {
-                    if (!EXISTS_NONE(quad))
-                        single_quad_filled(contour, quad, lower_level,
-                                           upper_level);
-                }
+            /* generate row of vertical and diagonal edges */
+            for (size_t cc = 0; cc < z_.cols() - 1; ++cc) {
+                fn_push_diagonal_edge(rr - 1, cc);
+                fn_push_vertical_edge(rr - 1, cc + 1);
             }
 
-            // Clear VISITED_W and VISITED_S flags that are reused by later
-            // chunks.
-            if (jchunk < _nychunk - 1) {
-                long quad_end = iend + jend * _nx;
-                for (long quad = istart + jend * _nx; quad < quad_end; ++quad)
-                    _cache[quad] &= ~MASK_VISITED_S;
+            /* generate first horizontal edge of lower row */
+            edge *e_l = fn_push_horizontal_edge(rr, 0);
+
+            /* generate lower row of horizontal edges */
+            for (size_t cc = 1; cc < z_.cols() - 1; ++cc)
+                fn_push_horizontal_edge(rr, cc);
+
+            /* generate row of triangles */
+            for (size_t cc = 0; cc < z_.cols() - 1; ++cc) {
+                fn_push_lower_triangle(e_v + 2 * cc, e_v + 2 * cc + 1,
+                                       e_l + cc);
+                fn_push_upper_triangle(e_v + 2 * cc + 1, e_u + cc,
+                                       e_v + 2 * (cc + 1));
             }
 
-            if (ichunk < _nxchunk - 1) {
-                long quad_end = iend + jend * _nx;
-                for (long quad = iend + jstart * _nx; quad < quad_end;
-                     quad += _nx)
-                    _cache[quad] &= ~MASK_VISITED_W;
-            }
-
-            // Create python objects to return for this chunk.
-            append_contour_to_vertices_and_codes(contour, vertices, codes);
-        }
-
-        return std::make_pair(vertices, codes);
-    }
-
-    XY QuadContourGenerator::edge_interp(const QuadEdge &quad_edge,
-                                         const double &level) {
-        assert(quad_edge.quad >= 0 && quad_edge.quad < _n &&
-               "Quad index out of bounds");
-        assert(quad_edge.edge != Edge_None && "Invalid edge");
-        return interp(get_edge_point_index(quad_edge, true),
-                      get_edge_point_index(quad_edge, false), level);
-    }
-
-    unsigned int QuadContourGenerator::follow_boundary(
-        ContourLine &contour_line, QuadEdge &quad_edge,
-        const double &lower_level, const double &upper_level,
-        unsigned int level_index, const QuadEdge &start_quad_edge) {
-        assert(quad_edge.quad >= 0 && quad_edge.quad < _n &&
-               "Quad index out of bounds");
-        assert(quad_edge.edge != Edge_None && "Invalid edge");
-        assert(is_edge_a_boundary(quad_edge) && "Not a boundary edge");
-        assert((level_index == 1 || level_index == 2) &&
-               "level index must be 1 or 2");
-        assert(start_quad_edge.quad >= 0 && start_quad_edge.quad < _n &&
-               "Start quad index out of bounds");
-        assert(start_quad_edge.edge != Edge_None && "Invalid start edge");
-
-        // Only called for filled contours, so always updates _parent_cache.
-        unsigned int end_level = 0;
-        bool first_edge = true;
-        bool stop = false;
-        long &quad = quad_edge.quad;
-
-        while (true) {
-            // Levels of start and end points of quad_edge.
-            unsigned int start_level =
-                (first_edge ? Z_LEVEL(get_edge_point_index(quad_edge, true))
-                            : end_level);
-            long end_point = get_edge_point_index(quad_edge, false);
-            end_level = Z_LEVEL(end_point);
-
-            if (level_index == 1) {
-                if (start_level <= level_index && end_level == 2) {
-                    // Increasing z, switching levels from 1 to 2.
-                    level_index = 2;
-                    stop = true;
-                } else if (start_level >= 1 && end_level == 0) {
-                    // Decreasing z, keeping same level.
-                    stop = true;
-                }
-            } else { // level_index == 2
-                if (start_level <= level_index && end_level == 2) {
-                    // Increasing z, keeping same level.
-                    stop = true;
-                } else if (start_level >= 1 && end_level == 0) {
-                    // Decreasing z, switching levels from 2 to 1.
-                    level_index = 1;
-                    stop = true;
-                }
-            }
-
-            if (!first_edge && !stop && quad_edge == start_quad_edge)
-                // Return if reached start point of contour line.  Do this
-                // before checking/setting VISITED flags as will already have
-                // been visited.
-                break;
-
-            switch (quad_edge.edge) {
-            case Edge_E:
-                assert(!VISITED_W(quad + 1) && "Already visited");
-                _cache[quad + 1] |= MASK_VISITED_W;
-                break;
-            case Edge_N:
-                assert(!VISITED_S(quad + _nx) && "Already visited");
-                _cache[quad + _nx] |= MASK_VISITED_S;
-                break;
-            case Edge_W:
-                assert(!VISITED_W(quad) && "Already visited");
-                _cache[quad] |= MASK_VISITED_W;
-                break;
-            case Edge_S:
-                assert(!VISITED_S(quad) && "Already visited");
-                _cache[quad] |= MASK_VISITED_S;
-                break;
-            case Edge_NE:
-            case Edge_NW:
-            case Edge_SW:
-            case Edge_SE:
-                assert(!VISITED_CORNER(quad) && "Already visited");
-                _cache[quad] |= MASK_VISITED_CORNER;
-                break;
-            default:
-                assert(0 && "Invalid Edge");
-                break;
-            }
-
-            if (stop) {
-                // Exiting boundary to enter interior.
-                contour_line.push_back(edge_interp(
-                    quad_edge, level_index == 1 ? lower_level : upper_level));
-                break;
-            }
-
-            move_to_next_boundary_edge(quad_edge);
-
-            // Just moved to new quad edge, so label parent of start of quad
-            // edge.
-            switch (quad_edge.edge) {
-            case Edge_W:
-            case Edge_SW:
-            case Edge_S:
-            case Edge_SE:
-                if (!EXISTS_SE_CORNER(quad))
-                    _parent_cache.set_parent(quad, contour_line);
-                break;
-            case Edge_E:
-            case Edge_NE:
-            case Edge_N:
-            case Edge_NW:
-                if (!EXISTS_SW_CORNER(quad))
-                    _parent_cache.set_parent(quad + 1, contour_line);
-                break;
-            default:
-                assert(0 && "Invalid edge");
-                break;
-            }
-
-            // Add point to contour.
-            contour_line.push_back(get_point_xy(end_point));
-
-            if (first_edge)
-                first_edge = false;
-        }
-
-        return level_index;
-    }
-
-    void QuadContourGenerator::follow_interior(
-        ContourLine &contour_line, QuadEdge &quad_edge,
-        unsigned int level_index, const double &level, bool want_initial_point,
-        const QuadEdge *start_quad_edge, unsigned int start_level_index,
-        bool set_parents) {
-        assert(quad_edge.quad >= 0 && quad_edge.quad < _n &&
-               "Quad index out of bounds.");
-        assert(quad_edge.edge != Edge_None && "Invalid edge");
-        assert((level_index == 1 || level_index == 2) &&
-               "level index must be 1 or 2");
-        assert((start_quad_edge == 0 ||
-                (start_quad_edge->quad >= 0 && start_quad_edge->quad < _n)) &&
-               "Start quad index out of bounds.");
-        assert((start_quad_edge == 0 || start_quad_edge->edge != Edge_None) &&
-               "Invalid start edge");
-        assert((start_level_index == 1 || start_level_index == 2) &&
-               "start level index must be 1 or 2");
-
-        long &quad = quad_edge.quad;
-        Edge &edge = quad_edge.edge;
-
-        if (want_initial_point)
-            contour_line.push_back(edge_interp(quad_edge, level));
-
-        CacheItem visited_mask =
-            (level_index == 1 ? MASK_VISITED_1 : MASK_VISITED_2);
-        CacheItem saddle_mask =
-            (level_index == 1 ? MASK_SADDLE_1 : MASK_SADDLE_2);
-        Dir dir = Dir_Straight;
-
-        while (true) {
-            assert(!EXISTS_NONE(quad) && "Quad does not exist");
-            assert(!(_cache[quad] & visited_mask) && "Quad already visited");
-
-            // Determine direction to move to next quad.  If the quad is already
-            // labelled as a saddle quad then the direction is easily read from
-            // the cache.  Otherwise the direction is determined differently
-            // depending on whether the quad is a corner quad or not.
-
-            if (_cache[quad] & saddle_mask) {
-                // Already identified as a saddle quad, so direction is easy.
-                dir = (SADDLE_LEFT(quad, level_index) ? Dir_Left : Dir_Right);
-                _cache[quad] |= visited_mask;
-            } else if (EXISTS_ANY_CORNER(quad)) {
-                // Need z-level of point opposite the entry edge, as that
-                // determines whether contour turns left or right.
-                long point_opposite = -1;
-                switch (edge) {
-                case Edge_E:
-                    point_opposite =
-                        (EXISTS_SE_CORNER(quad) ? POINT_SW : POINT_NW);
-                    break;
-                case Edge_N:
-                    point_opposite =
-                        (EXISTS_NW_CORNER(quad) ? POINT_SW : POINT_SE);
-                    break;
-                case Edge_W:
-                    point_opposite =
-                        (EXISTS_SW_CORNER(quad) ? POINT_SE : POINT_NE);
-                    break;
-                case Edge_S:
-                    point_opposite =
-                        (EXISTS_SW_CORNER(quad) ? POINT_NW : POINT_NE);
-                    break;
-                case Edge_NE:
-                    point_opposite = POINT_SW;
-                    break;
-                case Edge_NW:
-                    point_opposite = POINT_SE;
-                    break;
-                case Edge_SW:
-                    point_opposite = POINT_NE;
-                    break;
-                case Edge_SE:
-                    point_opposite = POINT_NW;
-                    break;
-                default:
-                    assert(0 && "Invalid edge");
-                    break;
-                }
-                assert(point_opposite != -1 && "Failed to find opposite point");
-
-                // Lower-level polygons (level_index == 1) always have higher
-                // values to the left of the contour.  Upper-level contours
-                // (level_index == 2) are reversed, which is what the fancy XOR
-                // does below.
-                if ((Z_LEVEL(point_opposite) >= level_index) ^
-                    (level_index == 2))
-                    dir = Dir_Right;
-                else
-                    dir = Dir_Left;
-                _cache[quad] |= visited_mask;
-            } else {
-                // Calculate configuration of this quad.
-                long point_left = -1, point_right = -1;
-                switch (edge) {
-                case Edge_E:
-                    point_left = POINT_SW;
-                    point_right = POINT_NW;
-                    break;
-                case Edge_N:
-                    point_left = POINT_SE;
-                    point_right = POINT_SW;
-                    break;
-                case Edge_W:
-                    point_left = POINT_NE;
-                    point_right = POINT_SE;
-                    break;
-                case Edge_S:
-                    point_left = POINT_NW;
-                    point_right = POINT_NE;
-                    break;
-                default:
-                    assert(0 && "Invalid edge");
-                    break;
-                }
-
-                unsigned int config = (Z_LEVEL(point_left) >= level_index)
-                                          << 1 |
-                                      (Z_LEVEL(point_right) >= level_index);
-
-                // Upper level (level_index == 2) polygons are reversed compared
-                // to lower level ones, i.e. higher values on the right rather
-                // than the left.
-                if (level_index == 2)
-                    config = 3 - config;
-
-                // Calculate turn direction to move to next quad along contour
-                // line.
-                if (config == 1) {
-                    // New saddle quad, set up cache bits for it.
-                    double zmid =
-                        0.25 * (get_point_z(POINT_SW) + get_point_z(POINT_SE) +
-                                get_point_z(POINT_NW) + get_point_z(POINT_NE));
-                    _cache[quad] |=
-                        (level_index == 1 ? MASK_SADDLE_1 : MASK_SADDLE_2);
-                    if ((zmid > level) ^ (level_index == 2)) {
-                        dir = Dir_Right;
-                    } else {
-                        dir = Dir_Left;
-                        _cache[quad] |= (level_index == 1 ? MASK_SADDLE_LEFT_1
-                                                          : MASK_SADDLE_LEFT_2);
-                    }
-                    if (edge == Edge_N || edge == Edge_E) {
-                        // Next visit to this quad must start on S or W.
-                        _cache[quad] |=
-                            (level_index == 1 ? MASK_SADDLE_START_SW_1
-                                              : MASK_SADDLE_START_SW_2);
-                    }
-                } else {
-                    // Normal (non-saddle) quad.
-                    dir = (config == 0
-                               ? Dir_Left
-                               : (config == 3 ? Dir_Right : Dir_Straight));
-                    _cache[quad] |= visited_mask;
-                }
-            }
-
-            // Use dir to determine exit edge.
-            edge = get_exit_edge(quad_edge, dir);
-
-            if (set_parents) {
-                if (edge == Edge_E)
-                    _parent_cache.set_parent(quad + 1, contour_line);
-                else if (edge == Edge_W)
-                    _parent_cache.set_parent(quad, contour_line);
-            }
-
-            // Add new point to contour line.
-            contour_line.push_back(edge_interp(quad_edge, level));
-
-            // Stop if reached boundary.
-            if (is_edge_a_boundary(quad_edge))
-                break;
-
-            move_to_next_quad(quad_edge);
-            assert(quad_edge.quad >= 0 && quad_edge.quad < _n &&
-                   "Quad index out of bounds");
-
-            // Return if reached start point of contour line.
-            if (start_quad_edge != 0 && quad_edge == *start_quad_edge &&
-                level_index == start_level_index)
-                break;
+            /* lower row of h edges becomes upper row of h edges
+             * for next mesh row */
+            e_u = e_l;
         }
     }
 
-    void QuadContourGenerator::get_chunk_limits(long ijchunk, long &ichunk,
-                                                long &jchunk, long &istart,
-                                                long &iend, long &jstart,
-                                                long &jend) {
-        assert(ijchunk >= 0 && ijchunk < _chunk_count &&
-               "ijchunk out of bounds");
-        ichunk = ijchunk % _nxchunk;
-        jchunk = ijchunk / _nxchunk;
-        istart = ichunk * _chunk_size;
-        iend = (ichunk == _nxchunk - 1 ? _nx : (ichunk + 1) * _chunk_size);
-        jstart = jchunk * _chunk_size;
-        jend = (jchunk == _nychunk - 1 ? _ny : (jchunk + 1) * _chunk_size);
-    }
+    contour_generator::contour
+    contour_generator::trace_contour(double z, size_t &num_active,
+                                     edge &e) const {
+        contour ctr;
+        ctr.closed = !e.flags.on_boundary;
 
-    Edge QuadContourGenerator::get_corner_start_edge(
-        long quad, unsigned int level_index) const {
-        assert(quad >= 0 && quad < _n && "Quad index out of bounds");
-        assert((level_index == 1 || level_index == 2) &&
-               "level index must be 1 or 2");
-        assert(EXISTS_ANY_CORNER(quad) && "Quad is not a corner");
+        auto fn_deactivate_edge = [&num_active](edge &e) {
+            assert(e.flags.active);
+            e.flags.active = false;
+            --num_active;
+        };
 
-        // Diagram for NE corner.  Rotate for other corners.
-        //
-        //           edge12
-        // point1 +---------+ point2
-        //          \       |
-        //            \     | edge23
-        //       edge31 \   |
-        //                \ |
-        //                  + point3
-        //
-        long point1, point2, point3;
-        Edge edge12, edge23, edge31;
-        switch (_cache[quad] & MASK_EXISTS) {
-        case MASK_EXISTS_SW_CORNER:
-            point1 = POINT_SE;
-            point2 = POINT_SW;
-            point3 = POINT_NW;
-            edge12 = Edge_S;
-            edge23 = Edge_W;
-            edge31 = Edge_NE;
-            break;
-        case MASK_EXISTS_SE_CORNER:
-            point1 = POINT_NE;
-            point2 = POINT_SE;
-            point3 = POINT_SW;
-            edge12 = Edge_E;
-            edge23 = Edge_S;
-            edge31 = Edge_NW;
-            break;
-        case MASK_EXISTS_NW_CORNER:
-            point1 = POINT_SW;
-            point2 = POINT_NW;
-            point3 = POINT_NE;
-            edge12 = Edge_W;
-            edge23 = Edge_N;
-            edge31 = Edge_SE;
-            break;
-        case MASK_EXISTS_NE_CORNER:
-            point1 = POINT_NW;
-            point2 = POINT_NE;
-            point3 = POINT_SE;
-            edge12 = Edge_N;
-            edge23 = Edge_E;
-            edge31 = Edge_SW;
-            break;
-        default:
-            assert(0 && "Invalid EXISTS for quad");
-            return Edge_None;
-        }
+        auto fn_fuzzy_equals = [this](contour::point p1, contour::point p2) {
+            double unit_x = std::abs(x_max_ - x_min_),
+                   unit_y = std::abs(y_max_ - y_min_);
 
-        unsigned int config = (Z_LEVEL(point1) >= level_index) << 2 |
-                              (Z_LEVEL(point2) >= level_index) << 1 |
-                              (Z_LEVEL(point3) >= level_index);
+            return ((std::abs(p1.x - p2.x) < unit_x * k_Epsilon) &&
+                    (std::abs(p1.y - p2.y) < unit_y * k_Epsilon));
+        };
 
-        // Upper level (level_index == 2) polygons are reversed compared to
-        // lower level ones, i.e. higher values on the right rather than the
-        // left.
-        if (level_index == 2)
-            config = 7 - config;
+        edge *e_start = &e, *e_cur = &e;
 
-        switch (config) {
-        case 0:
-            return Edge_None;
-        case 1:
-            return edge23;
-        case 2:
-            return edge12;
-        case 3:
-            return edge12;
-        case 4:
-            return edge31;
-        case 5:
-            return edge23;
-        case 6:
-            return edge31;
-        case 7:
-            return Edge_None;
-        default:
-            assert(0 && "Invalid config");
-            return Edge_None;
-        }
-    }
+        /* push back first point in edge */
+        ctr.points.emplace_back(contour_point(z, *e_cur));
+        fn_deactivate_edge(*e_cur);
 
-    long QuadContourGenerator::get_edge_point_index(const QuadEdge &quad_edge,
-                                                    bool start) const {
-        assert(quad_edge.quad >= 0 && quad_edge.quad < _n &&
-               "Quad index out of bounds");
-        assert(quad_edge.edge != Edge_None && "Invalid edge");
-
-        // Edges are ordered anticlockwise around their quad, as indicated by
-        // directions of arrows in diagrams below.
-        //           Full quad                    NW corner (others similar)
-        //
-        //  POINT_NW   Edge_N   POINT_NE         POINT_NW   Edge_N   POINT_NE
-        //          +----<-----+                         +----<-----+
-        //          |          |                         |         /
-        //          |          |                         | quad  /
-        //  Edge_W  V   quad   ^  Edge_E         Edge_W  V     ^
-        //          |          |                         |   /  Edge_SE
-        //          |          |                         | /
-        //          +---->-----+                         +
-        //  POINT_SW   Edge_S   POINT_SE         POINT_SW
-        //
-        const long &quad = quad_edge.quad;
-        switch (quad_edge.edge) {
-        case Edge_E:
-            return (start ? POINT_SE : POINT_NE);
-        case Edge_N:
-            return (start ? POINT_NE : POINT_NW);
-        case Edge_W:
-            return (start ? POINT_NW : POINT_SW);
-        case Edge_S:
-            return (start ? POINT_SW : POINT_SE);
-        case Edge_NE:
-            return (start ? POINT_SE : POINT_NW);
-        case Edge_NW:
-            return (start ? POINT_NE : POINT_SW);
-        case Edge_SW:
-            return (start ? POINT_NW : POINT_SE);
-        case Edge_SE:
-            return (start ? POINT_SW : POINT_NE);
-        default:
-            assert(0 && "Invalid edge");
-            return 0;
-        }
-    }
-
-    Edge QuadContourGenerator::get_exit_edge(const QuadEdge &quad_edge,
-                                             Dir dir) const {
-        assert(quad_edge.quad >= 0 && quad_edge.quad < _n &&
-               "Quad index out of bounds");
-        assert(quad_edge.edge != Edge_None && "Invalid edge");
-
-        const long &quad = quad_edge.quad;
-        const Edge &edge = quad_edge.edge;
-        if (EXISTS_ANY_CORNER(quad)) {
-            // Corner directions are always left or right.  A corner is a
-            // triangle, entered via one edge so the other two edges are the
-            // left and right ones.
-            switch (edge) {
-            case Edge_E:
-                return (EXISTS_SE_CORNER(quad)
-                            ? (dir == Dir_Left ? Edge_S : Edge_NW)
-                            : (dir == Dir_Right ? Edge_N : Edge_SW));
-            case Edge_N:
-                return (EXISTS_NW_CORNER(quad)
-                            ? (dir == Dir_Right ? Edge_W : Edge_SE)
-                            : (dir == Dir_Left ? Edge_E : Edge_SW));
-            case Edge_W:
-                return (EXISTS_SW_CORNER(quad)
-                            ? (dir == Dir_Right ? Edge_S : Edge_NE)
-                            : (dir == Dir_Left ? Edge_N : Edge_SE));
-            case Edge_S:
-                return (EXISTS_SW_CORNER(quad)
-                            ? (dir == Dir_Left ? Edge_W : Edge_NE)
-                            : (dir == Dir_Right ? Edge_E : Edge_NW));
-            case Edge_NE:
-                return (dir == Dir_Left ? Edge_S : Edge_W);
-            case Edge_NW:
-                return (dir == Dir_Left ? Edge_E : Edge_S);
-            case Edge_SW:
-                return (dir == Dir_Left ? Edge_N : Edge_E);
-            case Edge_SE:
-                return (dir == Dir_Left ? Edge_W : Edge_N);
-            default:
-                assert(0 && "Invalid edge");
-                return Edge_None;
-            }
-        } else {
-            // A full quad has four edges, entered via one edge so that other
-            // three edges correspond to left, straight and right directions.
-            switch (edge) {
-            case Edge_E:
-                return (dir == Dir_Left ? Edge_S
-                                        : (dir == Dir_Right ? Edge_N : Edge_W));
-            case Edge_N:
-                return (dir == Dir_Left ? Edge_E
-                                        : (dir == Dir_Right ? Edge_W : Edge_S));
-            case Edge_W:
-                return (dir == Dir_Left ? Edge_N
-                                        : (dir == Dir_Right ? Edge_S : Edge_E));
-            case Edge_S:
-                return (dir == Dir_Left ? Edge_W
-                                        : (dir == Dir_Right ? Edge_E : Edge_N));
-            default:
-                assert(0 && "Invalid edge");
-                return Edge_None;
-            }
-        }
-    }
-
-    XY QuadContourGenerator::get_point_xy(long point) const {
-        assert(point >= 0 && point < _n && "Point index out of bounds.");
-        return XY(_x[0].data()[static_cast<size_t>(point)],
-                  _y[0].data()[static_cast<size_t>(point)]);
-    }
-
-    const double &QuadContourGenerator::get_point_z(long point) const {
-        assert(point >= 0 && point < _n && "Point index out of bounds.");
-        return _z[0].data()[static_cast<size_t>(point)];
-    }
-
-    Edge
-    QuadContourGenerator::get_quad_start_edge(long quad,
-                                              unsigned int level_index) const {
-        assert(quad >= 0 && quad < _n && "Quad index out of bounds");
-        assert((level_index == 1 || level_index == 2) &&
-               "level index must be 1 or 2");
-        assert(EXISTS_QUAD(quad) && "Quad does not exist");
-
-        unsigned int config =
-            (Z_NW >= level_index) << 3 | (Z_NE >= level_index) << 2 |
-            (Z_SW >= level_index) << 1 | (Z_SE >= level_index);
-
-        // Upper level (level_index == 2) polygons are reversed compared to
-        // lower level ones, i.e. higher values on the right rather than the
-        // left.
-        if (level_index == 2)
-            config = 15 - config;
-
-        switch (config) {
-        case 0:
-            return Edge_None;
-        case 1:
-            return Edge_E;
-        case 2:
-            return Edge_S;
-        case 3:
-            return Edge_E;
-        case 4:
-            return Edge_N;
-        case 5:
-            return Edge_N;
-        case 6:
-            // If already identified as a saddle quad then the start edge is
-            // read from the cache.  Otherwise return either valid start edge
-            // and the subsequent call to follow_interior() will correctly set
-            // up saddle bits in cache.
-            if (!SADDLE(quad, level_index) ||
-                SADDLE_START_SW(quad, level_index))
-                return Edge_S;
-            else
-                return Edge_N;
-        case 7:
-            return Edge_N;
-        case 8:
-            return Edge_W;
-        case 9:
-            // See comment for 6 above.
-            if (!SADDLE(quad, level_index) ||
-                SADDLE_START_SW(quad, level_index))
-                return Edge_W;
-            else
-                return Edge_E;
-        case 10:
-            return Edge_S;
-        case 11:
-            return Edge_E;
-        case 12:
-            return Edge_W;
-        case 13:
-            return Edge_W;
-        case 14:
-            return Edge_S;
-        case 15:
-            return Edge_None;
-        default:
-            assert(0 && "Invalid config");
-            return Edge_None;
-        }
-    }
-
-    Edge QuadContourGenerator::get_start_edge(long quad,
-                                              unsigned int level_index) const {
-        if (EXISTS_ANY_CORNER(quad))
-            return get_corner_start_edge(quad, level_index);
-        else
-            return get_quad_start_edge(quad, level_index);
-    }
-
-    void QuadContourGenerator::init_cache_grid() {
-        long i, j, quad;
-
-        quad = 0;
-        for (j = 0; j < _ny; ++j) {
-            for (i = 0; i < _nx; ++i, ++quad) {
-                _cache[quad] = 0;
-
-                if (i < _nx - 1 && j < _ny - 1)
-                    _cache[quad] |= MASK_EXISTS_QUAD;
-
-                if ((i % _chunk_size == 0 || i == _nx - 1) && j < _ny - 1)
-                    _cache[quad] |= MASK_BOUNDARY_W;
-
-                if ((j % _chunk_size == 0 || j == _ny - 1) && i < _nx - 1)
-                    _cache[quad] |= MASK_BOUNDARY_S;
-            }
-        }
-    }
-
-    void QuadContourGenerator::init_cache_levels(const double &lower_level,
-                                                 const double &upper_level) {
-        assert(upper_level >= lower_level &&
-               "upper and lower levels are wrong way round");
-
-        bool two_levels = (lower_level != upper_level);
-        CacheItem keep_mask =
-            (_corner_mask
-                 ? MASK_EXISTS | MASK_BOUNDARY_S | MASK_BOUNDARY_W
-                 : MASK_EXISTS_QUAD | MASK_BOUNDARY_S | MASK_BOUNDARY_W);
-
-        if (two_levels) {
-            const double *z_ptr = _z[0].data();
-            for (long quad = 0; quad < _n; ++quad, ++z_ptr) {
-                _cache[quad] &= keep_mask;
-                if (*z_ptr > upper_level)
-                    _cache[quad] |= MASK_Z_LEVEL_2;
-                else if (*z_ptr > lower_level)
-                    _cache[quad] |= MASK_Z_LEVEL_1;
-            }
-        } else {
-            const double *z_ptr = _z[0].data();
-            for (long quad = 0; quad < _n; ++quad, ++z_ptr) {
-                _cache[quad] &= keep_mask;
-                if (*z_ptr > lower_level)
-                    _cache[quad] |= MASK_Z_LEVEL_1;
-            }
-        }
-    }
-
-    XY QuadContourGenerator::interp(long point1, long point2,
-                                    const double &level) const {
-        assert(point1 >= 0 && point1 < _n && "Point index 1 out of bounds.");
-        assert(point2 >= 0 && point2 < _n && "Point index 2 out of bounds.");
-        assert(point1 != point2 && "Identical points");
-        double fraction = (get_point_z(point2) - level) /
-                          (get_point_z(point2) - get_point_z(point1));
-        return get_point_xy(point1) * fraction +
-               get_point_xy(point2) * (1.0 - fraction);
-    }
-
-    bool
-    QuadContourGenerator::is_edge_a_boundary(const QuadEdge &quad_edge) const {
-        assert(quad_edge.quad >= 0 && quad_edge.quad < _n &&
-               "Quad index out of bounds");
-        assert(quad_edge.edge != Edge_None && "Invalid edge");
-
-        switch (quad_edge.edge) {
-        case Edge_E:
-            return BOUNDARY_E(quad_edge.quad);
-        case Edge_N:
-            return BOUNDARY_N(quad_edge.quad);
-        case Edge_W:
-            return BOUNDARY_W(quad_edge.quad);
-        case Edge_S:
-            return BOUNDARY_S(quad_edge.quad);
-        case Edge_NE:
-            return EXISTS_SW_CORNER(quad_edge.quad);
-        case Edge_NW:
-            return EXISTS_SE_CORNER(quad_edge.quad);
-        case Edge_SW:
-            return EXISTS_NE_CORNER(quad_edge.quad);
-        case Edge_SE:
-            return EXISTS_NW_CORNER(quad_edge.quad);
-        default:
-            assert(0 && "Invalid edge");
-            return true;
-        }
-    }
-
-    void QuadContourGenerator::move_to_next_boundary_edge(
-        QuadEdge &quad_edge) const {
-        assert(is_edge_a_boundary(quad_edge) && "QuadEdge is not a boundary");
-
-        long &quad = quad_edge.quad;
-        Edge &edge = quad_edge.edge;
-
-        quad = get_edge_point_index(quad_edge, false);
-
-        // quad is now such that POINT_SW is the end point of the quad_edge
-        // passed to this function.
-
-        // To find the next boundary edge, first attempt to turn left 135
-        // degrees and if that edge is a boundary then move to it.  If not,
-        // attempt to turn left 90 degrees, then left 45 degrees, then straight
-        // on, etc, until can move. First determine which edge to attempt first.
-        int index = 0;
-        switch (edge) {
-        case Edge_E:
-            index = 0;
-            break;
-        case Edge_SE:
-            index = 1;
-            break;
-        case Edge_S:
-            index = 2;
-            break;
-        case Edge_SW:
-            index = 3;
-            break;
-        case Edge_W:
-            index = 4;
-            break;
-        case Edge_NW:
-            index = 5;
-            break;
-        case Edge_N:
-            index = 6;
-            break;
-        case Edge_NE:
-            index = 7;
-            break;
-        default:
-            assert(0 && "Invalid edge");
-            break;
-        }
-
-        // If _corner_mask not set, only need to consider odd index in loop
-        // below.
-        if (!_corner_mask)
-            ++index;
-
-        // Try each edge in turn until a boundary is found.
-        int start_index = index;
+        triangle *t_last = nullptr;
         do {
-            switch (index) {
-            case 0:
-                if (EXISTS_SE_CORNER(quad - _nx -
-                                     1)) { // Equivalent to BOUNDARY_NW
-                    quad -= _nx + 1;
-                    edge = Edge_NW;
-                    return;
-                }
-                break;
-            case 1:
-                if (BOUNDARY_N(quad - _nx - 1)) {
-                    quad -= _nx + 1;
-                    edge = Edge_N;
-                    return;
-                }
-                break;
-            case 2:
-                if (EXISTS_SW_CORNER(quad - 1)) { // Equivalent to BOUNDARY_NE
-                    quad -= 1;
-                    edge = Edge_NE;
-                    return;
-                }
-                break;
-            case 3:
-                if (BOUNDARY_E(quad - 1)) {
-                    quad -= 1;
-                    edge = Edge_E;
-                    return;
-                }
-                break;
-            case 4:
-                if (EXISTS_NW_CORNER(quad)) { // Equivalent to BOUNDARY_SE
-                    edge = Edge_SE;
-                    return;
-                }
-                break;
-            case 5:
-                if (BOUNDARY_S(quad)) {
-                    edge = Edge_S;
-                    return;
-                }
-                break;
-            case 6:
-                if (EXISTS_NE_CORNER(quad - _nx)) { // Equivalent to BOUNDARY_SW
-                    quad -= _nx;
-                    edge = Edge_SW;
-                    return;
-                }
-                break;
-            case 7:
-                if (BOUNDARY_W(quad - _nx)) {
-                    quad -= _nx;
-                    edge = Edge_W;
-                    return;
-                }
-                break;
-            default:
-                assert(0 && "Invalid index");
-                break;
+            /* find triangle to continue (but not whence we came) */
+            triangle *t_cur;
+            if (e_cur->t[0] == t_last)
+                t_cur = e_cur->t[1];
+            else
+                t_cur = e_cur->t[0];
+
+            edge *e_next = nullptr;
+            for (edge *e_t : t_cur->e) {
+                if (e_t != e_cur && e_t->flags.active)
+                    e_next = e_t;
             }
 
-            if (_corner_mask)
-                index = (index + 1) % 8;
-            else
-                index = (index + 2) % 8;
-        } while (index != start_index);
-
-        assert(0 && "Failed to find next boundary edge");
-    }
-
-    void QuadContourGenerator::move_to_next_quad(QuadEdge &quad_edge) const {
-        assert(quad_edge.quad >= 0 && quad_edge.quad < _n &&
-               "Quad index out of bounds");
-        assert(quad_edge.edge != Edge_None && "Invalid edge");
-
-        // Move from quad_edge.quad to the neighbouring quad in the direction
-        // specified by quad_edge.edge.
-        switch (quad_edge.edge) {
-        case Edge_E:
-            quad_edge.quad += 1;
-            quad_edge.edge = Edge_W;
-            break;
-        case Edge_N:
-            quad_edge.quad += _nx;
-            quad_edge.edge = Edge_S;
-            break;
-        case Edge_W:
-            quad_edge.quad -= 1;
-            quad_edge.edge = Edge_E;
-            break;
-        case Edge_S:
-            quad_edge.quad -= _nx;
-            quad_edge.edge = Edge_N;
-            break;
-        default:
-            assert(0 && "Invalid edge");
-            break;
-        }
-    }
-
-    void QuadContourGenerator::single_quad_filled(Contour &contour, long quad,
-                                                  const double &lower_level,
-                                                  const double &upper_level) {
-        assert(quad >= 0 && quad < _n && "Quad index out of bounds");
-
-        // Order of checking is important here as can have different
-        // ContourLines from both lower and upper levels in the same quad. First
-        // check the S edge, then move up the quad to the N edge checking as
-        // required.
-
-        // Possible starts from S boundary.
-        if (BOUNDARY_S(quad) && EXISTS_S_EDGE(quad)) {
-
-            // Lower-level start from S boundary into interior.
-            if (!VISITED_S(quad) && Z_SW >= 1 && Z_SE == 0)
-                contour.push_back(start_filled(quad, Edge_S, 1, NotHole,
-                                               Interior, lower_level,
-                                               upper_level));
-
-            // Upper-level start from S boundary into interior.
-            if (!VISITED_S(quad) && Z_SW < 2 && Z_SE == 2)
-                contour.push_back(start_filled(quad, Edge_S, 2, NotHole,
-                                               Interior, lower_level,
-                                               upper_level));
-
-            // Lower-level start following S boundary from W to E.
-            if (!VISITED_S(quad) && Z_SW <= 1 && Z_SE == 1)
-                contour.push_back(start_filled(quad, Edge_S, 1, NotHole,
-                                               Boundary, lower_level,
-                                               upper_level));
-
-            // Upper-level start following S boundary from W to E.
-            if (!VISITED_S(quad) && Z_SW == 2 && Z_SE == 1)
-                contour.push_back(start_filled(quad, Edge_S, 2, NotHole,
-                                               Boundary, lower_level,
-                                               upper_level));
-        }
-
-        // Possible starts from W boundary.
-        if (BOUNDARY_W(quad) && EXISTS_W_EDGE(quad)) {
-
-            // Lower-level start from W boundary into interior.
-            if (!VISITED_W(quad) && Z_NW >= 1 && Z_SW == 0)
-                contour.push_back(start_filled(quad, Edge_W, 1, NotHole,
-                                               Interior, lower_level,
-                                               upper_level));
-
-            // Upper-level start from W boundary into interior.
-            if (!VISITED_W(quad) && Z_NW < 2 && Z_SW == 2)
-                contour.push_back(start_filled(quad, Edge_W, 2, NotHole,
-                                               Interior, lower_level,
-                                               upper_level));
-
-            // Lower-level start following W boundary from N to S.
-            if (!VISITED_W(quad) && Z_NW <= 1 && Z_SW == 1)
-                contour.push_back(start_filled(quad, Edge_W, 1, NotHole,
-                                               Boundary, lower_level,
-                                               upper_level));
-
-            // Upper-level start following W boundary from N to S.
-            if (!VISITED_W(quad) && Z_NW == 2 && Z_SW == 1)
-                contour.push_back(start_filled(quad, Edge_W, 2, NotHole,
-                                               Boundary, lower_level,
-                                               upper_level));
-        }
-
-        // Possible starts from NE boundary.
-        if (EXISTS_SW_CORNER(quad)) { // i.e. BOUNDARY_NE
-
-            // Lower-level start following NE boundary from SE to NW, hole.
-            if (!VISITED_CORNER(quad) && Z_NW == 1 && Z_SE == 1)
-                contour.push_back(start_filled(quad, Edge_NE, 1, Hole, Boundary,
-                                               lower_level, upper_level));
-        }
-        // Possible starts from SE boundary.
-        else if (EXISTS_NW_CORNER(quad)) { // i.e. BOUNDARY_SE
-
-            // Lower-level start from N to SE.
-            if (!VISITED(quad, 1) && Z_NW == 0 && Z_SW == 0 && Z_NE >= 1)
-                contour.push_back(start_filled(quad, Edge_N, 1, NotHole,
-                                               Interior, lower_level,
-                                               upper_level));
-
-            // Upper-level start from SE to N, hole.
-            if (!VISITED(quad, 2) && Z_NW < 2 && Z_SW < 2 && Z_NE == 2)
-                contour.push_back(start_filled(quad, Edge_SE, 2, Hole, Interior,
-                                               lower_level, upper_level));
-
-            // Upper-level start from N to SE.
-            if (!VISITED(quad, 2) && Z_NW == 2 && Z_SW == 2 && Z_NE < 2)
-                contour.push_back(start_filled(quad, Edge_N, 2, NotHole,
-                                               Interior, lower_level,
-                                               upper_level));
-
-            // Lower-level start from SE to N, hole.
-            if (!VISITED(quad, 1) && Z_NW >= 1 && Z_SW >= 1 && Z_NE == 0)
-                contour.push_back(start_filled(quad, Edge_SE, 1, Hole, Interior,
-                                               lower_level, upper_level));
-        }
-        // Possible starts from NW boundary.
-        else if (EXISTS_SE_CORNER(quad)) { // i.e. BOUNDARY_NW
-
-            // Lower-level start from NW to E.
-            if (!VISITED(quad, 1) && Z_SW == 0 && Z_SE == 0 && Z_NE >= 1)
-                contour.push_back(start_filled(quad, Edge_NW, 1, NotHole,
-                                               Interior, lower_level,
-                                               upper_level));
-
-            // Upper-level start from E to NW, hole.
-            if (!VISITED(quad, 2) && Z_SW < 2 && Z_SE < 2 && Z_NE == 2)
-                contour.push_back(start_filled(quad, Edge_E, 2, Hole, Interior,
-                                               lower_level, upper_level));
-
-            // Upper-level start from NW to E.
-            if (!VISITED(quad, 2) && Z_SW == 2 && Z_SE == 2 && Z_NE < 2)
-                contour.push_back(start_filled(quad, Edge_NW, 2, NotHole,
-                                               Interior, lower_level,
-                                               upper_level));
-
-            // Lower-level start from E to NW, hole.
-            if (!VISITED(quad, 1) && Z_SW >= 1 && Z_SE >= 1 && Z_NE == 0)
-                contour.push_back(start_filled(quad, Edge_E, 1, Hole, Interior,
-                                               lower_level, upper_level));
-        }
-        // Possible starts from SW boundary.
-        else if (EXISTS_NE_CORNER(quad)) { // i.e. BOUNDARY_SW
-
-            // Lower-level start from SW boundary into interior.
-            if (!VISITED_CORNER(quad) && Z_NW >= 1 && Z_SE == 0)
-                contour.push_back(start_filled(quad, Edge_SW, 1, NotHole,
-                                               Interior, lower_level,
-                                               upper_level));
-
-            // Upper-level start from SW boundary into interior.
-            if (!VISITED_CORNER(quad) && Z_NW < 2 && Z_SE == 2)
-                contour.push_back(start_filled(quad, Edge_SW, 2, NotHole,
-                                               Interior, lower_level,
-                                               upper_level));
-
-            // Lower-level start following SW boundary from NW to SE.
-            if (!VISITED_CORNER(quad) && Z_NW <= 1 && Z_SE == 1)
-                contour.push_back(start_filled(quad, Edge_SW, 1, NotHole,
-                                               Boundary, lower_level,
-                                               upper_level));
-
-            // Upper-level start following SW boundary from NW to SE.
-            if (!VISITED_CORNER(quad) && Z_NW == 2 && Z_SE == 1)
-                contour.push_back(start_filled(quad, Edge_SW, 2, NotHole,
-                                               Boundary, lower_level,
-                                               upper_level));
-        }
-
-        // A full (unmasked) quad can only have a start on the NE corner, i.e.
-        // from N to E (lower level) or E to N (upper level).  Any other start
-        // will have already been created in a call to this function for a prior
-        // quad so we don't need to test for it again here.
-        //
-        // The situation is complicated by the possibility that the quad is a
-        // saddle quad, in which case a contour line starting on the N could
-        // leave by either the W or the E.  We only need to consider those
-        // leaving E.
-        //
-        // A NE corner can also have a N to E or E to N start.
-        if (EXISTS_QUAD(quad) || EXISTS_NE_CORNER(quad)) {
-
-            // Lower-level start from N to E.
-            if (!VISITED(quad, 1) && Z_NW == 0 && Z_SE == 0 && Z_NE >= 1 &&
-                (!SADDLE(quad, 1) || SADDLE_LEFT(quad, 1)))
-                contour.push_back(start_filled(quad, Edge_N, 1, NotHole,
-                                               Interior, lower_level,
-                                               upper_level));
-
-            // Upper-level start from E to N, hole.
-            if (!VISITED(quad, 2) && Z_NW < 2 && Z_SE < 2 && Z_NE == 2 &&
-                (!SADDLE(quad, 2) || !SADDLE_LEFT(quad, 2)))
-                contour.push_back(start_filled(quad, Edge_E, 2, Hole, Interior,
-                                               lower_level, upper_level));
-
-            // Upper-level start from N to E.
-            if (!VISITED(quad, 2) && Z_NW == 2 && Z_SE == 2 && Z_NE < 2 &&
-                (!SADDLE(quad, 2) || SADDLE_LEFT(quad, 2)))
-                contour.push_back(start_filled(quad, Edge_N, 2, NotHole,
-                                               Interior, lower_level,
-                                               upper_level));
-
-            // Lower-level start from E to N, hole.
-            if (!VISITED(quad, 1) && Z_NW >= 1 && Z_SE >= 1 && Z_NE == 0 &&
-                (!SADDLE(quad, 1) || !SADDLE_LEFT(quad, 1)))
-                contour.push_back(start_filled(quad, Edge_E, 1, Hole, Interior,
-                                               lower_level, upper_level));
-
-            // All possible contours passing through the interior of this quad
-            // should have already been created, so assert this.
-            assert(
-                (VISITED(quad, 1) || get_start_edge(quad, 1) == Edge_None) &&
-                "Found start of contour that should have already been created");
-            assert(
-                (VISITED(quad, 2) || get_start_edge(quad, 2) == Edge_None) &&
-                "Found start of contour that should have already been created");
-        }
-
-        // Lower-level start following N boundary from E to W, hole.
-        // This is required for an internal masked region which is a hole in a
-        // surrounding contour line.
-        if (BOUNDARY_N(quad) && EXISTS_N_EDGE(quad) && !VISITED_S(quad + _nx) &&
-            Z_NW == 1 && Z_NE == 1)
-            contour.push_back(start_filled(quad, Edge_N, 1, Hole, Boundary,
-                                           lower_level, upper_level));
-    }
-
-    ContourLine *QuadContourGenerator::start_filled(
-        long quad, Edge edge, unsigned int start_level_index,
-        HoleOrNot hole_or_not, BoundaryOrInterior boundary_or_interior,
-        const double &lower_level, const double &upper_level) {
-        assert(quad >= 0 && quad < _n && "Quad index out of bounds");
-        assert(edge != Edge_None && "Invalid edge");
-        assert((start_level_index == 1 || start_level_index == 2) &&
-               "start level index must be 1 or 2");
-
-        ContourLine *contour_line = new ContourLine(hole_or_not == Hole);
-        if (hole_or_not == Hole) {
-            // Find and set parent ContourLine.
-            ContourLine *parent = _parent_cache.get_parent(quad + 1);
-            assert(parent != 0 && "Failed to find parent ContourLine");
-            contour_line->set_parent(parent);
-            parent->add_child(contour_line);
-        }
-
-        QuadEdge quad_edge(quad, edge);
-        const QuadEdge start_quad_edge(quad_edge);
-        unsigned int level_index = start_level_index;
-
-        // If starts on interior, can only finish on interior.
-        // If starts on boundary, can only finish on boundary.
-
-        while (true) {
-            if (boundary_or_interior == Interior) {
-                double level = (level_index == 1 ? lower_level : upper_level);
-                follow_interior(*contour_line, quad_edge, level_index, level,
-                                false, &start_quad_edge, start_level_index,
-                                true);
-            } else {
-                level_index =
-                    follow_boundary(*contour_line, quad_edge, lower_level,
-                                    upper_level, level_index, start_quad_edge);
+            if (!e_next) {
+                /* TODO: handle somewhat gracefully */
+                return contour();
             }
+            e_cur = e_next;
+            t_last = t_cur;
 
-            if (quad_edge == start_quad_edge &&
-                (boundary_or_interior == Boundary ||
-                 level_index == start_level_index))
-                break;
+            fn_deactivate_edge(*e_cur);
 
-            if (boundary_or_interior == Boundary)
-                boundary_or_interior = Interior;
-            else
-                boundary_or_interior = Boundary;
-        }
+            if (!e_cur->flags.diagonal) {
+                contour::point p = contour_point(z, *e_cur);
 
-        return contour_line;
+                if (!fn_fuzzy_equals(ctr.points.back(), p))
+                    ctr.points.emplace_back(contour_point(z, *e_cur));
+            }
+        } while ((e_start != e_cur) && (!e_cur->flags.on_boundary));
+
+        /* for a closed contour the first and last point should be equal */
+        if (e_start == e_cur)
+            ctr.points.front() = ctr.points.back();
+
+        return ctr;
     }
+} // namespace matplot::detail
 
-    bool QuadContourGenerator::start_line(vertices_list_type &vertices_list,
-                                          long quad, Edge edge,
-                                          const double &level) {
-        assert(is_edge_a_boundary(QuadEdge(quad, edge)) &&
-               "QuadEdge is not a boundary");
-
-        QuadEdge quad_edge(quad, edge);
-        ContourLine contour_line(false);
-        follow_interior(contour_line, quad_edge, 1, level, true, 0, 1, false);
-        append_contour_line_to_vertices(contour_line, vertices_list);
-        return VISITED(quad, 1);
-    }
-
-    void QuadContourGenerator::write_cache(bool grid_only) const {
-        std::cout << "-----------------------------------------------"
-                  << std::endl;
-        for (long quad = 0; quad < _n; ++quad)
-            write_cache_quad(quad, grid_only);
-        std::cout << "-----------------------------------------------"
-                  << std::endl;
-    }
-
-    void QuadContourGenerator::write_cache_quad(long quad,
-                                                bool grid_only) const {
-        long j = quad / _nx;
-        long i = quad - j * _nx;
-        std::cout << quad << ": i=" << i << " j=" << j
-                  << " EXISTS=" << EXISTS_QUAD(quad);
-        if (_corner_mask)
-            std::cout << " CORNER=" << EXISTS_SW_CORNER(quad)
-                      << EXISTS_SE_CORNER(quad) << EXISTS_NW_CORNER(quad)
-                      << EXISTS_NE_CORNER(quad);
-        std::cout << " BNDY=" << (BOUNDARY_S(quad) > 0)
-                  << (BOUNDARY_W(quad) > 0);
-        if (!grid_only) {
-            std::cout << " Z=" << Z_LEVEL(quad) << " SAD=" << SADDLE(quad, 1)
-                      << SADDLE(quad, 2) << " LEFT=" << SADDLE_LEFT(quad, 1)
-                      << SADDLE_LEFT(quad, 2)
-                      << " NW=" << SADDLE_START_SW(quad, 1)
-                      << SADDLE_START_SW(quad, 2) << " VIS=" << VISITED(quad, 1)
-                      << VISITED(quad, 2) << VISITED_S(quad) << VISITED_W(quad)
-                      << VISITED_CORNER(quad);
-        }
-        std::cout << std::endl;
-    }
-
+namespace matplot {
     std::tuple<double, std::pair<double, double>, std::pair<size_t, size_t>>
     find_closest_point_on_path(const std::vector<double> &xs,
                                const std::vector<double> &ys, double px,
@@ -1905,12 +392,12 @@ namespace matplot {
         };
 
         auto contour_line_in_bounds = [&]() {
-            QuadContourGenerator contour_generator(X, Y, Z, false, 0);
+            detail::contour_generator contour_generator(X, Y, Z);
             auto c = contour_generator.create_contour(level);
             size_t attempts = 0;
             while (!contour_is_in_bounds(c) && attempts < 10) {
                 std::cerr << "Contour out of bounds" << std::endl;
-                QuadContourGenerator contour_generator2(X, Y, Z, false, 0);
+                detail::contour_generator contour_generator2(X, Y, Z);
                 c = contour_generator2.create_contour(level);
                 ++attempts;
             }

--- a/source/matplot/util/contourc.cpp
+++ b/source/matplot/util/contourc.cpp
@@ -282,6 +282,7 @@ namespace matplot::detail {
             else
                 t_cur = e_cur->t[0];
 
+            /* find edge to continue (but not whence we came) */
             edge *e_next = nullptr;
             for (edge *e_t : t_cur->e) {
                 if (e_t != e_cur && e_t->flags.active)
@@ -298,9 +299,12 @@ namespace matplot::detail {
 
             fn_deactivate_edge(*e_cur);
 
+            /* do not include points at diagonal edges or we get awful
+             * zigzag patterns */
             if (!e_cur->flags.diagonal) {
                 contour::point p = contour_point(z, *e_cur);
 
+                /* do not include points that are too close to each other */
                 if (!fn_fuzzy_equals(ctr.points.back(), p))
                     ctr.points.emplace_back(contour_point(z, *e_cur));
             }

--- a/source/matplot/util/contourc.cpp
+++ b/source/matplot/util/contourc.cpp
@@ -18,6 +18,259 @@
 #include <cassert>
 #include <matplot/axes_objects/contours.h>
 #include <matplot/util/contourc.h>
+#include <queue>
+#include <set>
+
+namespace {
+    struct point_2d {
+        double x, y;
+
+        bool operator==(const point_2d &p) const noexcept {
+            return x == p.x && y == p.y;
+        }
+        bool operator!=(const point_2d &p) const noexcept {
+            return x != p.x || y != p.y;
+        }
+    };
+
+    using line_segment = std::vector<point_2d>;
+    struct contour_line_segment {
+        struct edge {
+            point_2d p[2];
+
+            /* in_dir[x] specifies whether moving towards p[x] brings you into
+             * the filled contour region */
+            bool in_dir[2];
+        };
+
+        line_segment segment;
+        edge intersection_edges[2];
+    };
+
+    /*  */
+    class rect_splitter {
+        enum order { eUpper = 1, eRight = 2, eBottom = 3, eLeft = 4 };
+
+        struct segment;
+
+        struct junction {
+            point_2d p;
+            struct {
+                /* whether moving cw (or ccw) brings you into the filled polygon
+                 * or not */
+                bool filled_forward : 1;
+                bool filled_backward : 1;
+
+                uint8_t passed_count : 2;
+
+                bool is_corner : 1;
+            } flags{};
+            junction *j[2]{};
+            segment *s{};
+        };
+
+        struct segment {
+            line_segment l;
+            struct {
+                uint8_t passed_count : 2;
+            } flags{};
+            junction *j[2]{};
+
+            explicit segment(line_segment ls) : l(std::move(ls)) {}
+        };
+
+      public:
+        rect_splitter(double x_min, double x_max, double y_min, double y_max)
+            : x_min_(x_min), x_max_(x_max), y_min_(y_min), y_max_(y_max) {}
+
+        void init(const std::vector<contour_line_segment> &segments) {
+            {
+                auto fn_check_filled_dir =
+                    [this](const contour_line_segment::edge &e, junction &j) {
+                        auto in_dir_back = e.in_dir[0],
+                             in_dir_forw = e.in_dir[1];
+                        if (junction_point_compare(e.p[1], e.p[0]))
+                            std::swap(in_dir_back, in_dir_forw);
+                        j.flags.filled_backward = in_dir_back;
+                        j.flags.filled_forward = in_dir_forw;
+                    };
+
+                auto junction_comparator = [this](const junction &j1,
+                                                  const junction &j2) {
+                    return junction_point_compare(j1.p, j2.p);
+                };
+                using comp = decltype(junction_comparator);
+
+                std::set<junction, comp> s(junction_comparator);
+
+                /* insert corners of full region */
+                s.insert({{{x_min_, y_max_}, {false, false, 1, true}},
+                          {{x_max_, y_max_}, {false, false, 1, true}},
+                          {{x_max_, y_min_}, {false, false, 1, true}},
+                          {{x_min_, y_min_}, {false, false, 1, true}}});
+
+                /* insert other boundary points */
+                for (const auto &l : segments) {
+                    assert(!l.segment.empty());
+
+                    junction j1;
+                    j1.p = l.segment.front();
+                    fn_check_filled_dir(l.intersection_edges[0], j1);
+                    j1.flags.is_corner = false;
+                    j1.flags.passed_count = 0;
+
+                    junction j2;
+                    j2.p = l.segment.back();
+                    fn_check_filled_dir(l.intersection_edges[1], j2);
+                    j2.flags.is_corner = false;
+                    j2.flags.passed_count = 0;
+
+                    s.insert({j1, j2});
+                }
+
+                /* copy sorted list to junctions_ */
+                junctions_.assign(s.begin(), s.end());
+            }
+
+            /* join chain */
+            junctions_.front().j[0] = &junctions_.back();
+            junctions_.back().j[1] = &junctions_.front();
+            for (size_t ii = 0; ii < junctions_.size() - 1; ++ii) {
+                junctions_[ii].j[1] = &junctions_[ii + 1];
+                junctions_[ii + 1].j[0] = &junctions_[ii];
+            }
+
+            /* build segment connections */
+            segments_.clear();
+            segments_.reserve(segments.size());
+            for (const auto &l : segments) {
+                segment &s = segments_.emplace_back(l.segment);
+                if (junction_point_compare(s.l.back(), s.l.front()))
+                    std::reverse(s.l.begin(), s.l.end());
+
+                s.j[0] = find_junction_at(s.l.front());
+                s.j[0]->s = &s;
+                s.j[1] = find_junction_at(s.l.back());
+                s.j[1]->s = &s;
+            }
+        }
+
+        std::vector<std::vector<point_2d>> split() noexcept {
+            std::queue<junction *> start_points;
+            start_points.push(&junctions_.front());
+
+            std::vector<std::vector<point_2d>> split_lines;
+            while (!start_points.empty()) {
+                bool is_filled = false, is_filled_check = false;
+                std::vector<point_2d> line;
+                auto fn_push_segment = [&line](const junction *j) {
+                    assert(j->s);
+                    assert(j->p == j->s->l.front() || j->p == j->s->l.back());
+
+                    if (j->p == j->s->l.front()) {
+                        line.insert(line.end(), j->s->l.begin() + 1,
+                                    j->s->l.end());
+                        return j->s->j[1];
+                    } else {
+                        line.insert(line.end(), j->s->l.rbegin() + 1,
+                                    j->s->l.rend());
+                        return j->s->j[0];
+                    }
+                };
+
+                auto *j = start_points.front();
+                start_points.pop();
+
+                while (j->flags.passed_count < 2) {
+                    ++j->flags.passed_count;
+
+                    line.push_back(j->p);
+
+                    if (j->s) {
+                        /* push start point for new shape */
+                        start_points.emplace(j->j[1]);
+
+                        /* go through segment */
+                        j = fn_push_segment(j);
+                        ++j->flags.passed_count;
+                    }
+
+                    if (!j->flags.is_corner) {
+//                        assert(!is_filled_check ||
+//                               is_filled == j->flags.filled_forward);
+                        is_filled = j->flags.filled_forward;
+//                        assert(j->j[1]->flags.is_corner ||
+//                               is_filled == j->j[1]->flags.filled_backward);
+                        is_filled_check = true;
+                    }
+
+                    /* go along boundary */
+                    j = j->j[1];
+
+                    /* check if we have closed the shape */
+                    if (j->p == line.front()) {
+                        line.push_back(j->p);
+                        break;
+                    }
+                }
+
+                if (is_filled && !line.empty())
+                    split_lines.emplace_back(std::move(line));
+            }
+
+            return split_lines;
+        }
+
+      private:
+        [[nodiscard]] junction *find_junction_at(const point_2d &p) noexcept {
+            auto it =
+                std::lower_bound(junctions_.begin(), junctions_.end(), p,
+                                 [this](const junction &j, const point_2d &p) {
+                                     return junction_point_compare(j.p, p);
+                                 });
+            assert(it != junctions_.end());
+            assert(it->p == p);
+            return &(*it);
+        }
+
+        [[nodiscard]] order boundary_order(const point_2d &p) const noexcept {
+            if (p.y >= y_max_) {
+                return eUpper;
+            } else if (p.x >= x_max_) {
+                return eRight;
+            } else if (p.y <= y_min_) {
+                return eBottom;
+            } else if (p.x <= x_min_) {
+                return eLeft;
+            } else {
+                assert(false);
+            }
+        }
+        [[nodiscard]] bool
+        junction_point_compare(const point_2d &j1,
+                               const point_2d &j2) const noexcept {
+            auto o1 = boundary_order(j1), o2 = boundary_order(j2);
+            if (o1 == o2) {
+                switch (o1) {
+                case eUpper:
+                    return j1.x < j2.x;
+                case eRight:
+                    return j1.y < j2.y;
+                case eBottom:
+                    return j2.x < j1.x;
+                case eLeft:
+                    return j2.y < j1.y;
+                }
+            } else {
+                return o1 < o2;
+            }
+        }
+
+        double x_min_, x_max_, y_min_, y_max_;
+        std::vector<junction> junctions_;
+        std::vector<segment> segments_;
+    };
+} // namespace
 
 namespace matplot::detail {
     namespace {
@@ -84,51 +337,46 @@ namespace matplot::detail {
     contour_generator::create_filled_contour(double lower_level,
                                              double upper_level) const {
         contour_generator::vertices_list_type vertices;
-        generate_contours(lower_level, vertices);
-
-        /* to demarcate upper contour lines and lower contour lines */
-        vertices.first.push_back(NaN);
-        vertices.second.push_back(NaN);
-
-        generate_contours(upper_level, vertices);
-
+        generate_filled_contours(lower_level, upper_level, vertices);
         return vertices;
     }
 
-    void contour_generator::generate_contours(double z, contour_generator::vertices_list_type &vertices) const {
-        auto fn_push_contour = [&vertices](const contour& c) {
-          if(c.points.empty())
-              return;
+    void contour_generator::generate_contours(
+        double z, contour_generator::vertices_list_type &vertices) const {
+        auto fn_push_contour = [&vertices](const contour &c) {
+            if (c.points.empty())
+                return;
 
-          vertices.first.reserve(vertices.first.size() + c.points.size() + 1);
-          vertices.second.reserve(vertices.second.size() + c.points.size() + 1);
+            vertices.first.reserve(vertices.first.size() + c.points.size() + 1);
+            vertices.second.reserve(vertices.second.size() + c.points.size() +
+                                    1);
 
-          for (auto point : c.points) {
-              vertices.first.push_back(point.x);
-              vertices.second.push_back(point.y);
-          }
-          vertices.first.push_back(NaN);
-          vertices.second.push_back(NaN);
+            for (auto point : c.points) {
+                vertices.first.push_back(point.x);
+                vertices.second.push_back(point.y);
+            }
+            vertices.first.push_back(NaN);
+            vertices.second.push_back(NaN);
         };
 
         size_t num_active = activate_edges(z);
 
         /* first look for contours that end on a boundary */
-        for(auto & e : edges_) {
-            if(e.flags.on_boundary && e.flags.active)
+        for (auto &e : edges_) {
+            if (e.flags.on_boundary && e.flags.active)
                 fn_push_contour(trace_contour(z, num_active, e));
-            if(num_active == 0)
+            if (num_active == 0)
                 break;
         }
 
         /* lastly look for closed contours */
-        for(auto & e : edges_) {
-            if(e.flags.active) {
+        for (auto &e : edges_) {
+            if (e.flags.active) {
                 /* shouldn't have any left on a boundary */
                 assert(!e.flags.on_boundary);
                 fn_push_contour(trace_contour(z, num_active, e));
             }
-            if(num_active == 0)
+            if (num_active == 0)
                 break;
         }
     }
@@ -244,6 +492,123 @@ namespace matplot::detail {
         }
     }
 
+    void contour_generator::generate_filled_contours(
+        double z_lower, double z_upper,
+        contour_generator::vertices_list_type &vertices) const {
+        auto fn_push_contour = [&vertices](const contour &c) {
+            if (c.points.empty())
+                return;
+
+            vertices.first.reserve(vertices.first.size() + c.points.size() + 1);
+            vertices.second.reserve(vertices.second.size() + c.points.size() +
+                                    1);
+
+            for (auto point : c.points) {
+                vertices.first.push_back(point.x);
+                vertices.second.push_back(point.y);
+            }
+            vertices.first.push_back(NaN);
+            vertices.second.push_back(NaN);
+        };
+
+        rect_splitter rs(x_min_, x_max_, y_min_, y_max_);
+
+        {
+            std::vector<contour_line_segment> boundary_segments;
+            auto fn_push_segment = [this, z_lower, z_upper, &boundary_segments](
+                                       const contour &c, double z) {
+                /* this should only be used for contour lines that cross the
+                 * boundary lines*/
+                assert(!c.closed);
+                assert(z == z_lower || z == z_upper);
+
+                if (c.points.empty())
+                    return;
+
+                contour_line_segment seg;
+                seg.segment.resize(c.points.size());
+                std::transform(c.points.begin(), c.points.end(),
+                               seg.segment.begin(),
+                               [](const contour::point &p) {
+                                   return point_2d{p.x, p.y};
+                               });
+                std::transform(
+                    std::begin(c.boundary_edges), std::end(c.boundary_edges),
+                    std::begin(seg.intersection_edges),
+                    [this, z_lower, z_upper, z](const edge *e) {
+                        assert(e->flags.horizontal || e->flags.vertical);
+                        assert(z == z_lower || z == z_upper);
+
+                        contour_line_segment::edge ce{};
+                        ce.p[0] = {x_[e->p[0]], y_[e->p[0]]};
+                        ce.p[1] = {x_[e->p[1]], y_[e->p[1]]};
+
+                        double z0 = z_[e->p[0]], z1 = z_[e->p[1]];
+                        ce.in_dir[0] = (z == z_upper) ? (z0 < z1) : !(z0 < z1);
+                        ce.in_dir[1] = !ce.in_dir[0];
+
+                        return ce;
+                    });
+
+                boundary_segments.emplace_back(std::move(seg));
+            };
+            auto fn_trace_contours = [this, &fn_push_segment,
+                                      &fn_push_contour](double z) {
+                size_t num_active = activate_edges(z);
+                /* first look for contours that end on a boundary */
+                for (auto &e : edges_) {
+                    if (e.flags.on_boundary && e.flags.active)
+                        fn_push_segment(trace_contour(z, num_active, e), z);
+                    if (num_active == 0)
+                        break;
+                }
+
+                /* lastly look for closed contours */
+                for (auto &e : edges_) {
+                    if (e.flags.active) {
+                        /* shouldn't have any left on a boundary */
+                        assert(!e.flags.on_boundary);
+                        fn_push_contour(trace_contour(z, num_active, e));
+                    }
+                    if (num_active == 0)
+                        break;
+                }
+            };
+
+            /* generate the contour lines */
+            fn_trace_contours(z_lower);
+
+            /* demarcate lower and upper closed contours */
+            vertices.first.push_back(NaN);
+            vertices.second.push_back(NaN);
+
+            /* generate the contour lines */
+            fn_trace_contours(z_upper);
+
+            /* demarcate upper contours and boundary-crossing contours */
+            vertices.first.push_back(NaN);
+            vertices.second.push_back(NaN);
+
+            /* split boundary according to intersection points */
+            rs.init(boundary_segments);
+        }
+
+        /* figure out the filled polygons for contour lines that cross
+         * a boundary */
+        auto boundary_polys = rs.split();
+        for (const auto &poly : boundary_polys) {
+            vertices.first.reserve(vertices.first.size() + poly.size() + 1);
+            vertices.second.reserve(vertices.second.size() + poly.size() + 1);
+
+            for (auto point : poly) {
+                vertices.first.push_back(point.x);
+                vertices.second.push_back(point.y);
+            }
+            vertices.first.push_back(NaN);
+            vertices.second.push_back(NaN);
+        }
+    }
+
     contour_generator::contour
     contour_generator::trace_contour(double z, size_t &num_active,
                                      edge &e) const {
@@ -321,6 +686,10 @@ namespace matplot::detail {
             /* for an open contour we must deactivate the starting edge (we
              * didn't do it initially so we have to do it now) */
             fn_deactivate_edge(*e_start);
+
+            /* we record the intersecting edges (useful for filled contours) */
+            ctr.boundary_edges[0] = e_start;
+            ctr.boundary_edges[1] = e_cur;
         }
 
         return ctr;

--- a/source/matplot/util/contourc.cpp
+++ b/source/matplot/util/contourc.cpp
@@ -117,6 +117,8 @@ namespace matplot::detail {
         for(auto & e : edges_) {
             if(e.flags.on_boundary && e.flags.active)
                 fn_push_contour(trace_contour(z, num_active, e));
+            if(num_active == 0)
+                break;
         }
 
         /* lastly look for closed contours */
@@ -126,6 +128,8 @@ namespace matplot::detail {
                 assert(!e.flags.on_boundary);
                 fn_push_contour(trace_contour(z, num_active, e));
             }
+            if(num_active == 0)
+                break;
         }
     }
 

--- a/source/matplot/util/contourc.cpp
+++ b/source/matplot/util/contourc.cpp
@@ -78,13 +78,15 @@ namespace matplot::detail {
         std::pair<vector_1d, vector_1d> vertices;
 
         auto fn_push_contour = [&vertices](const contour &c) {
-            vertices.first.reserve(vertices.first.size() + c.points.size());
-            vertices.second.reserve(vertices.second.size() + c.points.size());
+            vertices.first.reserve(vertices.first.size() + c.points.size() + 1);
+            vertices.second.reserve(vertices.second.size() + c.points.size() + 1);
 
             for (auto point : c.points) {
                 vertices.first.push_back(point.x);
                 vertices.second.push_back(point.y);
             }
+            vertices.first.push_back(NaN);
+            vertices.second.push_back(NaN);
         };
 
         generation_parameters p{};

--- a/source/matplot/util/contourc.h
+++ b/source/matplot/util/contourc.h
@@ -73,6 +73,8 @@ namespace matplot::detail {
     };
 
     class contour_generator {
+        struct edge;
+
         struct contour {
             struct point {
                 double x, y;
@@ -80,6 +82,7 @@ namespace matplot::detail {
 
             bool closed;
             std::vector<point> points;
+            edge* boundary_edges[2]{};
         };
 
         struct triangle;
@@ -177,6 +180,7 @@ namespace matplot::detail {
         }
         size_t activate_edges(double z) const noexcept;
         void generate_contours(double z, vertices_list_type& vertices) const;
+        void generate_filled_contours(double z_lower, double z_upper, vertices_list_type& vertices) const;
 
         contour::point contour_point(double z, const edge &e) const noexcept {
             /* test if t is out of interval [0:1]

--- a/source/matplot/util/contourc.h
+++ b/source/matplot/util/contourc.h
@@ -179,6 +179,7 @@ namespace matplot::detail {
             return e.flags.active;
         }
         size_t activate_edges(double z) const noexcept;
+        void generate_contours(double z, vertices_list_type& vertices) const;
 
         contour::point contour_point(double z, const edge &e) const noexcept {
             /* test if t is out of interval [0:1]
@@ -190,7 +191,6 @@ namespace matplot::detail {
                     y_[e.p[1]] * t + y_[e.p[0]] * (1 - t)};
         }
         contour trace_contour(double z, size_t &num_active, edge &e) const;
-        contour generate_contour(double z, generation_parameters &p) const;
 
         array_2d<double> x_, y_, z_;
         double x_min_, x_max_, y_min_, y_max_;

--- a/source/matplot/util/contourc.h
+++ b/source/matplot/util/contourc.h
@@ -1,158 +1,11 @@
 //
-// Adapted from
-// https://github.com/matplotlib/matplotlib/blob/master/src/_contour.h
-//          and
-//          https://github.com/matplotlib/matplotlib/blob/master/lib/matplotlib/contour.py
-//
+// Adapted from gnuplot: src/contour.c
 
 #ifndef MATPLOTPLUSPLUS_CONTOURC_H
 #define MATPLOTPLUSPLUS_CONTOURC_H
 
-/*
- * QuadContourGenerator
- * --------------------
- * A QuadContourGenerator generates contours for scalar fields defined on
- * quadrilateral grids.  A single QuadContourGenerator object can create both
- * line contours (at single levels) and filled contours (between pairs of
- * levels) for the same field.
- *
- * A field to be contoured has nx, ny points in the x- and y-directions
- * respectively.  The quad grid is defined by x and y arrays of shape(ny, nx),
- * and the field itself is the z array also of shape(ny, nx).  There is an
- * optional boolean mask; if it exists then it also has shape(ny, nx).  The
- * mask applies to grid points rather than quads.
- *
- * How quads are masked based on the point mask is determined by the boolean
- * 'corner_mask' flag.  If false then any quad that has one or more of its four
- * corner points masked is itself masked.  If true the behaviour is the same
- * except that any quad which has exactly one of its four corner points masked
- * has only the triangular corner (half of the quad) adjacent to that point
- * masked; the opposite triangular corner has three unmasked points and is not
- * masked.
- *
- * By default the entire domain of nx*ny points is contoured together which can
- * result in some very long polygons.  The alternative is to break up the
- * domain into subdomains or 'chunks' of smaller size, each of which is
- * independently contoured.  The size of these chunks is controlled by the
- * 'nchunk' (or 'chunk_size') parameter.  Chunking not only results in shorter
- * polygons but also requires slightly less RAM.  It can result in rendering
- * artifacts though, depending on backend, antialiased flag and alpha value.
- *
- * Notation
- * --------
- * i and j are array indices in the x- and y-directions respectively.  Although
- * a single element of an array z can be accessed using z[j][i] or z(j,i), it
- * is often convenient to use the single quad index z[quad], where
- *     quad = i + j*nx
- * and hence
- *     i = quad % nx
- *     j = quad / nx
- *
- * Rather than referring to x- and y-directions, compass directions are used
- * instead such that W, E, S, N refer to the -x, +x, -y, +y directions
- * respectively.  To move one quad to the E you would therefore add 1 to the
- * quad index, to move one quad to the N you would add nx to the quad index.
- *
- * Cache
- * -----
- * Lots of information that is reused during contouring is stored as single
- * bits in a mesh-sized cache, indexed by quad.  Each quad's cache entry stores
- * information about the quad itself such as if it is masked, and about the
- * point at the SW corner of the quad, and about the W and S edges.  Hence
- * information about each point and each edge is only stored once in the cache.
- *
- * Cache information is divided into two types: that which is constant over the
- * lifetime of the QuadContourGenerator, and that which changes for each
- * contouring operation.  The former is all grid-specific information such
- * as quad and corner masks, and which edges are boundaries, either between
- * masked and non-masked regions or between adjacent chunks.  The latter
- * includes whether points lie above or below the current contour levels, plus
- * some flags to indicate how the contouring is progressing.
- *
- * Line Contours
- * -------------
- * A line contour connects points with the same z-value.  Each point of such a
- * contour occurs on an edge of the grid, at a point linearly interpolated to
- * the contour z-level from the z-values at the end points of the edge.  The
- * direction of a line contour is such that higher values are to the left of
- * the contour, so any edge that the contour passes through will have a left-
- * hand end point with z > contour level and a right-hand end point with
- * z <= contour level.
- *
- * Line contours are of two types.  Firstly there are open line strips that
- * start on a boundary, traverse the interior of the domain and end on a
- * boundary.  Secondly there are closed line loops that occur completely within
- * the interior of the domain and do not touch a boundary.
- *
- * The QuadContourGenerator makes two sweeps through the grid to generate line
- * contours for a particular level.  In the first sweep it looks only for start
- * points that occur on boundaries, and when it finds one it follows the
- * contour through the interior until it finishes on another boundary edge.
- * Each quad that is visited by the algorithm has a 'visited' flag set in the
- * cache to indicate that the quad does not need to be visited again.  In the
- * second sweep all non-visited quads are checked to see if they contain part
- * of an interior closed loop, and again each time one is found it is followed
- * through the domain interior until it returns back to its start quad and is
- * therefore completed.
- *
- * The situation is complicated by saddle quads that have two opposite corners
- * with z >= contour level and the other two corners with z < contour level.
- * These therefore contain two segments of a line contour, and the visited
- * flags take account of this by only being set on the second visit.  On the
- * first visit a number of saddle flags are set in the cache to indicate which
- * one of the two segments has been completed so far.
- *
- * Filled Contours
- * ---------------
- * Filled contours are produced between two contour levels and are always
- * closed polygons.  They can occur completely within the interior of the
- * domain without touching a boundary, following either the lower or upper
- * contour levels.  Those on the lower level are exactly like interior line
- * contours with higher values on the left.  Those on the upper level are
- * reversed such that higher values are on the right.
- *
- * Filled contours can also involve a boundary in which case they consist of
- * one or more sections along a boundary and one or more sections through the
- * interior.  Interior sections can be on either level, and again those on the
- * upper level have higher values on the right.  Boundary sections can remain
- * on either contour level or switch between the two.
- *
- * Once the start of a filled contour is found, the algorithm is similar to
- * that for line contours in that it follows the contour to its end, which
- * because filled contours are always closed polygons will be by returning
- * back to the start.  However, because two levels must be considered, each
- * level has its own set of saddle and visited flags and indeed some extra
- * visited flags for boundary edges.
- *
- * The major complication for filled contours is that some polygons can be
- * holes (with points ordered clockwise) within other polygons (with points
- * ordered anticlockwise).  When it comes to rendering filled contours each
- * non-hole polygon must be rendered along with its zero or more contained
- * holes or the rendering will not be correct.  The filled contour finding
- * algorithm could progress pretty much as the line contour algorithm does,
- * taking each polygon as it is found, but then at the end there would have to
- * be an extra step to identify the parent non-hole polygon for each hole.
- * This is not a particularly onerous task but it does not scale well and can
- * easily dominate the execution time of the contour finding for even modest
- * problems.  It is much better to identity each hole's parent non-hole during
- * the sweep algorithm.
- *
- * This requirement dictates the order that filled contours are identified.  As
- * the algorithm sweeps up through the grid, every time a polygon passes
- * through a quad a ParentCache object is updated with the new possible parent.
- * When a new hole polygon is started, the ParentCache is used to find the
- * first possible parent in the same quad or to the S of it.  Great care is
- * needed each time a new quad is checked to see if a new polygon should be
- * started, as a single quad can have multiple polygon starts, e.g. a quad
- * could be a saddle quad for both lower and upper contour levels, meaning it
- * has four contour line segments passing through it which could all be from
- * different polygons.  The S-most polygon must be started first, then the next
- * S-most and so on until the N-most polygon is started in that quad.
- */
-
-// #include "numpy_cpp.h"
-// https://github.com/matplotlib/matplotlib/blob/master/src/numpy_cpp.h
 #include <array>
+#include <cassert>
 #include <cmath>
 #include <iostream>
 #include <list>
@@ -163,395 +16,190 @@
 #include <stdint.h>
 #include <vector>
 
-namespace matplot {
+namespace matplot::detail {
+    template <typename T> class array_2d {
+        using value_type = T;
+        using size_type = size_t;
+        using data_type = std::vector<value_type>;
 
-    // Edge of a quad including diagonal edges of masked quads if _corner_mask
-    // true.
-    typedef enum {
-        // Listing values here so easier to check for debug purposes.
-        Edge_None = -1,
-        Edge_E = 0,
-        Edge_N = 1,
-        Edge_W = 2,
-        Edge_S = 3,
-        // The following are only used if _corner_mask is true.
-        Edge_NE = 4,
-        Edge_NW = 5,
-        Edge_SW = 6,
-        Edge_SE = 7
-    } Edge;
-
-    // Combination of a quad and an edge of that quad.
-    // An invalid quad edge has quad of -1.
-    struct QuadEdge {
-        QuadEdge();
-
-        QuadEdge(long quad_, Edge edge_);
-
-        bool operator<(const QuadEdge &other) const;
-
-        bool operator==(const QuadEdge &other) const;
-
-        bool operator!=(const QuadEdge &other) const;
-
-        friend std::ostream &operator<<(std::ostream &os,
-                                        const QuadEdge &quad_edge);
-
-        long quad;
-        Edge edge;
-    };
-
-    // 2D point with x,y coordinates.
-    struct XY {
-        XY();
-
-        XY(const double &x_, const double &y_);
-
-        bool operator==(const XY &other) const;
-
-        bool operator!=(const XY &other) const;
-
-        XY operator*(const double &multiplier) const;
-
-        const XY &operator+=(const XY &other);
-
-        const XY &operator-=(const XY &other);
-
-        XY operator+(const XY &other) const;
-
-        XY operator-(const XY &other) const;
-
-        friend std::ostream &operator<<(std::ostream &os, const XY &xy);
-
-        double x, y;
-    };
-
-    // A single line of a contour, which may be a closed line loop or an open
-    // line strip.  Identical adjacent points are avoided using push_back(). A
-    // ContourLine is either a hole (points ordered clockwise) or it is not
-    // (points ordered anticlockwise).  Each hole has a parent ContourLine that
-    // is not a hole; each non-hole contains zero or more child holes.  A
-    // non-hole and its child holes must be rendered together to obtain the
-    // correct results.
-    class ContourLine : public std::vector<XY> {
       public:
-        typedef std::list<ContourLine *> Children;
+        array_2d() : rows_(0), cols_(0), data_() {}
+        array_2d(size_type rows, size_type cols) : array_2d() {
+            resize(rows, cols);
+        }
 
-        ContourLine(bool is_hole);
+        [[nodiscard]] auto begin() noexcept { return data_.begin(); }
+        [[nodiscard]] auto begin() const noexcept { return data_.begin(); }
+        [[nodiscard]] auto end() noexcept { return data_.end(); }
+        [[nodiscard]] auto end() const noexcept { return data_.end(); }
 
-        void add_child(ContourLine *child);
+        void resize(size_type rows, size_type cols) {
+            rows_ = rows * cols > 0 ? rows : 0;
+            cols_ = rows * cols > 0 ? cols : 0;
+            data_.resize(rows_ * cols_);
+        }
 
-        void clear_parent();
+        [[nodiscard]] size_type index(size_type r, size_type c) const noexcept {
+            assert(r < rows_ && c < cols_);
+            return r * cols_ + c;
+        }
 
-        const Children &get_children() const;
+        [[nodiscard]] bool empty() const noexcept { return data_.empty(); }
 
-        const ContourLine *get_parent() const;
+        [[nodiscard]] size_type cols() const noexcept { return cols_; }
+        [[nodiscard]] size_type rows() const noexcept { return rows_; }
+        [[nodiscard]] size_type size() const noexcept { return data_.size(); }
 
-        ContourLine *get_parent();
-
-        bool is_hole() const;
-
-        void push_back(const XY &point);
-
-        void set_parent(ContourLine *parent);
-
-        void write() const;
+        [[nodiscard]] value_type &operator()(size_type r,
+                                             size_type c) noexcept {
+            return data_[index(r, c)];
+        }
+        [[nodiscard]] const value_type &operator()(size_type r,
+                                                   size_type c) const noexcept {
+            return data_[index(r, c)];
+        }
+        [[nodiscard]] value_type &operator[](size_type i) noexcept {
+            assert(i < data_.size());
+            return data_[i];
+        }
+        [[nodiscard]] const value_type &operator[](size_type i) const noexcept {
+            assert(i < data_.size());
+            return data_[i];
+        }
 
       private:
-        bool _is_hole;
-        ContourLine *_parent; // Only set if is_hole, not owned.
-        Children _children;   // Only set if !is_hole, not owned.
+        size_type rows_, cols_;
+        data_type data_;
     };
 
-    // A Contour is a collection of zero or more ContourLines.
-    class Contour : public std::vector<ContourLine *> {
+    class contour_generator {
+        struct contour {
+            struct point {
+                double x, y;
+            };
+
+            bool closed;
+            std::vector<point> points;
+        };
+
+        struct triangle;
+
+        struct edge {
+            size_t p[2];
+            triangle *t[2];
+            struct {
+                bool active : 1;
+                bool on_boundary : 1;
+                bool horizontal : 1;
+                bool vertical : 1;
+                bool diagonal : 1;
+            } flags;
+        };
+
+        struct triangle {
+            edge *e[3];
+        };
+
       public:
-        Contour();
+        contour_generator() = default;
+        contour_generator(const vector_2d &x, const vector_2d &y,
+                          const vector_2d &z);
 
-        virtual ~Contour();
-
-        void delete_contour_lines();
-
-        void write() const;
-    };
-
-    // Single chunk of ContourLine parents, indexed by quad.  As a chunk's
-    // filled contours are created, the ParentCache is updated each time a
-    // ContourLine passes through each quad.  When a new ContourLine is created,
-    // if it is a hole its parent ContourLine is read from the ParentCache by
-    // looking at the start quad, then each quad to the S in turn until a
-    // non-zero ContourLine is found.
-    class ParentCache {
-      public:
-        ParentCache() = default;
-
-        ParentCache(long nx, long x_chunk_points, long y_chunk_points);
-
-        ContourLine *get_parent(long quad);
-
-        void set_chunk_starts(long istart, long jstart);
-
-        void set_parent(long quad, ContourLine &contour_line);
-
-      private:
-        long quad_to_index(long quad) const;
-
-        long _nx;
-        long _x_chunk_points, _y_chunk_points; // Number of points not quads.
-        std::vector<ContourLine *> _lines;     // Not owned.
-        long _istart, _jstart;
-    };
-
-    // See overview of algorithm at top of file.
-    class QuadContourGenerator {
-      public:
-        // using CoordinateArray = numpy::array_view<const double, 2>;
-        using CoordinateArray = vector_2d;
-        // using MaskArray = numpy::array_view<const bool, 2>;
-        using MaskArray = std::array<const bool, 2>;
-
-        // This constructor is just a placeholder
-        // This object will obviously not work
-        QuadContourGenerator() = default;
-
-        // Constructor with optional mask.
-        //   x, y, z: double arrays of shape (ny,nx).
-        //   mask: boolean array, ether empty (if no mask), or of shape (ny,nx).
-        //   corner_mask: flag for different masking behaviour.
-        //   chunk_size: 0 for no chunking, or +ve integer for size of chunks
-        //   that
-        //     the domain is subdivided into.
-        // https://github.com/matplotlib/matplotlib/blob/master/lib/matplotlib/contour.py
-        QuadContourGenerator(const vector_2d &x, const vector_2d &y,
-                             const vector_2d &z, bool corner_mask,
-                             long chunk_size);
-
-        // Create and return polygons for a line (i.e. non-filled) contour at
-        // the specified level.
         using vertices_list_type = std::pair<vector_1d, vector_1d>;
-        vertices_list_type create_contour(const double &level);
+        vertices_list_type create_contour(double level) const;
 
-        // Create and return polygons for a filled contour between the two
-        // specified levels.
         using codes_list_type = std::vector<unsigned char>;
         std::pair<vertices_list_type, codes_list_type>
-        create_filled_contour(const double &lower_level,
-                              const double &upper_level);
+        create_filled_contour(double lower_level, double upper_level) const;
 
       private:
-        // Typedef for following either a boundary of the domain or the
-        // interior; clearer than using a boolean.
-        typedef enum { Boundary, Interior } BoundaryOrInterior;
+        struct generation_parameters {
+            struct {
+                bool closed_contour : 1;
+            } flags;
+            size_t index;
+            size_t num_active;
+        };
 
-        // Typedef for direction of movement from one quad to the next.
-        typedef enum { Dir_Right = -1, Dir_Straight = 0, Dir_Left = +1 } Dir;
+        void calculate_minmax() noexcept;
 
-        // Typedef for a polygon being a hole or not; clearer than using a
-        // boolean.
-        typedef enum { NotHole, Hole } HoleOrNot;
+        edge generate_diagonal_edge(size_t r, size_t c) const noexcept {
+            assert(r < (z_.rows() - 1) && c <= (z_.cols() - 1));
 
-        // Append a C++ ContourLine to the end of a python list.  Used for line
-        // contours where each ContourLine is converted to a separate numpy
-        // array of (x,y) points. Clears the ContourLine too.
-        void append_contour_line_to_vertices(
-            ContourLine &contour_line, vertices_list_type &vertices_list) const;
+            edge e{};
+            e.p[0] = z_.index(r, c);
+            e.p[1] = z_.index(r + 1, c + 1);
+            e.t[0] = nullptr;
+            e.t[1] = nullptr;
+            e.flags.on_boundary = false;
+            e.flags.horizontal = false;
+            e.flags.vertical = false;
+            e.flags.diagonal = true;
 
-        // Append a C++ Contour to the end of two python lists.  Used for filled
-        // contours where each non-hole ContourLine and its child holes are
-        // represented by a numpy array of (x,y) points and a second numpy array
-        // of 'kinds' or 'codes' that indicates where the points array is split
-        // into individual polygons. Clears the Contour too, freeing each
-        // ContourLine as soon as possible for minimum RAM usage.
-        void
-        append_contour_to_vertices_and_codes(Contour &contour,
-                                             vertices_list_type &vertices_list,
-                                             codes_list_type &codes_list) const;
+            return e;
+        }
+        edge generate_horizontal_edge(size_t r, size_t c) const noexcept {
+            assert(r < z_.rows() && c <= (z_.cols() - 1));
 
-        // Return number of chunks that fit in the specified point_count.
-        long calc_chunk_count(long point_count) const;
+            edge e{};
+            e.p[0] = z_.index(r, c);
+            e.p[1] = z_.index(r, c + 1);
+            e.t[0] = nullptr;
+            e.t[1] = nullptr;
+            e.flags.on_boundary = (r == 0 || r == (z_.rows() - 1));
+            e.flags.horizontal = true;
+            e.flags.vertical = false;
+            e.flags.diagonal = false;
 
-        // Return the point on the specified QuadEdge that intersects the
-        // specified level.
-        XY edge_interp(const QuadEdge &quad_edge, const double &level);
+            return e;
+        }
+        edge generate_vertical_edge(size_t r, size_t c) const noexcept {
+            assert(r < (z_.rows() - 1) && c <= z_.cols());
 
-        // Follow a contour along a boundary, appending points to the
-        // ContourLine as it progresses.  Only called for filled contours. Stops
-        // when the contour leaves the boundary to move into the interior of the
-        // domain, or when the start_quad_edge is reached in which case the
-        // ContourLine is a completed closed loop.  Always adds the end point of
-        // each boundary edge to the ContourLine, regardless of whether moving
-        // to another boundary edge or leaving the boundary into the interior.
-        // Never adds the start point of the first boundary edge to the
-        // ContourLine.
-        //   contour_line: ContourLine to append points to.
-        //   quad_edge: on entry the QuadEdge to start from, on exit the
-        //   QuadEdge
-        //     that is stopped on.
-        //   lower_level: lower contour z-value.
-        //   upper_level: upper contour z-value.
-        //   level_index: level index started on (1 = lower, 2 = upper level).
-        //   start_quad_edge: QuadEdge that the ContourLine started from, which
-        //   is
-        //     used to check if the ContourLine is finished.
-        // Returns the end level_index.
-        unsigned int follow_boundary(ContourLine &contour_line,
-                                     QuadEdge &quad_edge,
-                                     const double &lower_level,
-                                     const double &upper_level,
-                                     unsigned int level_index,
-                                     const QuadEdge &start_quad_edge);
+            edge e{};
+            e.p[0] = z_.index(r, c);
+            e.p[1] = z_.index(r + 1, c);
+            e.t[0] = nullptr;
+            e.t[1] = nullptr;
+            e.flags.on_boundary = (c == 0 || c == (z_.cols() - 1));
+            e.flags.horizontal = false;
+            e.flags.vertical = true;
+            e.flags.diagonal = false;
 
-        // Follow a contour across the interior of the domain, appending points
-        // to the ContourLine as it progresses.  Called for both line and filled
-        // contours.  Stops when the contour reaches a boundary or, if the
-        // start_quad_edge is specified, when quad_edge == start_quad_edge and
-        // level_index == start_level_index.  Always adds the end point of each
-        // quad traversed to the ContourLine; only adds the start point of the
-        // first quad if want_initial_point flag is true.
-        //   contour_line: ContourLine to append points to.
-        //   quad_edge: on entry the QuadEdge to start from, on exit the
-        //   QuadEdge
-        //     that is stopped on.
-        //   level_index: level index started on (1 = lower, 2 = upper level).
-        //   level: contour z-value.
-        //   want_initial_point: whether want to append the initial point to the
-        //     ContourLine or not.
-        //   start_quad_edge: the QuadEdge that the ContourLine started from to
-        //     check if the ContourLine is finished, or 0 if no check should
-        //     occur.
-        //   start_level_index: the level_index that the ContourLine started
-        //   from. set_parents: whether should set ParentCache as it progresses
-        //   or not.
-        //     This is true for filled contours, false for line contours.
-        void follow_interior(ContourLine &contour_line, QuadEdge &quad_edge,
-                             unsigned int level_index, const double &level,
-                             bool want_initial_point,
-                             const QuadEdge *start_quad_edge,
-                             unsigned int start_level_index, bool set_parents);
+            return e;
+        }
+        void generate_edges_and_triangles();
 
-        // Return the index limits of a particular chunk.
-        void get_chunk_limits(long ijchunk, long &ichunk, long &jchunk,
-                              long &istart, long &iend, long &jstart,
-                              long &jend);
+        inline bool activate_edge(double z,
+                                  contour_generator::edge &e) const noexcept {
+            /* use the same test at both vertices to avoid roundoff errors */
+            if ((z_[e.p[0]] >= z) != (z_[e.p[1]] >= z))
+                e.flags.active = true;
 
-        // Check if a contour starts within the specified corner quad on the
-        // specified level_index, and if so return the start edge.  Otherwise
-        // return Edge_None.
-        Edge get_corner_start_edge(long quad, unsigned int level_index) const;
+            return e.flags.active;
+        }
+        size_t activate_edges(double z) const noexcept;
 
-        // Return index of point at start or end of specified QuadEdge, assuming
-        // anticlockwise ordering around non-masked quads.
-        long get_edge_point_index(const QuadEdge &quad_edge, bool start) const;
+        contour::point contour_point(double z, const edge &e) const noexcept {
+            /* test if t is out of interval [0:1]
+             * (should not happen but who knows ...) */
+            double t = (z - z_[e.p[0]]) / (z_[e.p[1]] - z_[e.p[0]]);
+            t = std::clamp(t, 0.0, 1.0);
 
-        // Return the edge to exit a quad from, given the specified entry
-        // quad_edge and direction to move in.
-        Edge get_exit_edge(const QuadEdge &quad_edge, Dir dir) const;
+            return {x_[e.p[1]] * t + x_[e.p[0]] * (1 - t),
+                    y_[e.p[1]] * t + y_[e.p[0]] * (1 - t)};
+        }
+        contour trace_contour(double z, size_t &num_active, edge &e) const;
+        contour generate_contour(double z, generation_parameters &p) const;
 
-        // Return the (x,y) coordinates of the specified point index.
-        XY get_point_xy(long point) const;
-
-        // Return the z-value of the specified point index.
-        const double &get_point_z(long point) const;
-
-        // Check if a contour starts within the specified non-corner quad on the
-        // specified level_index, and if so return the start edge.  Otherwise
-        // return Edge_None.
-        Edge get_quad_start_edge(long quad, unsigned int level_index) const;
-
-        // Check if a contour starts within the specified quad, whether it is a
-        // corner or a full quad, and if so return the start edge.  Otherwise
-        // return Edge_None.
-        Edge get_start_edge(long quad, unsigned int level_index) const;
-
-        // Initialise the cache to contain grid information that is constant
-        // across the lifetime of this object, i.e. does not vary between calls
-        // to create_contour() and create_filled_contour().
-        void init_cache_grid();
-
-        // Initialise the cache with information that is specific to contouring
-        // the specified two levels.  The levels are the same for contour lines,
-        // different for filled contours.
-        void init_cache_levels(const double &lower_level,
-                               const double &upper_level);
-
-        // Return the (x,y) point at which the level intersects the line
-        // connecting the two specified point indices.
-        XY interp(long point1, long point2, const double &level) const;
-
-        // Return true if the specified QuadEdge is a boundary, i.e. is either
-        // an edge between a masked and non-masked quad/corner or is a chunk
-        // boundary.
-        bool is_edge_a_boundary(const QuadEdge &quad_edge) const;
-
-        // Follow a boundary from one QuadEdge to the next in an anticlockwise
-        // manner around the non-masked region.
-        void move_to_next_boundary_edge(QuadEdge &quad_edge) const;
-
-        // Move from the quad specified by quad_edge.quad to the neighbouring
-        // quad by crossing the edge specified by quad_edge.edge.
-        void move_to_next_quad(QuadEdge &quad_edge) const;
-
-        // Check for filled contours starting within the specified quad and
-        // complete any that are found, appending them to the specified Contour.
-        void single_quad_filled(Contour &contour, long quad,
-                                const double &lower_level,
-                                const double &upper_level);
-
-        // Start and complete a filled contour line.
-        //   quad: index of quad to start ContourLine in.
-        //   edge: edge of quad to start ContourLine from.
-        //   start_level_index: the level_index that the ContourLine starts
-        //   from. hole_or_not: whether the ContourLine is a hole or not.
-        //   boundary_or_interior: whether the ContourLine starts on a boundary
-        //   or
-        //     the interior.
-        //   lower_level: lower contour z-value.
-        //   upper_level: upper contour z-value.
-        // Returns newly created ContourLine.
-        ContourLine *start_filled(long quad, Edge edge,
-                                  unsigned int start_level_index,
-                                  HoleOrNot hole_or_not,
-                                  BoundaryOrInterior boundary_or_interior,
-                                  const double &lower_level,
-                                  const double &upper_level);
-
-        // Start and complete a line contour that both starts and end on a
-        // boundary, traversing the interior of the domain.
-        //   vertices_list: Python list that the ContourLine should be appended
-        //   to. quad: index of quad to start ContourLine in. edge: boundary
-        //   edge to start ContourLine from. level: contour z-value.
-        // Returns true if the start quad does not need to be visited again,
-        // i.e. VISITED(quad,1).
-        bool start_line(vertices_list_type &vertices_list, long quad, Edge edge,
-                        const double &level);
-
-        // Debug function that writes the cache status to stdout.
-        void write_cache(bool grid_only = false) const;
-
-        // Debug function that writes that cache status for a single quad to
-        // stdout.
-        void write_cache_quad(long quad, bool grid_only) const;
-
-        // Note that mask is not stored as once it has been used to initialise
-        // the cache it is no longer needed.
-        CoordinateArray _x, _y, _z;
-        long _nx, _ny; // Number of points in each direction.
-        long _n;       // Total number of points (and hence quads).
-
-        bool _corner_mask;
-        long _chunk_size; // Number of quads per chunk (not points).
-        // Always > 0, unlike python nchunk which is 0
-        //     for no chunking.
-
-        long _nxchunk, _nychunk; // Number of chunks in each direction.
-        long _chunk_count;       // Total number of chunks.
-
-        typedef uint32_t CacheItem;
-        std::vector<CacheItem> _cache;
-
-        ParentCache _parent_cache; // On W quad sides.
+        array_2d<double> x_, y_, z_;
+        double x_min_, x_max_, y_min_, y_max_;
+        mutable std::vector<edge> edges_;
+        std::vector<triangle> triangles_;
     };
+} // namespace matplot::detail
 
+namespace matplot {
     /// Segments are considered as including their end-points; i.e if the
     //            closest point on the path is a node in *xys* with index *i*,
     //            this

--- a/source/matplot/util/contourc.h
+++ b/source/matplot/util/contourc.h
@@ -107,10 +107,7 @@ namespace matplot::detail {
 
         using vertices_list_type = std::pair<vector_1d, vector_1d>;
         vertices_list_type create_contour(double level) const;
-
-        using codes_list_type = std::vector<unsigned char>;
-        std::pair<vertices_list_type, codes_list_type>
-        create_filled_contour(double lower_level, double upper_level) const;
+        vertices_list_type create_filled_contour(double lower_level, double upper_level) const;
 
       private:
         struct generation_parameters {

--- a/source/matplot/util/contourc.h
+++ b/source/matplot/util/contourc.h
@@ -82,7 +82,7 @@ namespace matplot::detail {
 
             bool closed;
             std::vector<point> points;
-            edge* boundary_edges[2]{};
+            edge *boundary_edges[2]{};
         };
 
         struct triangle;
@@ -110,7 +110,8 @@ namespace matplot::detail {
 
         using vertices_list_type = std::pair<vector_1d, vector_1d>;
         vertices_list_type create_contour(double level) const;
-        vertices_list_type create_filled_contour(double lower_level, double upper_level) const;
+        vertices_list_type create_filled_contour(double lower_level,
+                                                 double upper_level) const;
 
       private:
         struct generation_parameters {
@@ -179,8 +180,9 @@ namespace matplot::detail {
             return e.flags.active;
         }
         size_t activate_edges(double z) const noexcept;
-        void generate_contours(double z, vertices_list_type& vertices) const;
-        void generate_filled_contours(double z_lower, double z_upper, vertices_list_type& vertices) const;
+        void generate_contours(double z, vertices_list_type &vertices) const;
+        void generate_filled_contours(double z_lower, double z_upper,
+                                      vertices_list_type &vertices) const;
 
         contour::point contour_point(double z, const edge &e) const noexcept {
             /* test if t is out of interval [0:1]


### PR DESCRIPTION
This implementation is based on gnuplot's contour generation implementation. 
This also fixes #52.

Given the (x,y,z) points, we generate a mesh of edges and triangles for the (x,y) grid. To generate a contour for a given level, first we go through all edges and mark them if the edge crosses the given z-plane. Finally, we trace the contour line by picking a marked edge and following through adjacent triangles to other marked edges until we either hit the grid boundary or we close the contour line.

Filled contour generation is not implemented yet so this PR isn't ready for merging.