### PR TITLE
Support back to GCC 7

### DIFF
--- a/examples/data_distribution/binscatter/binscatter_2.cpp
+++ b/examples/data_distribution/binscatter/binscatter_2.cpp
@@ -12,8 +12,8 @@ int main() {
 
     auto x = randn(1e6, 0, 1);
     auto y = transform(x, [](double x) { return 2 * x + randn(0, 1); });
-    std::vector x_line(x.begin(), x.begin() + 1000);
-    std::vector y_line(y.begin(), y.begin() + 1000);
+    std::vector<double> x_line(x.begin(), x.begin() + 1000);
+    std::vector<double> y_line(y.begin(), y.begin() + 1000);
 
     subplot(2, 3, 0);
     scatter(x_line, y_line);

--- a/source/matplot/CMakeLists.txt
+++ b/source/matplot/CMakeLists.txt
@@ -1,4 +1,23 @@
-find_package(Filesystem REQUIRED)
+find_package(Filesystem REQUIRED COMPONENTS Final Experimental)
+
+# generate filesystem compatibility header
+file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/matplot)
+set(FS_COMPAT_HEADER ${CMAKE_CURRENT_BINARY_DIR}/matplot/std_filesystem.h)
+
+if(CXX_FILESYSTEM_IS_EXPERIMENTAL)
+    set(STD_FS_INCLUDE "experimental/filesystem")
+    set(STD_FS_NAMESPACE "std::experimental::filesystem")
+else()
+    set(STD_FS_INCLUDE "filesystem")
+    set(STD_FS_NAMESPACE "std::filesystem")
+endif()
+
+file(GENERATE OUTPUT ${FS_COMPAT_HEADER}
+    CONTENT "#include <${STD_FS_INCLUDE}>
+namespace matplot
+{
+namespace fs = ${STD_FS_NAMESPACE};
+}")
 
 add_library(matplot
         matplot.h
@@ -83,12 +102,14 @@ add_library(matplot
         freestanding/histcounts.h
         freestanding/histcounts.cpp
         freestanding/plot.h
+
+        ${FS_COMPAT_HEADER}
 )
 
 target_include_directories(matplot
     PUBLIC $<BUILD_INTERFACE:${MATPLOT_ROOT_DIR}/source>
+           $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
            $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
-
 target_link_libraries(matplot
     PRIVATE cimg nodesoup std::filesystem)
 
@@ -102,7 +123,17 @@ if(MSVC)
     target_compile_options(matplot PUBLIC /wd4305)
     # Fix compile error caused by utf8 character in line_spec.cpp
     target_compile_options(matplot PUBLIC /utf-8)
+
 endif()
+
+if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+    if(${CMAKE_CXX_COMPILER_VERSION} VERSION_LESS 7.3)
+        # In GCC<7.3, std::string_view(const char*) is not properly constexpr.
+        # See https://github.com/seqan/seqan3/issues/1202
+        target_compile_definitions(matplot PRIVATE STRING_VIEW_CONSTEXPR_BUG=1)
+    endif()
+endif()
+
 
 include(CheckSymbolExists)
 
@@ -123,21 +154,13 @@ endif()
 if (BUILD_FOR_DOCUMENTATION_IMAGES)
     message("Building matplot for documentation images. wait() commands will be ignored. ~figure will save the files.")
     target_compile_definitions(matplot PUBLIC MATPLOT_BUILD_FOR_DOCUMENTATION_IMAGES)
-endif ()
+endif()
 
 if (BUILD_HIGH_RESOLUTION_WORLD_MAP)
     target_compile_definitions(matplot PUBLIC MATPLOT_BUILD_HIGH_RESOLUTION_WORLD_MAP)
-else ()
+else()
     message("Not including the high resolution maps for geoplots")
-endif ()
-
-if (BUILD_WITH_PEDANTIC_WARNINGS)
-    if (MSVC)
-        target_compile_options(matplot PRIVATE /W4 /WX)
-    else ()
-        target_compile_options(matplot PRIVATE -Wall -Wextra -pedantic -Werror)
-    endif ()
-endif ()
+endif()
 
 if (BUILD_EXPERIMENTAL_OPENGL_BACKEND)
     # Library for the OpenGL example
@@ -183,7 +206,7 @@ if (BUILD_EXPERIMENTAL_OPENGL_BACKEND)
         CPMAddPackage(NAME glad GIT_REPOSITORY https://github.com/Dav1dde/glad GIT_TAG df8e9e16110b305479a875399cee13daa0ccadd9 VERSION 0.1.33)
     endif()
 
-    find_package(glfw3 REQUIRED)
+    find_package(glfw3 REQUIRED CONFIG)
 
     add_library(matplot_opengl
             backend/opengl_embed.h
@@ -196,24 +219,19 @@ endif()
 
 
 # Install
-if (BUILD_INSTALLER)
-    # Install targets
+if(MASTER_PROJECT)
     install(TARGETS matplot
-            EXPORT Matplot++Targets
-            LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-            ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
-            )
-
-    # Install headers
+        EXPORT Matplot++Targets
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
     install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-            DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
-            FILES_MATCHING PATTERN "*.h"
-            )
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+        FILES_MATCHING PATTERN "*.h")
+    install(FILES ${FS_COMPAT_HEADER} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 
-    # Install cmake script
+
     install(EXPORT Matplot++Targets
-            FILE Matplot++Targets.cmake
-            NAMESPACE Matplot++::
-            DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/Matplot++
-            )
+        FILE Matplot++Targets.cmake
+        NAMESPACE Matplot++::
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/Matplot++)
 endif()

--- a/source/matplot/CMakeLists.txt
+++ b/source/matplot/CMakeLists.txt
@@ -162,6 +162,14 @@ else()
     message("Not including the high resolution maps for geoplots")
 endif()
 
+if (BUILD_WITH_PEDANTIC_WARNINGS)
+    if (MSVC)
+        target_compile_options(matplot PRIVATE /W4 /WX)
+    else ()
+        target_compile_options(matplot PRIVATE -Wall -Wextra -pedantic -Werror)
+    endif ()
+endif ()
+
 if (BUILD_EXPERIMENTAL_OPENGL_BACKEND)
     # Library for the OpenGL example
     # This is an example of what an OpenGL backend *could* look like.
@@ -219,19 +227,27 @@ endif()
 
 
 # Install
-if(MASTER_PROJECT)
+if (BUILD_INSTALLER)
+    # Install targets
     install(TARGETS matplot
         EXPORT Matplot++Targets
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        )
+
+    # Install headers
     install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
         DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
-        FILES_MATCHING PATTERN "*.h")
-    install(FILES ${FS_COMPAT_HEADER} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+        FILES_MATCHING PATTERN "*.h"
+        )
+    install(FILES ${FS_COMPAT_HEADER}
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+        )
 
-
+    # Install cmake script
     install(EXPORT Matplot++Targets
         FILE Matplot++Targets.cmake
         NAMESPACE Matplot++::
-        DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/Matplot++)
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/Matplot++
+        )
 endif()

--- a/source/matplot/backend/gnuplot.cpp
+++ b/source/matplot/backend/gnuplot.cpp
@@ -3,7 +3,7 @@
 //
 
 #include "gnuplot.h"
-#include <filesystem>
+#include <matplot/std_filesystem.h>
 #include <iostream>
 #include <matplot/util/common.h>
 #include <matplot/util/popen.h>
@@ -71,6 +71,12 @@ namespace matplot::backend {
 
     const std::string &gnuplot::output_format() { return terminal_; }
 
+#ifdef STRING_VIEW_CONSTEXPR_BUG
+#define SV_CONSTEXPR
+#else
+#define SV_CONSTEXPR constexpr
+#endif
+
     bool gnuplot::output(const std::string &filename) {
         if (filename.empty()) {
             output_ = filename;
@@ -79,12 +85,11 @@ namespace matplot::backend {
         }
 
         // look at the extension
-        namespace fs = std::filesystem;
         fs::path p{filename};
         std::string ext = p.extension().string();
 
         // check terminal for that extension
-        constexpr auto exts = extension_terminal();
+        SV_CONSTEXPR auto exts = extension_terminal();
         auto it = std::find_if(exts.begin(), exts.end(),
                                [&](const auto &e) { return e.first == ext; });
 
@@ -115,7 +120,7 @@ namespace matplot::backend {
         }
 
         // Check if file format is valid
-        constexpr auto exts = extension_terminal();
+        SV_CONSTEXPR auto exts = extension_terminal();
         auto it = std::find_if(exts.begin(), exts.end(), [&](const auto &e) {
             return e.second == format;
         });
@@ -127,7 +132,6 @@ namespace matplot::backend {
         }
 
         // Create file if it does not exist
-        namespace fs = std::filesystem;
         fs::path p{filename};
         if (!p.parent_path().empty() && !fs::exists(p.parent_path())) {
             fs::create_directory(p.parent_path());
@@ -306,7 +310,7 @@ namespace matplot::backend {
     }
 
     bool gnuplot::terminal_has_title_option(const std::string &t) {
-        constexpr std::string_view whitelist[] = {
+        SV_CONSTEXPR std::string_view whitelist[] = {
             "qt", "aqua", "caca", "canvas", "windows", "wxt", "x11"};
         return std::find(std::begin(whitelist), std::end(whitelist), t) !=
                std::end(whitelist);
@@ -316,7 +320,7 @@ namespace matplot::backend {
         // Terminals that have the size option *in the way we expect it to work*
         // This includes only the size option with {width, height} and not
         // the size option for cropping or scaling
-        constexpr std::string_view whitelist[] = {
+        SV_CONSTEXPR std::string_view whitelist[] = {
             "qt",      "aqua",     "caca",    "canvas", "eepic",
             "emf",     "gif",      "jpeg",    "pbm",    "png",
             "sixelgd", "tkcanvas", "windows", "wxt",    "svg"};
@@ -325,13 +329,13 @@ namespace matplot::backend {
     }
 
     bool gnuplot::terminal_has_position_option(const std::string &t) {
-        constexpr std::string_view whitelist[] = {"qt", "windows", "wxt"};
+        SV_CONSTEXPR std::string_view whitelist[] = {"qt", "windows", "wxt"};
         return std::find(std::begin(whitelist), std::end(whitelist), t) !=
                std::end(whitelist);
     }
 
     bool gnuplot::terminal_has_enhanced_option(const std::string &t) {
-        constexpr std::string_view whitelist[] = {
+        SV_CONSTEXPR std::string_view whitelist[] = {
             "canvas",     "postscript", "qt",       "aqua",     "caca",
             "canvas",     "dumb",       "emf",      "enhanced", "jpeg",
             "pdf",        "pdfcairo",   "pm",       "png",      "pngcairo",
@@ -342,7 +346,7 @@ namespace matplot::backend {
     }
 
     bool gnuplot::terminal_has_color_option(const std::string &t) {
-        constexpr std::string_view whitelist[] = {
+        SV_CONSTEXPR std::string_view whitelist[] = {
             "postscript", "aifm",     "caca",     "cairolatex", "context",
             "corel",      "eepic",    "emf",      "epscairo",   "epslatex",
             "fig",        "lua tikz", "mif",      "mp",         "pbm",
@@ -357,7 +361,7 @@ namespace matplot::backend {
         // and terminals for which we want to use only the default fonts
         // We prefer a blacklist because it's better to get a warning
         // in a false positive than remove the fonts in a false negative.
-        constexpr std::string_view blacklist[] = {
+        SV_CONSTEXPR std::string_view blacklist[] = {
             "dxf",      "eepic",   "emtex",   "hpgl",    "latex",
             "mf",       "pcl5",    "pslatex", "pstex",   "pstricks",
             "qms",      "tek40xx", "tek410x", "texdraw", "tkcanvas",

--- a/source/matplot/backend/opengl.h
+++ b/source/matplot/backend/opengl.h
@@ -6,6 +6,7 @@
 #define MATPLOTPLUSPLUS_OPENGL_H
 
 #include <thread>
+#include <mutex>
 #include <matplot/backend/opengl_embed.h>
 
 namespace matplot::backend {

--- a/source/matplot/util/world_map_110m.cpp
+++ b/source/matplot/util/world_map_110m.cpp
@@ -10528,7 +10528,7 @@ namespace matplot {
                 -84.472517999202552,
                 -84.71338
         };
-        return std::make_pair(std::vector(std::begin(x), std::end(x)), std::vector(std::begin(y), std::end(y)));
+        return std::make_pair(std::vector<double>(std::begin(x), std::end(x)), std::vector<double>(std::begin(y), std::end(y)));
 	}
 
     std::pair<std::vector<double>, std::vector<double>>& world_map_110m() {

--- a/source/matplot/util/world_map_50m.cpp
+++ b/source/matplot/util/world_map_50m.cpp
@@ -123703,7 +123703,7 @@ std::numeric_limits<double>::quiet_NaN(),
 -84.268359375000017,
 -84.3515625,
 };
-        return std::make_pair(std::vector(std::begin(x), std::end(x)), std::vector(std::begin(y), std::end(y)));
+        return std::make_pair(std::vector<double>(std::begin(x), std::end(x)), std::vector<double>(std::begin(y), std::end(y)));
 	}
 
     std::pair<std::vector<double>, std::vector<double>>& world_map_50m() {

--- a/test/generate_examples/CMakeLists.txt
+++ b/test/generate_examples/CMakeLists.txt
@@ -1,4 +1,9 @@
-find_package(Filesystem REQUIRED)
-add_executable(generate_examples main.cpp)
-target_link_libraries(generate_examples std::filesystem)
-target_compile_features(generate_examples PRIVATE cxx_std_17)
+find_package(Filesystem REQUIRED COMPONENTS Final Experimental)
+
+if(CXX_FILESYSTEM_IS_EXPERIMENTAL)
+	message(WARNING "Only std::experimental::filesystem is available, cannot build generate_examples")
+else()
+	add_executable(generate_examples main.cpp)
+	target_link_libraries(generate_examples std::filesystem)
+	target_compile_features(generate_examples PRIVATE cxx_std_17)
+endif()


### PR DESCRIPTION
I'm really loving this library so far, but it can be a bit troublesome to install because it requires GCC 8.1 or newer, which isn't readily available on all distros/machines.  This PR adds support for back to GCC 7.1 and possibly even older versions (don't have a machine readily available to test).

The biggest change was related to std::filesystem.  This PR allows CMake to find the old libstdc++ std::experimental::filesystem implementation, and introduces a new generated header (`matplot/std_filesystem.h`) to automatically include the correct library.  std::experimental::filesystem is mostly compatible with std::filesystem, but it's missing the `path::lexically_proximate()` function and a few others.  So, the matplot library builds fine but I had to disable generate_examples for gcc 7.x.

There were also a few other changes, mainly dealing with a constexpr related bug and helping the compiler out with some types it couldn't deduce.

With these changes, the library builds and works fine on GCC 7.1, land it has never gone before!  Hope this is useful.