### PR TITLE
add archlinux install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2093,6 +2093,25 @@ brew install matplotplusplus
 
 This formula is a [contribution](https://github.com/Homebrew/homebrew-core/pull/62577) to [Homebrew](https://github.com/Homebrew/homebrew-core) by [Andrew Kane](https://github.com/ankane).  
 
+#### Arch Linux
+
+Matplot++ is available in the Arch User Repository
+([AUR](https://wiki.archlinux.org/index.php/Arch_User_Repository)) as
+[`matplotplusplus`](https://aur.archlinux.org/packages/matplotplusplus/).
+
+Note you can manually install the package by following the instructions on the
+[Arch Wiki](https://wiki.archlinux.org/index.php/Arch_User_Repository#Installing_packages)
+or use an [AUR helper](https://wiki.archlinux.org/index.php/AUR_helpers) like
+[`yay`](https://aur.archlinux.org/packages/yay/)
+(recommended for ease of install).
+
+```bash
+yay -S matplotplusplus
+```
+
+To discuss any issues related to this package refer to the comments section on
+the AUR page of `matplotplusplus` [here](https://aur.archlinux.org/packages/matplotplusplus/).
+
 ### Build from Source
 
 #### Dependencies


### PR DESCRIPTION
This PR adds instructions for natively installing matplotplusplus through the Arch Linux package ecosystem.