### PR TITLE
make bash build examples work

### DIFF
--- a/README.md
+++ b/README.md
@@ -2319,7 +2319,7 @@ This will build the examples in the `build/examples` directory:
 mkdir build
 cd build
 cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS="-O2"
-cmake --build . --config Release
+cmake --build . -j 2 --config Release
 ```
 
 On windows, replace `-O2` with `/O2`.
@@ -2332,7 +2332,7 @@ This will install Matplot++ on your system:
 mkdir build
 cd build
 cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS="-O2" -DBUILD_EXAMPLES=OFF -DBUILD_TESTS=OFF 
-cmake --build . --config Release
+cmake --build . -j 2 --config Release
 cmake --install .
 ```
 
@@ -2346,12 +2346,14 @@ This will create the binary packages you can use to install Matplot++ on your sy
 mkdir build
 cd build
 cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS="-O2" -DBUILD_EXAMPLES=OFF -DBUILD_TESTS=OFF
-cmake --build . --config Release
+cmake --build . -j 2 --config Release
 cmake --install .
 cpack .
 ```
 
 On windows, replace `-O2` with `/O2`. You might need `sudo` for this last command.
+
+
 
 ### CMake targets
 

--- a/README.md
+++ b/README.md
@@ -2317,9 +2317,9 @@ This will build the examples in the `build/examples` directory:
 
 ```bash
 mkdir build
-cmake -version
+cd build
 cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS="-O2"
-cmake --build . -j 2 --config Release
+cmake --build . --config Release
 ```
 
 On windows, replace `-O2` with `/O2`.
@@ -2330,9 +2330,9 @@ This will install Matplot++ on your system:
 
 ```bash
 mkdir build
-cmake -version
+cd build
 cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS="-O2" -DBUILD_EXAMPLES=OFF -DBUILD_TESTS=OFF 
-cmake --build . -j 2 --config Release
+cmake --build . --config Release
 cmake --install .
 ```
 
@@ -2344,9 +2344,9 @@ This will create the binary packages you can use to install Matplot++ on your sy
 
 ```bash
 mkdir build
-cmake -version
+cd build
 cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS="-O2" -DBUILD_EXAMPLES=OFF -DBUILD_TESTS=OFF
-cmake --build . -j 2 --config Release
+cmake --build . --config Release
 cmake --install .
 cpack .
 ```


### PR DESCRIPTION
Hi there, I'm building from source on OS X Catalina and contributing anything I'm finding that might be a hurdle. The bash scripts did not work as listed—possibly you have `mkdir foo` aliased to `mkdir foo; cd foo` on your system?

I had never used the -j option to cmake before—my feeling is that this might confuse unnecessarily and slow down builds on some machines. 
