### PR TITLE
Fix NVCC compilation error

### DIFF
--- a/source/matplot/core/axes_type.h
+++ b/source/matplot/core/axes_type.h
@@ -2789,7 +2789,7 @@ namespace matplot {
             default_color(3), default_color(4), default_color(5),
             default_color(6)};
         size_t colororder_index_{0};
-        std::vector<std::vector<double>> colormap_{palette::default_map()};
+        std::vector<std::vector<double>> colormap_ = {palette::default_map()};
         size_t max_colors_{0}; // limit number of colors in the colormap
 
         // complete box around the axes


### PR DESCRIPTION
When compiling with NVCC a compilation error occurs

`_deps/matplot-src/source/matplot/core/axes_type.h:2790:38: error: ‘colormap_palette’ has not been declared 2790 | std::vector<std::vector<double>> colormap_{palette::default_map()}; `

that really is an error of NVCC, not the code itself, as it compiles just fine with g++. This fixes the error when using NVCC.