### PR TITLE
Reset axis_type directions when clearing axes_type

### DIFF
--- a/source/matplot/core/axes_type.cpp
+++ b/source/matplot/core/axes_type.cpp
@@ -47,7 +47,6 @@ namespace matplot {
         if (next_plot_replace_) {
             children_.clear();
             colororder_index_ = 0;
-            axes_type::clear();
         }
         children_.push_back(obj);
         touch();

--- a/source/matplot/core/axes_type.cpp
+++ b/source/matplot/core/axes_type.cpp
@@ -2318,6 +2318,8 @@ namespace matplot {
     line_handle axes_type::plot(const std::vector<double> &x,
                                 const std::vector<double> &y,
                                 std::string_view line_spec) {
+        this->y_axis().reverse(false);
+        this->minor_grid(false);
         axes_silencer s{this};
         line_handle l = std::make_shared<class line>(this, x, y, line_spec);
         this->emplace_object(l);
@@ -2326,6 +2328,8 @@ namespace matplot {
 
     line_handle axes_type::plot(const std::vector<double> &y,
                                 std::string_view line_spec) {
+        this->y_axis().reverse(false);
+        this->minor_grid(false);
         axes_silencer s{this};
         line_handle l = std::make_shared<class line>(this, y, line_spec);
         this->emplace_object(l);

--- a/source/matplot/core/axes_type.cpp
+++ b/source/matplot/core/axes_type.cpp
@@ -47,6 +47,7 @@ namespace matplot {
         if (next_plot_replace_) {
             children_.clear();
             colororder_index_ = 0;
+            axes_type::clear();
         }
         children_.push_back(obj);
         touch();
@@ -2214,6 +2215,9 @@ namespace matplot {
         y_axis_.limits_mode_auto(true);
         y2_axis_.limits_mode_auto(true);
         z_axis_.limits_mode_auto(true);
+        axes_type::x_axis().reverse(false);
+        axes_type::y_axis().reverse(false);
+        minor_grid(false);
         touch();
     }
 
@@ -2318,8 +2322,6 @@ namespace matplot {
     line_handle axes_type::plot(const std::vector<double> &x,
                                 const std::vector<double> &y,
                                 std::string_view line_spec) {
-        this->y_axis().reverse(false);
-        this->minor_grid(false);
         axes_silencer s{this};
         line_handle l = std::make_shared<class line>(this, x, y, line_spec);
         this->emplace_object(l);
@@ -2328,8 +2330,6 @@ namespace matplot {
 
     line_handle axes_type::plot(const std::vector<double> &y,
                                 std::string_view line_spec) {
-        this->y_axis().reverse(false);
-        this->minor_grid(false);
         axes_silencer s{this};
         line_handle l = std::make_shared<class line>(this, y, line_spec);
         this->emplace_object(l);


### PR DESCRIPTION
The plot can inherit properties of a heat map and become reversed in Y-axis and have the minor_grid enabled as proposed in the issue #110 . Adding these 2 lines to each plot function solves the issue, but it is a very bad fix in my opinion. Ideally, every class should have a feature where its default settings are reset, otherwise this issue will appear forever.
I propose adding this as a temporary fix, close the #110 issue and create a new issue about objects not resetting their properties upon creation.