### PR TITLE
Fixing MinGW issue due to  MSVC's "_dupenv_s" call

### DIFF
--- a/source/matplot/backend/gnuplot.cpp
+++ b/source/matplot/backend/gnuplot.cpp
@@ -37,7 +37,7 @@ namespace matplot::backend {
 
     gnuplot::gnuplot() {
         // 1st option: terminal in GNUTERM environment variable
-#if defined(_WIN32) || defined(_WIN64) || defined(__MINGW32__) ||              \
+#if defined(_MSC_VER) ||              \
     defined(__CYGWIN__)
         char *environment_terminal;
         size_t len;


### PR DESCRIPTION
Hello everyone,
thank you for this nice library.

I tried to compile the library with mingw on windows and it worked but at linking in my project i witnessed the following error:

> source/matplot/libmatplot.a(gnuplot.cpp.obj):gnuplot.cpp:(.text+0x5921): undefined reference to `__imp__dupenv_s'

I fixed it with the following change since `_dupenv_s` is a Visual Studio only command and therefore mingw should follow the other branch.


I hope this is the correct way to do this PR. Thanks!