### PR TITLE
Fix axis error in axes_type::ylim()

### DIFF
--- a/source/matplot/core/axes_type.cpp
+++ b/source/matplot/core/axes_type.cpp
@@ -2132,7 +2132,7 @@ namespace matplot {
     }
 
     std::array<double, 2> axes_type::ylim() const {
-        if (x_axis_.limits_mode_auto()) {
+        if (y_axis_.limits_mode_auto()) {
             auto [xmin, xmax, ymin, ymax] = this->child_limits();
             return std::array<double, 2>{ymin, ymax};
         } else {


### PR DESCRIPTION
In axes_type::ylim(), x_axis_ should be replaced with y_axis_. Guess this was a copy-paste error.