### PR TITLE
Fix Cygwin installation

### DIFF
--- a/source/matplot/CMakeLists.txt
+++ b/source/matplot/CMakeLists.txt
@@ -256,6 +256,7 @@ if (BUILD_INSTALLER)
     # Install targets
     install(TARGETS matplot
             EXPORT Matplot++Targets
+	    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
             LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
             ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
             )


### PR DESCRIPTION
Fix installation of shared libraries (cygmatplot.dll installation in bin directory) on Cygwin.

Signed-off-by: Pedro Luis Castedo Cepeda <pedroluis.castedo@upm.es>