### PR TITLE
Add Presets for Installation

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,62 @@
+{
+  "version": 3,
+  "cmakeMinimumRequired": {
+    "major": 3,
+    "minor": 19,
+    "patch": 0
+  },
+  "configurePresets": [
+    {
+      "name": "dev",
+      "displayName": "Development Mode",
+      "description": "Build with warnings and debug symbols",
+      "binaryDir": "build",
+      "generator": "Unix Makefiles",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "RelWithDebInfo"
+      }
+    },
+    {
+      "name": "system",
+      "displayName": "Build for system installation",
+      "description": "Bulid for system installation (BUILD_EXAMPLES and BUILD_TESTS are OFF)",
+      "binaryDir": "${sourceDir}/build/system",
+      "generator": "Unix Makefiles",
+      "cacheVariables": {
+        "BUILD_EXAMPLES": "OFF",
+        "BUILD_TESTS": "OFF",
+        "BUILD_SHARED_LIBS": "ON",
+        "CMAKE_BUILD_TYPE": "Release",
+        "CMAKE_INTERPROCEDURAL_OPTIMIZATION": "ON"
+      }
+    },
+    {
+      "name": "local",
+      "displayName":"Build for installation in $HOME/.local",
+      "description": "Build for installaton in $HOME/.local",
+      "inherits": "system",
+      "binaryDir": "${sourceDir}/build/local",
+      "installDir": "$env{HOME}/.local"
+    }
+  ],
+  "buildPresets": [
+    {
+      "name": "dev",
+      "configurePreset": "dev",
+      "configuration": "RelWithDebInfo",
+      "jobs": 8
+    },
+    {
+      "name": "system",
+      "configurePreset": "system",
+      "configuration": "Release",
+      "jobs": 8
+    },
+    {
+      "name": "local",
+      "configurePreset": "local",
+      "configuration": "Release",
+      "jobs": 8
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -210,6 +210,71 @@ Add this header to your source files:
 
 However, in larger projects, it's always recommended to look for Matplot++ with `find_package` before including it as a subdirectory to avoid [ODR errors](https://en.wikipedia.org/wiki/One_Definition_Rule).
 
+#### Install as a Package via CMake
+
+If you have CMake 3.21 or greater, you can use the `system` build preset to 
+build the package system-wide:
+
+```bash
+cmake --preset=system
+cmake --build --preset=system
+sudo cmake --install build/system
+```
+
+Alternatively, if the `CMAKE_PREFIX_PATH` environment variable is set to 
+`$HOME/.local`, then you can install it locally. This can be set in `/etc/profile` 
+or your shell config. This will not affect discovery of packages installed 
+system-wide.
+
+```bash
+export CMAKE_PREFIX_PATH="$HOME/.local"
+```
+
+This has the advantage of not
+requiring sudo, and matplotplusplus will be installed in `$HOME/.local`. 
+
+```bash
+cmake --preset=local
+cmake --build --preset=local
+cmake --install build/local
+```
+
+You can now use it from CMake with `find_package`:
+
+```cmake
+find_package(Matplot++ REQUIRED)
+
+target_link_libraries(<your target> Matplot++::matplot)
+```
+
+If you're using a version of CMake too old to support presets, then building with
+ the system preset is equivilant to:
+
+```bash
+cmake -B build/system         \
+    -DBUILD_EXAMPLES=OFF      \
+    -DBUILD_SHARED_LIBS=ON    \
+    -DBUILD_TESTS=OFF         \
+    -CMAKE_BUILD_TYPE=Release \
+    -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON
+
+cmake --build build/system
+```
+
+While building with the local preset is equivilant to:
+
+```bash
+cmake -B build/local                      \
+    -DBUILD_EXAMPLES=OFF                  \
+    -DBUILD_SHARED_LIBS=ON                \
+    -DBUILD_TESTS=OFF                     \
+    -DCMAKE_BUILD_TYPE=Release            \
+    -DCMAKE_INSTALL_PREFIX="$HOME/.local" \
+    -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON
+
+cmake --build build/local
+```
+
 #### Embed with automatic download
 
 `FetchContent` is a CMake command that can automatically download the Matplot++ repository. Check if you have [Cmake](http://cmake.org) 3.14+ installed:


### PR DESCRIPTION
This commit adds presets for common use cases, including local and
system installation. It also updates the README to explain the use of
these presets and how they can be used for installation.

If you have CMake 3.21 or greater, you can use the `system` build preset to 
build the package system-wide:

```bash
cmake --preset=system
cmake --build --preset=system
sudo cmake --install build/system
```

Alternatively, if the `CMAKE_PREFIX_PATH` environment variable is set to 
`$HOME/.local`, then you can install it locally. This can be set in `/etc/profile` 
or your shell config. This will not affect discovery of packages installed 
system-wide.

```bash
export CMAKE_PREFIX_PATH="$HOME/.local"
```

This has the advantage of not
requiring sudo, and matplotplusplus will be installed in `$HOME/.local`. 

```bash
cmake --preset=local
cmake --build --preset=local
cmake --install build/local
```

If you're using a version of CMake too old to support presets, then building with
 the system preset is equivilant to:

```bash
cmake -B build/system         \
    -DBUILD_EXAMPLES=OFF      \
    -DBUILD_SHARED_LIBS=ON    \
    -DBUILD_TESTS=OFF         \
    -CMAKE_BUILD_TYPE=Release \
    -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON

cmake --build build/system
```

While building with the local preset is equivilant to:

```bash
cmake -B build/local                      \
    -DBUILD_EXAMPLES=OFF                  \
    -DBUILD_SHARED_LIBS=ON                \
    -DBUILD_TESTS=OFF                     \
    -DCMAKE_BUILD_TYPE=Release            \
    -DCMAKE_INSTALL_PREFIX="$HOME/.local" \
    -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON

cmake --build build/local
```