### PR TITLE
Remove block indent from code and images to fix GitHub view

### DIFF
--- a/README.md
+++ b/README.md
@@ -429,15 +429,15 @@ Make sure your C++ compiler supports C++17:
 
 === "Ubuntu + GCC"
 
-    ```bash
-    g++ --version
-    ```
+```bash
+g++ --version
+```
 
 === "Mac Os + Clang"
 
-    ```bash
-    clang --version
-    ```
+```bash
+clang --version
+```
 
 === "Windows + MSVC"
 
@@ -449,15 +449,15 @@ The output should be something like:
 
 === "Ubuntu + GCC"
 
-    ```console
-    g++-8 (Ubuntu 8.4.0-1ubuntu1~18.04) 8.4.0
-    ```
+```console
+g++-8 (Ubuntu 8.4.0-1ubuntu1~18.04) 8.4.0
+```
 
 === "Mac Os + Clang"
 
-    ```console
-    Apple clang version 11.0.0 (clang-1100.0.33.8)
-    ```
+```console
+Apple clang version 11.0.0 (clang-1100.0.33.8)
+```
 
 === "Windows + MSVC"
 
@@ -465,58 +465,57 @@ The output should be something like:
         * Visit the [Visual Studio](https://visualstudio.microsoft.com) website
         * Download Git from [https://git-scm.com/download/win](https://git-scm.com/download/win) and install it
 
-
 If you need to update your compiler:
 
 === "Ubuntu + GCC"
 
-    ```bash
-    # install GCC-8
-    sudo apt update
-    sudo apt install gcc-8
-    sudo apt install g++-8
-    ```
+```bash
+# install GCC-8
+sudo apt update
+sudo apt install gcc-8
+sudo apt install g++-8
+```
 
-    To update to any other version, like GCC-9 or GCC-10:
-    
-    ```bash
-    sudo apt install build-essential
-    sudo add-apt-repository ppa:ubuntu-toolchain-r/test
-    sudo apt-get update
-    sudo apt install g++-10
-    ```
+To update to any other version, like GCC-9 or GCC-10:
 
-    Once you installed a newer version of GCC, you can link it to `update-alternatives`. For instance, if you have GCC-7 and GCC-10, you can link them with:
+```bash
+sudo apt install build-essential
+sudo add-apt-repository ppa:ubuntu-toolchain-r/test
+sudo apt-get update
+sudo apt install g++-10
+```
 
-    ```bash
-    sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-7 7
-    sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-7 7
-    sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 10
-    sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-10 10
-    ```
+Once you installed a newer version of GCC, you can link it to `update-alternatives`. For instance, if you have GCC-7 and GCC-10, you can link them with:
 
-    You can now use `update-alternatives` to set your default `gcc` and `g++` to a more recent version:
+```bash
+sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-7 7
+sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-7 7
+sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 10
+sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-10 10
+```
 
-    ```bash
-    update-alternatives --config g++
-    update-alternatives --config gcc
-    ```
+You can now use `update-alternatives` to set your default `gcc` and `g++` to a more recent version:
+
+```bash
+update-alternatives --config g++
+update-alternatives --config gcc
+```
 
 === "Mac Os + Clang"
 
-    ```bash
-    # download clang
-    curl --output clang.tar.xz -L https://github.com/llvm/llvm-project/releases/download/llvmorg-11.0.0/clang+llvm-11.0.0-x86_64-apple-darwin.tar.xz
-    mkdir clang
-    tar -xvJf clang.tar.xz -C clang
+```bash
+# download clang
+curl --output clang.tar.xz -L https://github.com/llvm/llvm-project/releases/download/llvmorg-11.0.0/clang+llvm-11.0.0-x86_64-apple-darwin.tar.xz
+mkdir clang
+tar -xvJf clang.tar.xz -C clang
 
-    # copy files to /usr/local
-    cd clang/clang+llvm-11.0.0-x86_64-apple-darwin
-    sudo cp -R * /usr/local/
+# copy files to /usr/local
+cd clang/clang+llvm-11.0.0-x86_64-apple-darwin
+sudo cp -R * /usr/local/
 
-    # update default compiler
-    export CXX=/usr/local/bin/clang++
-    ```
+# update default compiler
+export CXX=/usr/local/bin/clang++
+```
 
 === "Windows + MSVC"
 
@@ -530,45 +529,45 @@ Also check your CMake version is at least 3.14+:
 
 === "Ubuntu + GCC"
 
-    ```bash
-    cmake --version
-    ```
+```bash
+cmake --version
+```
 
 === "Mac Os + Clang"
 
-    ```bash
-    cmake --version
-    ```
+```bash
+cmake --version
+```
 
 === "Windows + MSVC"
 
-    ```bash
-    cmake --version
-    ```
+```bash
+cmake --version
+```
 
 If CMake is not installed or its version is older than CMake 3.14, update it with
 
 === "Ubuntu + GCC"
 
-    ```bash
-    sudo apt upgrade cmake
-    ```
+```bash
+sudo apt upgrade cmake
+```
 
     !!! warning ""
         Alternatively, download the most recent version from [cmake.org](https://cmake.org/).
 
 === "Mac Os + Clang"
 
-    ```bash
-    sudo brew upgrade cmake
-    ```
+```bash
+sudo brew upgrade cmake
+```
 
     !!! warning "Homebrew"
         If this command fails because you don't have [Homebrew](https://brew.sh) on your computer, you can install it with
 
-        ```bash
-        /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
-        ```
+```bash
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
+```
 
         or you can follow the instructions in [https://brew.sh](https://brew.sh).
 
@@ -587,10 +586,10 @@ Install Gnuplot 5.2.6+ (Required at runtime)
 
 === "Ubuntu + GCC"
 
-    ```bash
-    sudo apt update
-    sudo apt install gnuplot
-    ```
+```bash
+sudo apt update
+sudo apt install gnuplot
+```
 
     !!! note ""
         Or download the latest version from [www.gnuplot.info](http://www.gnuplot.info). If you're using an installer, make sure you mark the option "Add application directory to your PATH environment variable".
@@ -598,9 +597,9 @@ Install Gnuplot 5.2.6+ (Required at runtime)
 
 === "Mac Os + Clang"
 
-    ```bash
-    sudo brew install gnuplot
-    ```
+```bash
+sudo brew install gnuplot
+```
 
     !!! note ""
         Or download the latest version from [www.gnuplot.info](http://www.gnuplot.info). If you're using an installer, make sure you mark the option "Add application directory to your PATH environment variable".
@@ -650,9 +649,9 @@ If these dependencies are not found, the build script will download them. In any
 
 === "Ubuntu + GCC"
 
-    ```bash
-    sudo apt-get install libglfw3-dev
-    ```
+```bash
+sudo apt-get install libglfw3-dev
+```
 
 === "Mac Os + Clang"
 
@@ -674,30 +673,30 @@ This will build the examples in the `build/examples` directory:
 
 === "Ubuntu + GCC"
 
-    ```bash
-    mkdir build
-    cd build
-    cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS="-O2"
-    sudo cmake --build . --parallel 2 --config Release
-    ```
+```bash
+mkdir build
+cd build
+cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS="-O2"
+sudo cmake --build . --parallel 2 --config Release
+```
 
 === "Mac Os + Clang"
 
-    ```bash
-    mkdir build
-    cd build
-    cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS="-O2"
-    cmake --build . --parallel 2 --config Release
-    ```
+```bash
+mkdir build
+cd build
+cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS="-O2"
+cmake --build . --parallel 2 --config Release
+```
 
 === "Windows + MSVC"
 
-    ```bash
-    mkdir build
-    cd build
-    cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS="/O2"
-    cmake --build . --parallel 2 --config Release
-    ```
+```bash
+mkdir build
+cd build
+cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS="/O2"
+cmake --build . --parallel 2 --config Release
+```
 
 !!! hint "Parallel Build"
 Replace `--parallel 2` with `--parallel <number of cores in your machine>`
@@ -706,9 +705,9 @@ Replace `--parallel 2` with `--parallel <number of cores in your machine>`
 
     If your C++ compiler that supports C++17 is not your default compiler, make sure you provide CMake with the compiler location with the DCMAKE_C_COMPILER and DCMAKE_CXX_COMPILER options. For instance:
 
-    ```bash
-    cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS="-O2" -DCMAKE_C_COMPILER=/usr/bin/gcc-8 -DCMAKE_CXX_COMPILER=/usr/bin/g++-8
-    ```
+```bash
+cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS="-O2" -DCMAKE_C_COMPILER=/usr/bin/gcc-8 -DCMAKE_CXX_COMPILER=/usr/bin/g++-8
+```
 
 **Installing**
 
@@ -716,33 +715,33 @@ You can 1) use `-DBUILD_EXAMPLES=OFF -DBUILD_TESTS=OFF` to bypass the examples a
 
 === "Ubuntu + GCC"
 
-    ```bash
-    mkdir build
-    cd build
-    cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS="-O2" -DBUILD_EXAMPLES=OFF -DBUILD_TESTS=OFF 
-    sudo cmake --build . --parallel 2 --config Release
-    sudo cmake --install .
-    ```
+```bash
+mkdir build
+cd build
+cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS="-O2" -DBUILD_EXAMPLES=OFF -DBUILD_TESTS=OFF 
+sudo cmake --build . --parallel 2 --config Release
+sudo cmake --install .
+```
 
 === "Mac Os + Clang"
 
-    ```bash
-    mkdir build
-    cd build
-    cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS="-O2" -DBUILD_EXAMPLES=OFF -DBUILD_TESTS=OFF 
-    cmake --build . --parallel 2 --config Release
-    cmake --install .
-    ```
+```bash
+mkdir build
+cd build
+cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS="-O2" -DBUILD_EXAMPLES=OFF -DBUILD_TESTS=OFF 
+cmake --build . --parallel 2 --config Release
+cmake --install .
+```
 
 === "Windows + MSVC"
 
-    ```bash
-    mkdir build
-    cd build
-    cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS="/O2" -DBUILD_EXAMPLES=OFF -DBUILD_TESTS=OFF 
-    cmake --build . --parallel 2 --config Release
-    cmake --install .
-    ```
+```bash
+mkdir build
+cd build
+cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS="/O2" -DBUILD_EXAMPLES=OFF -DBUILD_TESTS=OFF 
+cmake --build . --parallel 2 --config Release
+cmake --install .
+```
 
 !!! hint "Parallel Build"
 Replace `--parallel 2` with `--parallel <number of cores in your machine>`
@@ -753,21 +752,21 @@ You can also create the binary packages to install Matplot++ on other systems:
 
 === "Ubuntu + GCC"
 
-    ```bash
-    sudo cpack .
-    ```
+```bash
+sudo cpack .
+```
 
 === "Mac Os + Clang"
 
-    ```bash
-    cpack .
-    ```
+```bash
+cpack .
+```
 
 === "Windows + MSVC"
 
-    ```bash
-    cpack .
-    ```
+```bash
+cpack .
+```
 
 ## Plot Types
 
@@ -799,13 +798,13 @@ Where `x` and `y` are are any value ranges.
 
 === "Plot"
 
-    [![example_plot_1](docs/examples/line_plot/plot/plot_1.svg)](examples/line_plot/plot/plot_1.cpp)
+[![example_plot_1](docs/examples/line_plot/plot/plot_1.svg)](examples/line_plot/plot/plot_1.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/line_plot/plot/plot_1.cpp"
-    ```
+```cpp
+--8<-- "examples/line_plot/plot/plot_1.cpp"
+```
 
 <!-- START mdsplit-ignore -->
 <details>
@@ -818,9 +817,9 @@ Where `x` and `y` are are any value ranges.
 !!! tip
     Setters return a reference to `*this` to allow method chaining:
 
-    ```cpp
-    plot(x,y)->line_width(2).color("red");
-    ```
+```cpp
+plot(x,y)->line_width(2).color("red");
+```
 
 !!! tip
     These examples use free-standing functions to create plots. You can also use a object-oriented style for plots. We discuss these coding styles in the Section [*Coding Styles*](#coding-styles).
@@ -829,123 +828,123 @@ Where `x` and `y` are are any value ranges.
 
 ===! "Plot"
 
-    [![example_plot_2](docs/examples/line_plot/plot/plot_2.svg)](examples/line_plot/plot/plot_2.cpp)
+[![example_plot_2](docs/examples/line_plot/plot/plot_2.svg)](examples/line_plot/plot/plot_2.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/line_plot/plot/plot_2.cpp"
-    ```
+```cpp
+--8<-- "examples/line_plot/plot/plot_2.cpp"
+```
 
 
 ===! "Plot"
 
-    [![example_plot_3](docs/examples/line_plot/plot/plot_3.svg)](examples/line_plot/plot/plot_3.cpp)
+[![example_plot_3](docs/examples/line_plot/plot/plot_3.svg)](examples/line_plot/plot/plot_3.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/line_plot/plot/plot_3.cpp"
-    ```
+```cpp
+--8<-- "examples/line_plot/plot/plot_3.cpp"
+```
 
 
 ===! "Plot"
 
-    [![example_plot_4](docs/examples/line_plot/plot/plot_4.svg)](examples/line_plot/plot/plot_4.cpp)
+[![example_plot_4](docs/examples/line_plot/plot/plot_4.svg)](examples/line_plot/plot/plot_4.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/line_plot/plot/plot_4.cpp"
-    ```
+```cpp
+--8<-- "examples/line_plot/plot/plot_4.cpp"
+```
 
 
 ===! "Plot"
 
-    [![example_plot_5](docs/examples/line_plot/plot/plot_5.svg)](examples/line_plot/plot/plot_5.cpp)
+[![example_plot_5](docs/examples/line_plot/plot/plot_5.svg)](examples/line_plot/plot/plot_5.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/line_plot/plot/plot_5.cpp"
-    ```
+```cpp
+--8<-- "examples/line_plot/plot/plot_5.cpp"
+```
 
 
 ===! "Plot"
 
-    [![example_plot_6](docs/examples/line_plot/plot/plot_6.svg)](examples/line_plot/plot/plot_6.cpp)
+[![example_plot_6](docs/examples/line_plot/plot/plot_6.svg)](examples/line_plot/plot/plot_6.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/line_plot/plot/plot_6.cpp"
-    ```
+```cpp
+--8<-- "examples/line_plot/plot/plot_6.cpp"
+```
 
 
 ===! "Plot"
 
-    [![example_plot_7](docs/examples/line_plot/plot/plot_7.svg)](examples/line_plot/plot/plot_7.cpp)
+[![example_plot_7](docs/examples/line_plot/plot/plot_7.svg)](examples/line_plot/plot/plot_7.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/line_plot/plot/plot_7.cpp"
-    ```
+```cpp
+--8<-- "examples/line_plot/plot/plot_7.cpp"
+```
 
 
 ===! "Plot"
 
-    [![example_plot_8](docs/examples/line_plot/plot/plot_8.svg)](examples/line_plot/plot/plot_8.cpp)
+[![example_plot_8](docs/examples/line_plot/plot/plot_8.svg)](examples/line_plot/plot/plot_8.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/line_plot/plot/plot_8.cpp"
-    ```
+```cpp
+--8<-- "examples/line_plot/plot/plot_8.cpp"
+```
 
 
 ===! "Plot"
 
-    [![example_plot_9](docs/examples/line_plot/plot/plot_9.svg)](examples/line_plot/plot/plot_9.cpp)
+[![example_plot_9](docs/examples/line_plot/plot/plot_9.svg)](examples/line_plot/plot/plot_9.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/line_plot/plot/plot_9.cpp"
-    ```
+```cpp
+--8<-- "examples/line_plot/plot/plot_9.cpp"
+```
 
 
 ===! "Plot"
 
-    [![example_plot_10](docs/examples/line_plot/plot/plot_10.svg)](examples/line_plot/plot/plot_10.cpp)
+[![example_plot_10](docs/examples/line_plot/plot/plot_10.svg)](examples/line_plot/plot/plot_10.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/line_plot/plot/plot_10.cpp"
-    ```
+```cpp
+--8<-- "examples/line_plot/plot/plot_10.cpp"
+```
 
 
 ===! "Plot"
 
-    [![example_plot_11](docs/examples/line_plot/plot/plot_11.svg)](examples/line_plot/plot/plot_11.cpp)
+[![example_plot_11](docs/examples/line_plot/plot/plot_11.svg)](examples/line_plot/plot/plot_11.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/line_plot/plot/plot_11.cpp"
-    ```
+```cpp
+--8<-- "examples/line_plot/plot/plot_11.cpp"
+```
 
 
 ===! "Plot"
 
-    [![example_plot_12](docs/examples/line_plot/plot/plot_12.svg)](examples/line_plot/plot/plot_12.cpp)
+[![example_plot_12](docs/examples/line_plot/plot/plot_12.svg)](examples/line_plot/plot/plot_12.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/line_plot/plot/plot_12.cpp"
-    ```
+```cpp
+--8<-- "examples/line_plot/plot/plot_12.cpp"
+```
 
 #### Line Plot 3D
 
@@ -955,20 +954,20 @@ plot3(x,y);
 
 === "Plot"
 
-    [![example_plot3_1](docs/examples/line_plot/plot3/plot3_1.svg)](examples/line_plot/plot3/plot3_1.cpp)
+[![example_plot3_1](docs/examples/line_plot/plot3/plot3_1.svg)](examples/line_plot/plot3/plot3_1.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/line_plot/plot3/plot3_1.cpp"
-    ```
+```cpp
+--8<-- "examples/line_plot/plot3/plot3_1.cpp"
+```
 
 !!! tip
     With method chaining:
 
-    ```cpp
-    plot3(x,y)->line_width(2).color("red");
-    ```
+```cpp
+plot3(x,y)->line_width(2).color("red");
+```
 
 <!-- START mdsplit-ignore -->
 <details>
@@ -982,83 +981,83 @@ plot3(x,y);
 
 ===! "Plot"
 
-    [![example_plot3_2](docs/examples/line_plot/plot3/plot3_2.svg)](examples/line_plot/plot3/plot3_2.cpp)
+[![example_plot3_2](docs/examples/line_plot/plot3/plot3_2.svg)](examples/line_plot/plot3/plot3_2.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/line_plot/plot3/plot3_2.cpp"
-    ```
+```cpp
+--8<-- "examples/line_plot/plot3/plot3_2.cpp"
+```
 
 ===! "Plot"
 
-    [![example_plot3_3](docs/examples/line_plot/plot3/plot3_3.svg)](examples/line_plot/plot3/plot3_3.cpp)
+[![example_plot3_3](docs/examples/line_plot/plot3/plot3_3.svg)](examples/line_plot/plot3/plot3_3.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/line_plot/plot3/plot3_3.cpp"
-    ```
+```cpp
+--8<-- "examples/line_plot/plot3/plot3_3.cpp"
+```
 
 ===! "Plot"
 
-    [![example_plot3_4](docs/examples/line_plot/plot3/plot3_4.png)](examples/line_plot/plot3/plot3_4.cpp)
+[![example_plot3_4](docs/examples/line_plot/plot3/plot3_4.png)](examples/line_plot/plot3/plot3_4.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/line_plot/plot3/plot3_4.cpp"
-    ```
+```cpp
+--8<-- "examples/line_plot/plot3/plot3_4.cpp"
+```
 
 ===! "Plot"
 
-    [![example_plot3_5](docs/examples/line_plot/plot3/plot3_5.svg)](examples/line_plot/plot3/plot3_5.cpp)
+[![example_plot3_5](docs/examples/line_plot/plot3/plot3_5.svg)](examples/line_plot/plot3/plot3_5.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/line_plot/plot3/plot3_5.cpp"
-    ```
+```cpp
+--8<-- "examples/line_plot/plot3/plot3_5.cpp"
+```
 
 ===! "Plot"
 
-    [![example_plot3_7](docs/examples/line_plot/plot3/plot3_7.svg)](examples/line_plot/plot3/plot3_7.cpp)
+[![example_plot3_7](docs/examples/line_plot/plot3/plot3_7.svg)](examples/line_plot/plot3/plot3_7.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/line_plot/plot3/plot3_7.cpp"
-    ```
+```cpp
+--8<-- "examples/line_plot/plot3/plot3_7.cpp"
+```
 
 ===! "Plot"
 
-    [![example_plot3_8](docs/examples/line_plot/plot3/plot3_8.svg)](examples/line_plot/plot3/plot3_8.cpp)
+[![example_plot3_8](docs/examples/line_plot/plot3/plot3_8.svg)](examples/line_plot/plot3/plot3_8.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/line_plot/plot3/plot3_8.cpp"
-    ```
+```cpp
+--8<-- "examples/line_plot/plot3/plot3_8.cpp"
+```
 
 ===! "Plot"
 
-    [![example_plot3_9](docs/examples/line_plot/plot3/plot3_9.svg)](examples/line_plot/plot3/plot3_9.cpp)
+[![example_plot3_9](docs/examples/line_plot/plot3/plot3_9.svg)](examples/line_plot/plot3/plot3_9.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/line_plot/plot3/plot3_9.cpp"
-    ```
+```cpp
+--8<-- "examples/line_plot/plot3/plot3_9.cpp"
+```
 
 ===! "Plot"
 
-    [![example_plot3_10](docs/examples/line_plot/plot3/plot3_10.svg)](examples/line_plot/plot3/plot3_10.cpp)
+[![example_plot3_10](docs/examples/line_plot/plot3/plot3_10.svg)](examples/line_plot/plot3/plot3_10.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/line_plot/plot3/plot3_10.cpp"
-    ```
+```cpp
+--8<-- "examples/line_plot/plot3/plot3_10.cpp"
+```
 
 #### Stairs
 
@@ -1082,96 +1081,96 @@ More examples:
 
 ===! "Plot"
 
-    [![example_stairs_2](docs/examples/line_plot/stairs/stairs_2.svg)](examples/line_plot/stairs/stairs_2.cpp)
+[![example_stairs_2](docs/examples/line_plot/stairs/stairs_2.svg)](examples/line_plot/stairs/stairs_2.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/line_plot/stairs/stairs_2.cpp"
-    ```
+```cpp
+--8<-- "examples/line_plot/stairs/stairs_2.cpp"
+```
 
 **More examples**
 
 
 ===! "Plot"
 
-    [![example_stairs_3](docs/examples/line_plot/stairs/stairs_3.svg)](examples/line_plot/stairs/stairs_3.cpp)
+[![example_stairs_3](docs/examples/line_plot/stairs/stairs_3.svg)](examples/line_plot/stairs/stairs_3.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/line_plot/stairs/stairs_3.cpp"
-    ```
+```cpp
+--8<-- "examples/line_plot/stairs/stairs_3.cpp"
+```
 
 ===! "Plot"
 
-    [![example_stairs_4](docs/examples/line_plot/stairs/stairs_4.svg)](examples/line_plot/stairs/stairs_4.cpp)
+[![example_stairs_4](docs/examples/line_plot/stairs/stairs_4.svg)](examples/line_plot/stairs/stairs_4.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/line_plot/stairs/stairs_4.cpp"
-    ```
+```cpp
+--8<-- "examples/line_plot/stairs/stairs_4.cpp"
+```
 
 ===! "Plot"
 
-    [![example_stairs_5](docs/examples/line_plot/stairs/stairs_5.svg)](examples/line_plot/stairs/stairs_5.cpp)
+[![example_stairs_5](docs/examples/line_plot/stairs/stairs_5.svg)](examples/line_plot/stairs/stairs_5.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/line_plot/stairs/stairs_5.cpp"
-    ```
+```cpp
+--8<-- "examples/line_plot/stairs/stairs_5.cpp"
+```
 
 ===! "Plot"
 
-    [![example_stairs_6](docs/examples/line_plot/stairs/stairs_6.svg)](examples/line_plot/stairs/stairs_6.cpp)
+[![example_stairs_6](docs/examples/line_plot/stairs/stairs_6.svg)](examples/line_plot/stairs/stairs_6.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/line_plot/stairs/stairs_6.cpp"
-    ```
+```cpp
+--8<-- "examples/line_plot/stairs/stairs_6.cpp"
+```
 
 ===! "Plot"
 
-    [![example_stairs_7](docs/examples/line_plot/stairs/stairs_7.svg)](examples/line_plot/stairs/stairs_7.cpp)
+[![example_stairs_7](docs/examples/line_plot/stairs/stairs_7.svg)](examples/line_plot/stairs/stairs_7.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/line_plot/stairs/stairs_7.cpp"
-    ```
+```cpp
+--8<-- "examples/line_plot/stairs/stairs_7.cpp"
+```
 
 ===! "Plot"
 
-    [![example_stairs_8](docs/examples/line_plot/stairs/stairs_8.svg)](examples/line_plot/stairs/stairs_8.cpp)
+[![example_stairs_8](docs/examples/line_plot/stairs/stairs_8.svg)](examples/line_plot/stairs/stairs_8.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/line_plot/stairs/stairs_8.cpp"
-    ```
+```cpp
+--8<-- "examples/line_plot/stairs/stairs_8.cpp"
+```
 
 ===! "Plot"
 
-    [![example_stairs_9](docs/examples/line_plot/stairs/stairs_9.svg)](examples/line_plot/stairs/stairs_9.cpp)
+[![example_stairs_9](docs/examples/line_plot/stairs/stairs_9.svg)](examples/line_plot/stairs/stairs_9.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/line_plot/stairs/stairs_9.cpp"
-    ```
+```cpp
+--8<-- "examples/line_plot/stairs/stairs_9.cpp"
+```
 
 ===! "Plot"
 
-    [![example_stairs_10](docs/examples/line_plot/stairs/stairs_10.svg)](examples/line_plot/stairs/stairs_10.cpp)
+[![example_stairs_10](docs/examples/line_plot/stairs/stairs_10.svg)](examples/line_plot/stairs/stairs_10.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/line_plot/stairs/stairs_10.cpp"
-    ```
+```cpp
+--8<-- "examples/line_plot/stairs/stairs_10.cpp"
+```
 
 
 #### Error Bars
@@ -1195,106 +1194,106 @@ More examples:
 
 ===! "Plot"
 
-    [![example_errorbar_1](docs/examples/line_plot/errorbar/errorbar_1.svg)](examples/line_plot/errorbar/errorbar_1.cpp)
+[![example_errorbar_1](docs/examples/line_plot/errorbar/errorbar_1.svg)](examples/line_plot/errorbar/errorbar_1.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/line_plot/errorbar/errorbar_1.cpp"
-    ```
+```cpp
+--8<-- "examples/line_plot/errorbar/errorbar_1.cpp"
+```
 
 **More examples**
 
 
 ===! "Plot"
 
-    [![example_errorbar_2](docs/examples/line_plot/errorbar/errorbar_2.svg)](examples/line_plot/errorbar/errorbar_2.cpp)
+[![example_errorbar_2](docs/examples/line_plot/errorbar/errorbar_2.svg)](examples/line_plot/errorbar/errorbar_2.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/line_plot/errorbar/errorbar_2.cpp"
-    ```
+```cpp
+--8<-- "examples/line_plot/errorbar/errorbar_2.cpp"
+```
 
 ===! "Plot"
 
-    [![example_errorbar_3](docs/examples/line_plot/errorbar/errorbar_3.svg)](examples/line_plot/errorbar/errorbar_3.cpp)
+[![example_errorbar_3](docs/examples/line_plot/errorbar/errorbar_3.svg)](examples/line_plot/errorbar/errorbar_3.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/line_plot/errorbar/errorbar_3.cpp"
-    ```
+```cpp
+--8<-- "examples/line_plot/errorbar/errorbar_3.cpp"
+```
 
 ===! "Plot"
 
-    [![example_errorbar_4](docs/examples/line_plot/errorbar/errorbar_4.svg)](examples/line_plot/errorbar/errorbar_4.cpp)
+[![example_errorbar_4](docs/examples/line_plot/errorbar/errorbar_4.svg)](examples/line_plot/errorbar/errorbar_4.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/line_plot/errorbar/errorbar_4.cpp"
-    ```
+```cpp
+--8<-- "examples/line_plot/errorbar/errorbar_4.cpp"
+```
 
 ===! "Plot"
 
-    [![example_errorbar_5](docs/examples/line_plot/errorbar/errorbar_5.svg)](examples/line_plot/errorbar/errorbar_5.cpp)
+[![example_errorbar_5](docs/examples/line_plot/errorbar/errorbar_5.svg)](examples/line_plot/errorbar/errorbar_5.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/line_plot/errorbar/errorbar_5.cpp"
-    ```
+```cpp
+--8<-- "examples/line_plot/errorbar/errorbar_5.cpp"
+```
 
 ===! "Plot"
 
-    [![example_errorbar_6](docs/examples/line_plot/errorbar/errorbar_6.svg)](examples/line_plot/errorbar/errorbar_6.cpp)
+[![example_errorbar_6](docs/examples/line_plot/errorbar/errorbar_6.svg)](examples/line_plot/errorbar/errorbar_6.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/line_plot/errorbar/errorbar_6.cpp"
-    ```
+```cpp
+--8<-- "examples/line_plot/errorbar/errorbar_6.cpp"
+```
 
 ===! "Plot"
 
-    [![example_errorbar_7](docs/examples/line_plot/errorbar/errorbar_7.svg)](examples/line_plot/errorbar/errorbar_7.cpp)
+[![example_errorbar_7](docs/examples/line_plot/errorbar/errorbar_7.svg)](examples/line_plot/errorbar/errorbar_7.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/line_plot/errorbar/errorbar_7.cpp"
-    ```
+```cpp
+--8<-- "examples/line_plot/errorbar/errorbar_7.cpp"
+```
 
 ===! "Plot"
 
-    [![example_errorbar_8](docs/examples/line_plot/errorbar/errorbar_8.svg)](examples/line_plot/errorbar/errorbar_8.cpp)
+[![example_errorbar_8](docs/examples/line_plot/errorbar/errorbar_8.svg)](examples/line_plot/errorbar/errorbar_8.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/line_plot/errorbar/errorbar_8.cpp"
-    ```
+```cpp
+--8<-- "examples/line_plot/errorbar/errorbar_8.cpp"
+```
 
 ===! "Plot"
 
-    [![example_errorbar_9](docs/examples/line_plot/errorbar/errorbar_9.svg)](examples/line_plot/errorbar/errorbar_9.cpp)
+[![example_errorbar_9](docs/examples/line_plot/errorbar/errorbar_9.svg)](examples/line_plot/errorbar/errorbar_9.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/line_plot/errorbar/errorbar_9.cpp"
-    ```
+```cpp
+--8<-- "examples/line_plot/errorbar/errorbar_9.cpp"
+```
 
 ===! "Plot"
 
-    [![example_errorbar_10](docs/examples/line_plot/errorbar/errorbar_10.svg)](examples/line_plot/errorbar/errorbar_10.cpp)
+[![example_errorbar_10](docs/examples/line_plot/errorbar/errorbar_10.svg)](examples/line_plot/errorbar/errorbar_10.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/line_plot/errorbar/errorbar_10.cpp"
-    ```
+```cpp
+--8<-- "examples/line_plot/errorbar/errorbar_10.cpp"
+```
 
 
 The `error bar` object includes extra lines to represent error around data points. Log plots are utility functions that adjust the x or y axes to a logarithmic scale. 
@@ -1320,46 +1319,46 @@ More examples:
 
 ===! "Plot"
 
-    [![example_area_1](docs/examples/line_plot/area/area_1.svg)](examples/line_plot/area/area_1.cpp)
+[![example_area_1](docs/examples/line_plot/area/area_1.svg)](examples/line_plot/area/area_1.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/line_plot/area/area_1.cpp"
-    ```
+```cpp
+--8<-- "examples/line_plot/area/area_1.cpp"
+```
 
 **More examples**
 
 
 ===! "Plot"
 
-    [![example_area_2](docs/examples/line_plot/area/area_2.svg)](examples/line_plot/area/area_2.cpp)
+[![example_area_2](docs/examples/line_plot/area/area_2.svg)](examples/line_plot/area/area_2.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/line_plot/area/area_2.cpp"
-    ```
+```cpp
+--8<-- "examples/line_plot/area/area_2.cpp"
+```
 
 ===! "Plot"
 
-    [![example_area_3](docs/examples/line_plot/area/area_3.svg)](examples/line_plot/area/area_3.cpp)
+[![example_area_3](docs/examples/line_plot/area/area_3.svg)](examples/line_plot/area/area_3.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/line_plot/area/area_3.cpp"
-    ```
+```cpp
+--8<-- "examples/line_plot/area/area_3.cpp"
+```
 
 ===! "Plot"
 
-    [![example_area_4](docs/examples/line_plot/area/area_4.svg)](examples/line_plot/area/area_4.cpp)
+[![example_area_4](docs/examples/line_plot/area/area_4.svg)](examples/line_plot/area/area_4.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/line_plot/area/area_4.cpp"
-    ```
+```cpp
+--8<-- "examples/line_plot/area/area_4.cpp"
+```
 
 #### Loglog Plot
 
@@ -1381,96 +1380,96 @@ More examples:
 
 ===! "Plot"
 
-      [![example_loglog_1](docs/examples/line_plot/loglog/loglog_1.svg)](examples/line_plot/loglog/loglog_1.cpp)
+[![example_loglog_1](docs/examples/line_plot/loglog/loglog_1.svg)](examples/line_plot/loglog/loglog_1.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/line_plot/loglog/loglog_1.cpp"
-    ```
+```cpp
+--8<-- "examples/line_plot/loglog/loglog_1.cpp"
+```
 
 
 **More examples**
 
 ===! "Plot"
 
-      [![example_loglog_2](docs/examples/line_plot/loglog/loglog_2.svg)](examples/line_plot/loglog/loglog_2.cpp)
+[![example_loglog_2](docs/examples/line_plot/loglog/loglog_2.svg)](examples/line_plot/loglog/loglog_2.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/line_plot/loglog/loglog_2.cpp"
-    ```
+```cpp
+--8<-- "examples/line_plot/loglog/loglog_2.cpp"
+```
 
 ===! "Plot"
 
-      [![example_loglog_3](docs/examples/line_plot/loglog/loglog_3.png)](examples/line_plot/loglog/loglog_3.cpp)
+[![example_loglog_3](docs/examples/line_plot/loglog/loglog_3.png)](examples/line_plot/loglog/loglog_3.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/line_plot/loglog/loglog_3.cpp"
-    ```
+```cpp
+--8<-- "examples/line_plot/loglog/loglog_3.cpp"
+```
 
 ===! "Plot"
 
-      [![example_loglog_4](docs/examples/line_plot/loglog/loglog_4.svg)](examples/line_plot/loglog/loglog_4.cpp)
+[![example_loglog_4](docs/examples/line_plot/loglog/loglog_4.svg)](examples/line_plot/loglog/loglog_4.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/line_plot/loglog/loglog_4.cpp"
-    ```
+```cpp
+--8<-- "examples/line_plot/loglog/loglog_4.cpp"
+```
 
 ===! "Plot"
 
-      [![example_loglog_5](docs/examples/line_plot/loglog/loglog_5.png)](examples/line_plot/loglog/loglog_5.cpp)
+[![example_loglog_5](docs/examples/line_plot/loglog/loglog_5.png)](examples/line_plot/loglog/loglog_5.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/line_plot/loglog/loglog_5.cpp"
-    ```
+```cpp
+--8<-- "examples/line_plot/loglog/loglog_5.cpp"
+```
 
 ===! "Plot"
 
-      [![example_loglog_6](docs/examples/line_plot/loglog/loglog_6.svg)](examples/line_plot/loglog/loglog_6.cpp)
+[![example_loglog_6](docs/examples/line_plot/loglog/loglog_6.svg)](examples/line_plot/loglog/loglog_6.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/line_plot/loglog/loglog_6.cpp"
-    ```
+```cpp
+--8<-- "examples/line_plot/loglog/loglog_6.cpp"
+```
 
 ===! "Plot"
 
-      [![example_loglog_7](docs/examples/line_plot/loglog/loglog_7.svg)](examples/line_plot/loglog/loglog_7.cpp)
+[![example_loglog_7](docs/examples/line_plot/loglog/loglog_7.svg)](examples/line_plot/loglog/loglog_7.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/line_plot/loglog/loglog_7.cpp"
-    ```
+```cpp
+--8<-- "examples/line_plot/loglog/loglog_7.cpp"
+```
 
 ===! "Plot"
 
-      [![example_loglog_8](docs/examples/line_plot/loglog/loglog_8.svg)](examples/line_plot/loglog/loglog_8.cpp)
+[![example_loglog_8](docs/examples/line_plot/loglog/loglog_8.svg)](examples/line_plot/loglog/loglog_8.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/line_plot/loglog/loglog_8.cpp"
-    ```
+```cpp
+--8<-- "examples/line_plot/loglog/loglog_8.cpp"
+```
 
 ===! "Plot"
 
-      [![example_loglog_9](docs/examples/line_plot/loglog/loglog_9.svg)](examples/line_plot/loglog/loglog_9.cpp)
+[![example_loglog_9](docs/examples/line_plot/loglog/loglog_9.svg)](examples/line_plot/loglog/loglog_9.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/line_plot/loglog/loglog_9.cpp"
-    ```
+```cpp
+--8<-- "examples/line_plot/loglog/loglog_9.cpp"
+```
 
 
 #### Semilogx Plot
@@ -1489,13 +1488,13 @@ semilogx(x,y);
 
 ===! "Plot"
 
-    [![example_semilogx_1](docs/examples/line_plot/semilogx/semilogx_1.svg)](examples/line_plot/semilogx/semilogx_1.cpp)
+[![example_semilogx_1](docs/examples/line_plot/semilogx/semilogx_1.svg)](examples/line_plot/semilogx/semilogx_1.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/line_plot/semilogx/semilogx_1.cpp"
-    ```
+```cpp
+--8<-- "examples/line_plot/semilogx/semilogx_1.cpp"
+```
 
 #### Semilogy Plot
 
@@ -1513,13 +1512,13 @@ semilogy(x,y);
 
 ===! "Plot"
 
-    [![example_semilogy_1](docs/examples/line_plot/semilogy/semilogy_1.svg)](examples/line_plot/semilogy/semilogy_1.cpp)
+[![example_semilogy_1](docs/examples/line_plot/semilogy/semilogy_1.svg)](examples/line_plot/semilogy/semilogy_1.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/line_plot/semilogy/semilogy_1.cpp"
-    ```
+```cpp
+--8<-- "examples/line_plot/semilogy/semilogy_1.cpp"
+```
 
 #### Function Plot
 
@@ -1542,66 +1541,66 @@ More examples:
 
 ===! "Plot"
 
-    [![example_fplot_1](docs/examples/line_plot/fplot/fplot_1.svg)](examples/line_plot/fplot/fplot_1.cpp)
+[![example_fplot_1](docs/examples/line_plot/fplot/fplot_1.svg)](examples/line_plot/fplot/fplot_1.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/line_plot/fplot/fplot_1.cpp"
-    ```
+```cpp
+--8<-- "examples/line_plot/fplot/fplot_1.cpp"
+```
 
 **More examples**
 
 
 ===! "Plot"
 
-    [![example_fplot_2](docs/examples/line_plot/fplot/fplot_2.svg)](examples/line_plot/fplot/fplot_2.cpp)
+[![example_fplot_2](docs/examples/line_plot/fplot/fplot_2.svg)](examples/line_plot/fplot/fplot_2.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/line_plot/fplot/fplot_2.cpp"
-    ```
+```cpp
+--8<-- "examples/line_plot/fplot/fplot_2.cpp"
+```
 
 ===! "Plot"
 
-    [![example_fplot_3](docs/examples/line_plot/fplot/fplot_3.png)](examples/line_plot/fplot/fplot_3.cpp)
+[![example_fplot_3](docs/examples/line_plot/fplot/fplot_3.png)](examples/line_plot/fplot/fplot_3.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/line_plot/fplot/fplot_3.cpp"
-    ```
+```cpp
+--8<-- "examples/line_plot/fplot/fplot_3.cpp"
+```
 
 ===! "Plot"
 
-    [![example_fplot_4](docs/examples/line_plot/fplot/fplot_4.png)](examples/line_plot/fplot/fplot_4.cpp)
+[![example_fplot_4](docs/examples/line_plot/fplot/fplot_4.png)](examples/line_plot/fplot/fplot_4.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/line_plot/fplot/fplot_4.cpp"
-    ```
+```cpp
+--8<-- "examples/line_plot/fplot/fplot_4.cpp"
+```
 
 ===! "Plot"
 
-    [![example_fplot_5](docs/examples/line_plot/fplot/fplot_5.png)](examples/line_plot/fplot/fplot_5.cpp)
+[![example_fplot_5](docs/examples/line_plot/fplot/fplot_5.png)](examples/line_plot/fplot/fplot_5.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/line_plot/fplot/fplot_5.cpp"
-    ```
+```cpp
+--8<-- "examples/line_plot/fplot/fplot_5.cpp"
+```
 
 ===! "Plot"
 
-    [![example_fplot_6](docs/examples/line_plot/fplot/fplot_6.svg)](examples/line_plot/fplot/fplot_6.cpp)
+[![example_fplot_6](docs/examples/line_plot/fplot/fplot_6.svg)](examples/line_plot/fplot/fplot_6.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/line_plot/fplot/fplot_6.cpp"
-    ```
+```cpp
+--8<-- "examples/line_plot/fplot/fplot_6.cpp"
+```
 
 Instead of storing data points, the objects `function line` and `string function` store a function as a lambda function or as a string with an expression. These objects use lazy evaluation to generate absolute data points. The data is generated only when the `draw` function is called.
 
@@ -1626,55 +1625,55 @@ More examples:
 
 ===! "Plot"
 
-    [![example_fplot3_1](docs/examples/line_plot/fplot3/fplot3_1.svg)](examples/line_plot/fplot3/fplot3_1.cpp)
+[![example_fplot3_1](docs/examples/line_plot/fplot3/fplot3_1.svg)](examples/line_plot/fplot3/fplot3_1.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/line_plot/fplot3/fplot3_1.cpp"
-    `````
+```cpp
+--8<-- "examples/line_plot/fplot3/fplot3_1.cpp"
+`````
 
 **More examples**
 
 ===! "Plot"
 
-    [![example_fplot3_2](docs/examples/line_plot/fplot3/fplot3_2.svg)](examples/line_plot/fplot3/fplot3_2.cpp)
+[![example_fplot3_2](docs/examples/line_plot/fplot3/fplot3_2.svg)](examples/line_plot/fplot3/fplot3_2.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/line_plot/fplot3/fplot3_2.cpp"
-    ```
+```cpp
+--8<-- "examples/line_plot/fplot3/fplot3_2.cpp"
+```
 
 ===! "Plot"
 
-    [![example_fplot3_3](docs/examples/line_plot/fplot3/fplot3_3.png)](examples/line_plot/fplot3/fplot3_3.cpp)
+[![example_fplot3_3](docs/examples/line_plot/fplot3/fplot3_3.png)](examples/line_plot/fplot3/fplot3_3.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/line_plot/fplot3/fplot3_3.cpp"
-    ```
+```cpp
+--8<-- "examples/line_plot/fplot3/fplot3_3.cpp"
+```
 
 ===! "Plot"
 
-    [![example_fplot3_4](docs/examples/line_plot/fplot3/fplot3_4.svg)](examples/line_plot/fplot3/fplot3_4.cpp)
+[![example_fplot3_4](docs/examples/line_plot/fplot3/fplot3_4.svg)](examples/line_plot/fplot3/fplot3_4.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/line_plot/fplot3/fplot3_4.cpp"
-    ```
+```cpp
+--8<-- "examples/line_plot/fplot3/fplot3_4.cpp"
+```
 
 ===! "Plot"
 
-    [![example_fplot3_5](docs/examples/line_plot/fplot3/fplot3_5.svg)](examples/line_plot/fplot3/fplot3_5.cpp)
+[![example_fplot3_5](docs/examples/line_plot/fplot3/fplot3_5.svg)](examples/line_plot/fplot3/fplot3_5.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/line_plot/fplot3/fplot3_5.cpp"
-    ```
+```cpp
+--8<-- "examples/line_plot/fplot3/fplot3_5.cpp"
+```
 
 #### Implicit function
 
@@ -1697,46 +1696,46 @@ More examples:
 
 ===! "Plot"
 
-    [![example_fimplicit_1](docs/examples/line_plot/fimplicit/fimplicit_1.svg)](examples/line_plot/fimplicit/fimplicit_1.cpp)
+[![example_fimplicit_1](docs/examples/line_plot/fimplicit/fimplicit_1.svg)](examples/line_plot/fimplicit/fimplicit_1.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/line_plot/fimplicit/fimplicit_1.cpp"
-    ```
+```cpp
+--8<-- "examples/line_plot/fimplicit/fimplicit_1.cpp"
+```
 
 **More examples**
 
 
 ===! "Plot"
 
-    [![example_fimplicit_2](docs/examples/line_plot/fimplicit/fimplicit_2.svg)](examples/line_plot/fimplicit/fimplicit_2.cpp)
+[![example_fimplicit_2](docs/examples/line_plot/fimplicit/fimplicit_2.svg)](examples/line_plot/fimplicit/fimplicit_2.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/line_plot/fimplicit/fimplicit_2.cpp"
-    ```
+```cpp
+--8<-- "examples/line_plot/fimplicit/fimplicit_2.cpp"
+```
 
 ===! "Plot"
 
-    [![example_fimplicit_3](docs/examples/line_plot/fimplicit/fimplicit_3.svg)](examples/line_plot/fimplicit/fimplicit_3.cpp)
+[![example_fimplicit_3](docs/examples/line_plot/fimplicit/fimplicit_3.svg)](examples/line_plot/fimplicit/fimplicit_3.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/line_plot/fimplicit/fimplicit_3.cpp"
-    ```
+```cpp
+--8<-- "examples/line_plot/fimplicit/fimplicit_3.cpp"
+```
 
 ===! "Plot"
 
-    [![example_fimplicit_4](docs/examples/line_plot/fimplicit/fimplicit_4.svg)](examples/line_plot/fimplicit/fimplicit_4.cpp)
+[![example_fimplicit_4](docs/examples/line_plot/fimplicit/fimplicit_4.svg)](examples/line_plot/fimplicit/fimplicit_4.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/line_plot/fimplicit/fimplicit_4.cpp"
-    ```
+```cpp
+--8<-- "examples/line_plot/fimplicit/fimplicit_4.cpp"
+```
 
 ### Data Distribution
 
@@ -1767,136 +1766,136 @@ More examples:
 
 ===! "Plot"
 
-    [![example_histogram_1](docs/examples/data_distribution/histogram/histogram_1.png)](examples/data_distribution/histogram/histogram_1.cpp)
+[![example_histogram_1](docs/examples/data_distribution/histogram/histogram_1.png)](examples/data_distribution/histogram/histogram_1.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/data_distribution/histogram/histogram_1.cpp"
-    ```
+```cpp
+--8<-- "examples/data_distribution/histogram/histogram_1.cpp"
+```
 
 **More examples**
 
 
 ===! "Plot"
 
-    [![example_histogram_2](docs/examples/data_distribution/histogram/histogram_2.png)](examples/data_distribution/histogram/histogram_2.cpp)
+[![example_histogram_2](docs/examples/data_distribution/histogram/histogram_2.png)](examples/data_distribution/histogram/histogram_2.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/data_distribution/histogram/histogram_2.cpp"
-    ```
+```cpp
+--8<-- "examples/data_distribution/histogram/histogram_2.cpp"
+```
 
 ===! "Plot"
 
-    [![example_histogram_3](docs/examples/data_distribution/histogram/histogram_3.png)](examples/data_distribution/histogram/histogram_3.cpp)
+[![example_histogram_3](docs/examples/data_distribution/histogram/histogram_3.png)](examples/data_distribution/histogram/histogram_3.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/data_distribution/histogram/histogram_3.cpp"
-    ```
+```cpp
+--8<-- "examples/data_distribution/histogram/histogram_3.cpp"
+```
 
 ===! "Plot"
 
-    [![example_histogram_4](docs/examples/data_distribution/histogram/histogram_4.png)](examples/data_distribution/histogram/histogram_4.cpp)
+[![example_histogram_4](docs/examples/data_distribution/histogram/histogram_4.png)](examples/data_distribution/histogram/histogram_4.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/data_distribution/histogram/histogram_4.cpp"
-    ```
+```cpp
+--8<-- "examples/data_distribution/histogram/histogram_4.cpp"
+```
 
 ===! "Plot"
 
-    [![example_histogram_5](docs/examples/data_distribution/histogram/histogram_5.png)](examples/data_distribution/histogram/histogram_5.cpp)
+[![example_histogram_5](docs/examples/data_distribution/histogram/histogram_5.png)](examples/data_distribution/histogram/histogram_5.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/data_distribution/histogram/histogram_5.cpp"
-    ```
+```cpp
+--8<-- "examples/data_distribution/histogram/histogram_5.cpp"
+```
 
 ===! "Plot"
 
-    [![example_histogram_6](docs/examples/data_distribution/histogram/histogram_6.png)](examples/data_distribution/histogram/histogram_6.cpp)
+[![example_histogram_6](docs/examples/data_distribution/histogram/histogram_6.png)](examples/data_distribution/histogram/histogram_6.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/data_distribution/histogram/histogram_6.cpp"
-    ```
+```cpp
+--8<-- "examples/data_distribution/histogram/histogram_6.cpp"
+```
 
 ===! "Plot"
 
-    [![example_histogram_7](docs/examples/data_distribution/histogram/histogram_7.svg)](examples/data_distribution/histogram/histogram_7.cpp)
+[![example_histogram_7](docs/examples/data_distribution/histogram/histogram_7.svg)](examples/data_distribution/histogram/histogram_7.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/data_distribution/histogram/histogram_7.cpp"
-    ```
+```cpp
+--8<-- "examples/data_distribution/histogram/histogram_7.cpp"
+```
 
 ===! "Plot"
 
-    [![example_histogram_8](docs/examples/data_distribution/histogram/histogram_8.png)](examples/data_distribution/histogram/histogram_8.cpp)
+[![example_histogram_8](docs/examples/data_distribution/histogram/histogram_8.png)](examples/data_distribution/histogram/histogram_8.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/data_distribution/histogram/histogram_8.cpp"
-    ```
+```cpp
+--8<-- "examples/data_distribution/histogram/histogram_8.cpp"
+```
 
 ===! "Plot"
 
-    [![example_histogram_9](docs/examples/data_distribution/histogram/histogram_9.png)](examples/data_distribution/histogram/histogram_9.cpp)
+[![example_histogram_9](docs/examples/data_distribution/histogram/histogram_9.png)](examples/data_distribution/histogram/histogram_9.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/data_distribution/histogram/histogram_9.cpp"
-    ```
+```cpp
+--8<-- "examples/data_distribution/histogram/histogram_9.cpp"
+```
 
 ===! "Plot"
 
-    [![example_histogram_10](docs/examples/data_distribution/histogram/histogram_10.svg)](examples/data_distribution/histogram/histogram_10.cpp)
+[![example_histogram_10](docs/examples/data_distribution/histogram/histogram_10.svg)](examples/data_distribution/histogram/histogram_10.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/data_distribution/histogram/histogram_10.cpp"
-    ```
+```cpp
+--8<-- "examples/data_distribution/histogram/histogram_10.cpp"
+```
 
 ===! "Plot"
 
-    [![example_histogram_11](docs/examples/data_distribution/histogram/histogram_11.svg)](examples/data_distribution/histogram/histogram_11.cpp)
+[![example_histogram_11](docs/examples/data_distribution/histogram/histogram_11.svg)](examples/data_distribution/histogram/histogram_11.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/data_distribution/histogram/histogram_11.cpp"
-    ```
+```cpp
+--8<-- "examples/data_distribution/histogram/histogram_11.cpp"
+```
 
 ===! "Plot"
 
-    [![example_histogram_12](docs/examples/data_distribution/histogram/histogram_12.svg)](examples/data_distribution/histogram/histogram_12.cpp)
+[![example_histogram_12](docs/examples/data_distribution/histogram/histogram_12.svg)](examples/data_distribution/histogram/histogram_12.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/data_distribution/histogram/histogram_12.cpp"
-    ```
+```cpp
+--8<-- "examples/data_distribution/histogram/histogram_12.cpp"
+```
 
 ===! "Plot"
 
-    [![example_histogram_14](docs/examples/data_distribution/histogram/histogram_14.png)](examples/data_distribution/histogram/histogram_14.cpp)
+[![example_histogram_14](docs/examples/data_distribution/histogram/histogram_14.png)](examples/data_distribution/histogram/histogram_14.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/data_distribution/histogram/histogram_14.cpp"
-    ```
+```cpp
+--8<-- "examples/data_distribution/histogram/histogram_14.cpp"
+```
 
 #### Boxplot
 
@@ -1918,37 +1917,37 @@ More examples:
 
 ===! "Plot"
 
-    [![example_boxplot_1](docs/examples/data_distribution/boxplot/boxplot_1.svg)](examples/data_distribution/boxplot/boxplot_1.cpp)
+[![example_boxplot_1](docs/examples/data_distribution/boxplot/boxplot_1.svg)](examples/data_distribution/boxplot/boxplot_1.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/data_distribution/boxplot/boxplot_1.cpp"
-    ```
+```cpp
+--8<-- "examples/data_distribution/boxplot/boxplot_1.cpp"
+```
 
 **More examples**
 
 ===! "Plot"
 
-    [![example_boxplot_2](docs/examples/data_distribution/boxplot/boxplot_2.svg)](examples/data_distribution/boxplot/boxplot_2.cpp)
+[![example_boxplot_2](docs/examples/data_distribution/boxplot/boxplot_2.svg)](examples/data_distribution/boxplot/boxplot_2.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/data_distribution/boxplot/boxplot_2.cpp"
-    ```
+```cpp
+--8<-- "examples/data_distribution/boxplot/boxplot_2.cpp"
+```
 
 
 
 ===! "Plot"
 
-    [![example_boxplot_3](docs/examples/data_distribution/boxplot/boxplot_3.png)](examples/data_distribution/boxplot/boxplot_3.cpp)
+[![example_boxplot_3](docs/examples/data_distribution/boxplot/boxplot_3.png)](examples/data_distribution/boxplot/boxplot_3.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/data_distribution/boxplot/boxplot_3.cpp"
-    ```
+```cpp
+--8<-- "examples/data_distribution/boxplot/boxplot_3.cpp"
+```
 
 
 
@@ -1972,95 +1971,95 @@ More examples:
 
 ===! "Plot"
 
-    [![example_scatter_1](docs/examples/data_distribution/scatter/scatter_1.svg)](examples/data_distribution/scatter/scatter_1.cpp)
+[![example_scatter_1](docs/examples/data_distribution/scatter/scatter_1.svg)](examples/data_distribution/scatter/scatter_1.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/data_distribution/scatter/scatter_1.cpp"
-    ```
+```cpp
+--8<-- "examples/data_distribution/scatter/scatter_1.cpp"
+```
 
 **More examples**
 
 ===! "Plot"
 
-    [![example_scatter_2](docs/examples/data_distribution/scatter/scatter_2.svg)](examples/data_distribution/scatter/scatter_2.cpp)
+[![example_scatter_2](docs/examples/data_distribution/scatter/scatter_2.svg)](examples/data_distribution/scatter/scatter_2.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/data_distribution/scatter/scatter_2.cpp"
-    ```
+```cpp
+--8<-- "examples/data_distribution/scatter/scatter_2.cpp"
+```
 
 
 
 ===! "Plot"
 
-    [![example_scatter_3](docs/examples/data_distribution/scatter/scatter_3.svg)](examples/data_distribution/scatter/scatter_3.cpp)
+[![example_scatter_3](docs/examples/data_distribution/scatter/scatter_3.svg)](examples/data_distribution/scatter/scatter_3.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/data_distribution/scatter/scatter_3.cpp"
-    ```
+```cpp
+--8<-- "examples/data_distribution/scatter/scatter_3.cpp"
+```
 
 
 ===! "Plot"
 
-    [![example_scatter_4](docs/examples/data_distribution/scatter/scatter_4.svg)](examples/data_distribution/scatter/scatter_4.cpp)
+[![example_scatter_4](docs/examples/data_distribution/scatter/scatter_4.svg)](examples/data_distribution/scatter/scatter_4.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/data_distribution/scatter/scatter_4.cpp"
-    ```
-
-
-
-===! "Plot"
-
-    [![example_scatter_5](docs/examples/data_distribution/scatter/scatter_5.svg)](examples/data_distribution/scatter/scatter_5.cpp)
-
-=== "C++"
-
-    ```cpp
-    --8<-- "examples/data_distribution/scatter/scatter_5.cpp"
-    ```
-
-
-===! "Plot"
-
-    [![example_scatter_6](docs/examples/data_distribution/scatter/scatter_6.svg)](examples/data_distribution/scatter/scatter_6.cpp)
-
-=== "C++"
-
-    ```cpp
-    --8<-- "examples/data_distribution/scatter/scatter_6.cpp"
-    ```
+```cpp
+--8<-- "examples/data_distribution/scatter/scatter_4.cpp"
+```
 
 
 
 ===! "Plot"
 
-    [![example_scatter_7](docs/examples/data_distribution/scatter/scatter_7.svg)](examples/data_distribution/scatter/scatter_7.cpp)
+[![example_scatter_5](docs/examples/data_distribution/scatter/scatter_5.svg)](examples/data_distribution/scatter/scatter_5.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/data_distribution/scatter/scatter_7.cpp"
-    ```
+```cpp
+--8<-- "examples/data_distribution/scatter/scatter_5.cpp"
+```
+
+
+===! "Plot"
+
+[![example_scatter_6](docs/examples/data_distribution/scatter/scatter_6.svg)](examples/data_distribution/scatter/scatter_6.cpp)
+
+=== "C++"
+
+```cpp
+--8<-- "examples/data_distribution/scatter/scatter_6.cpp"
+```
 
 
 
 ===! "Plot"
 
-    [![example_scatter_8](docs/examples/data_distribution/scatter/scatter_8.svg)](examples/data_distribution/scatter/scatter_8.cpp)
+[![example_scatter_7](docs/examples/data_distribution/scatter/scatter_7.svg)](examples/data_distribution/scatter/scatter_7.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/data_distribution/scatter/scatter_8.cpp"
-    ```
+```cpp
+--8<-- "examples/data_distribution/scatter/scatter_7.cpp"
+```
+
+
+
+===! "Plot"
+
+[![example_scatter_8](docs/examples/data_distribution/scatter/scatter_8.svg)](examples/data_distribution/scatter/scatter_8.cpp)
+
+=== "C++"
+
+```cpp
+--8<-- "examples/data_distribution/scatter/scatter_8.cpp"
+```
 
 
 
@@ -2086,72 +2085,72 @@ More examples:
 
 ===! "Plot"
 
-    [![example_scatter3_1](docs/examples/data_distribution/scatter3/scatter3_1.svg)](examples/data_distribution/scatter3/scatter3_1.cpp)
+[![example_scatter3_1](docs/examples/data_distribution/scatter3/scatter3_1.svg)](examples/data_distribution/scatter3/scatter3_1.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/data_distribution/scatter3/scatter3_1.cpp"
-    ```
+```cpp
+--8<-- "examples/data_distribution/scatter3/scatter3_1.cpp"
+```
 
 **More examples**
 
 ===! "Plot"
 
-    [![example_scatter3_2](docs/examples/data_distribution/scatter3/scatter3_2.svg)](examples/data_distribution/scatter3/scatter3_2.cpp)
+[![example_scatter3_2](docs/examples/data_distribution/scatter3/scatter3_2.svg)](examples/data_distribution/scatter3/scatter3_2.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/data_distribution/scatter3/scatter3_2.cpp"
-    ```
+```cpp
+--8<-- "examples/data_distribution/scatter3/scatter3_2.cpp"
+```
 
 
 
 ===! "Plot"
 
-    [![example_scatter3_3](docs/examples/data_distribution/scatter3/scatter3_3.svg)](examples/data_distribution/scatter3/scatter3_3.cpp)
+[![example_scatter3_3](docs/examples/data_distribution/scatter3/scatter3_3.svg)](examples/data_distribution/scatter3/scatter3_3.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/data_distribution/scatter3/scatter3_3.cpp"
-    ```
+```cpp
+--8<-- "examples/data_distribution/scatter3/scatter3_3.cpp"
+```
 
 
 ===! "Plot"
 
-    [![example_scatter3_4](docs/examples/data_distribution/scatter3/scatter3_4.svg)](examples/data_distribution/scatter3/scatter3_4.cpp)
+[![example_scatter3_4](docs/examples/data_distribution/scatter3/scatter3_4.svg)](examples/data_distribution/scatter3/scatter3_4.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/data_distribution/scatter3/scatter3_4.cpp"
-    ```
-
-
-
-===! "Plot"
-
-    [![example_scatter3_5](docs/examples/data_distribution/scatter3/scatter3_5.svg)](examples/data_distribution/scatter3/scatter3_5.cpp)
-
-=== "C++"
-
-    ```cpp
-    --8<-- "examples/data_distribution/scatter3/scatter3_5.cpp"
-    ```
+```cpp
+--8<-- "examples/data_distribution/scatter3/scatter3_4.cpp"
+```
 
 
 
 ===! "Plot"
 
-    [![example_scatter3_6](docs/examples/data_distribution/scatter3/scatter3_6.png)](examples/data_distribution/scatter3/scatter3_6.cpp)
+[![example_scatter3_5](docs/examples/data_distribution/scatter3/scatter3_5.svg)](examples/data_distribution/scatter3/scatter3_5.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/data_distribution/scatter3/scatter3_6.cpp"
-    ```
+```cpp
+--8<-- "examples/data_distribution/scatter3/scatter3_5.cpp"
+```
+
+
+
+===! "Plot"
+
+[![example_scatter3_6](docs/examples/data_distribution/scatter3/scatter3_6.png)](examples/data_distribution/scatter3/scatter3_6.cpp)
+
+=== "C++"
+
+```cpp
+--8<-- "examples/data_distribution/scatter3/scatter3_6.cpp"
+```
 
 
 
@@ -2176,83 +2175,83 @@ More examples:
 
 ===! "Plot"
 
-    [![example_binscatter_1](docs/examples/data_distribution/binscatter/binscatter_1.png)](examples/data_distribution/binscatter/binscatter_1.cpp)
+[![example_binscatter_1](docs/examples/data_distribution/binscatter/binscatter_1.png)](examples/data_distribution/binscatter/binscatter_1.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/data_distribution/binscatter/binscatter_1.cpp"
-    ```
+```cpp
+--8<-- "examples/data_distribution/binscatter/binscatter_1.cpp"
+```
 
 **More examples**
 
 ===! "Plot"
 
-    [![example_binscatter_2](docs/examples/data_distribution/binscatter/binscatter_2.png)](examples/data_distribution/binscatter/binscatter_2.cpp)
+[![example_binscatter_2](docs/examples/data_distribution/binscatter/binscatter_2.png)](examples/data_distribution/binscatter/binscatter_2.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/data_distribution/binscatter/binscatter_2.cpp"
-    ```
+```cpp
+--8<-- "examples/data_distribution/binscatter/binscatter_2.cpp"
+```
 
 
 
 ===! "Plot"
 
-    [![example_binscatter_3](docs/examples/data_distribution/binscatter/binscatter_3.png)](examples/data_distribution/binscatter/binscatter_3.cpp)
+[![example_binscatter_3](docs/examples/data_distribution/binscatter/binscatter_3.png)](examples/data_distribution/binscatter/binscatter_3.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/data_distribution/binscatter/binscatter_3.cpp"
-    ```
+```cpp
+--8<-- "examples/data_distribution/binscatter/binscatter_3.cpp"
+```
 
 
 ===! "Plot"
 
-    [![example_binscatter_4](docs/examples/data_distribution/binscatter/binscatter_4.png)](examples/data_distribution/binscatter/binscatter_4.cpp)
+[![example_binscatter_4](docs/examples/data_distribution/binscatter/binscatter_4.png)](examples/data_distribution/binscatter/binscatter_4.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/data_distribution/binscatter/binscatter_4.cpp"
-    ```
-
-
-
-===! "Plot"
-
-    [![example_binscatter_5](docs/examples/data_distribution/binscatter/binscatter_5.png)](examples/data_distribution/binscatter/binscatter_5.cpp)
-
-=== "C++"
-
-    ```cpp
-    --8<-- "examples/data_distribution/binscatter/binscatter_5.cpp"
-    ```
-
-
-===! "Plot"
-
-    [![example_binscatter_6](docs/examples/data_distribution/binscatter/binscatter_6.png)](examples/data_distribution/binscatter/binscatter_6.cpp)
-
-=== "C++"
-
-    ```cpp
-    --8<-- "examples/data_distribution/binscatter/binscatter_6.cpp"
-    ```
+```cpp
+--8<-- "examples/data_distribution/binscatter/binscatter_4.cpp"
+```
 
 
 
 ===! "Plot"
 
-    [![example_binscatter_7](docs/examples/data_distribution/binscatter/binscatter_7.svg)](examples/data_distribution/binscatter/binscatter_7.cpp)
+[![example_binscatter_5](docs/examples/data_distribution/binscatter/binscatter_5.png)](examples/data_distribution/binscatter/binscatter_5.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/data_distribution/binscatter/binscatter_7.cpp"
-    ```
+```cpp
+--8<-- "examples/data_distribution/binscatter/binscatter_5.cpp"
+```
+
+
+===! "Plot"
+
+[![example_binscatter_6](docs/examples/data_distribution/binscatter/binscatter_6.png)](examples/data_distribution/binscatter/binscatter_6.cpp)
+
+=== "C++"
+
+```cpp
+--8<-- "examples/data_distribution/binscatter/binscatter_6.cpp"
+```
+
+
+
+===! "Plot"
+
+[![example_binscatter_7](docs/examples/data_distribution/binscatter/binscatter_7.svg)](examples/data_distribution/binscatter/binscatter_7.cpp)
+
+=== "C++"
+
+```cpp
+--8<-- "examples/data_distribution/binscatter/binscatter_7.cpp"
+```
 
 
 
@@ -2279,49 +2278,49 @@ More examples:
 
 ===! "Plot"
 
-    [![example_plotmatrix_1](docs/examples/data_distribution/plotmatrix/plotmatrix_1.svg)](examples/data_distribution/plotmatrix/plotmatrix_1.cpp)
+[![example_plotmatrix_1](docs/examples/data_distribution/plotmatrix/plotmatrix_1.svg)](examples/data_distribution/plotmatrix/plotmatrix_1.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/data_distribution/plotmatrix/plotmatrix_1.cpp"
-    ```
+```cpp
+--8<-- "examples/data_distribution/plotmatrix/plotmatrix_1.cpp"
+```
 
 **More examples**
 
 ===! "Plot"
 
-    [![example_plotmatrix_2](docs/examples/data_distribution/plotmatrix/plotmatrix_2.png)](examples/data_distribution/plotmatrix/plotmatrix_2.cpp)
+[![example_plotmatrix_2](docs/examples/data_distribution/plotmatrix/plotmatrix_2.png)](examples/data_distribution/plotmatrix/plotmatrix_2.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/data_distribution/plotmatrix/plotmatrix_2.cpp"
-    ```
+```cpp
+--8<-- "examples/data_distribution/plotmatrix/plotmatrix_2.cpp"
+```
 
 
 
 ===! "Plot"
 
-    [![example_plotmatrix_3](docs/examples/data_distribution/plotmatrix/plotmatrix_3.png)](examples/data_distribution/plotmatrix/plotmatrix_3.cpp)
+[![example_plotmatrix_3](docs/examples/data_distribution/plotmatrix/plotmatrix_3.png)](examples/data_distribution/plotmatrix/plotmatrix_3.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/data_distribution/plotmatrix/plotmatrix_3.cpp"
-    ```
+```cpp
+--8<-- "examples/data_distribution/plotmatrix/plotmatrix_3.cpp"
+```
 
 
 
 ===! "Plot"
 
-    [![example_plotmatrix_4](docs/examples/data_distribution/plotmatrix/plotmatrix_4.svg)](examples/data_distribution/plotmatrix/plotmatrix_4.cpp)
+[![example_plotmatrix_4](docs/examples/data_distribution/plotmatrix/plotmatrix_4.svg)](examples/data_distribution/plotmatrix/plotmatrix_4.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/data_distribution/plotmatrix/plotmatrix_4.cpp"
-    ```
+```cpp
+--8<-- "examples/data_distribution/plotmatrix/plotmatrix_4.cpp"
+```
 
 
 
@@ -2348,37 +2347,37 @@ More examples:
 
 ===! "Plot"
 
-    [![example_parallelplot_1](docs/examples/data_distribution/parallelplot/parallelplot_1.svg)](examples/data_distribution/parallelplot/parallelplot_1.cpp)
+[![example_parallelplot_1](docs/examples/data_distribution/parallelplot/parallelplot_1.svg)](examples/data_distribution/parallelplot/parallelplot_1.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/data_distribution/parallelplot/parallelplot_1.cpp"
-    ```
+```cpp
+--8<-- "examples/data_distribution/parallelplot/parallelplot_1.cpp"
+```
 
 **More examples**
 
 ===! "Plot"
 
-    [![example_parallelplot_2](docs/examples/data_distribution/parallelplot/parallelplot_2.svg)](examples/data_distribution/parallelplot/parallelplot_2.cpp)
+[![example_parallelplot_2](docs/examples/data_distribution/parallelplot/parallelplot_2.svg)](examples/data_distribution/parallelplot/parallelplot_2.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/data_distribution/parallelplot/parallelplot_2.cpp"
-    ```
+```cpp
+--8<-- "examples/data_distribution/parallelplot/parallelplot_2.cpp"
+```
 
 
 
 ===! "Plot"
 
-    [![example_parallelplot_3](docs/examples/data_distribution/parallelplot/parallelplot_3.svg)](examples/data_distribution/parallelplot/parallelplot_3.cpp)
+[![example_parallelplot_3](docs/examples/data_distribution/parallelplot/parallelplot_3.svg)](examples/data_distribution/parallelplot/parallelplot_3.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/data_distribution/parallelplot/parallelplot_3.cpp"
-    ```
+```cpp
+--8<-- "examples/data_distribution/parallelplot/parallelplot_3.cpp"
+```
 
 
 
@@ -2406,72 +2405,72 @@ More examples:
 
 ===! "Plot"
 
-    [![example_pie_1](docs/examples/data_distribution/pie/pie_1.svg)](examples/data_distribution/pie/pie_1.cpp)
+[![example_pie_1](docs/examples/data_distribution/pie/pie_1.svg)](examples/data_distribution/pie/pie_1.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/data_distribution/pie/pie_1.cpp"
-    ```
+```cpp
+--8<-- "examples/data_distribution/pie/pie_1.cpp"
+```
 
 **More examples**
 
 ===! "Plot"
 
-    [![example_pie_2](docs/examples/data_distribution/pie/pie_2.svg)](examples/data_distribution/pie/pie_2.cpp)
+[![example_pie_2](docs/examples/data_distribution/pie/pie_2.svg)](examples/data_distribution/pie/pie_2.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/data_distribution/pie/pie_2.cpp"
-    ```
+```cpp
+--8<-- "examples/data_distribution/pie/pie_2.cpp"
+```
 
 
 
 ===! "Plot"
 
-    [![example_pie_3](docs/examples/data_distribution/pie/pie_3.svg)](examples/data_distribution/pie/pie_3.cpp)
+[![example_pie_3](docs/examples/data_distribution/pie/pie_3.svg)](examples/data_distribution/pie/pie_3.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/data_distribution/pie/pie_3.cpp"
-    ```
+```cpp
+--8<-- "examples/data_distribution/pie/pie_3.cpp"
+```
 
 
 ===! "Plot"
 
-    [![example_pie_4](docs/examples/data_distribution/pie/pie_4.svg)](examples/data_distribution/pie/pie_4.cpp)
+[![example_pie_4](docs/examples/data_distribution/pie/pie_4.svg)](examples/data_distribution/pie/pie_4.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/data_distribution/pie/pie_4.cpp"
-    ```
-
-
-
-===! "Plot"
-
-    [![example_pie_5](docs/examples/data_distribution/pie/pie_5.svg)](examples/data_distribution/pie/pie_5.cpp)
-
-=== "C++"
-
-    ```cpp
-    --8<-- "examples/data_distribution/pie/pie_5.cpp"
-    ```
+```cpp
+--8<-- "examples/data_distribution/pie/pie_4.cpp"
+```
 
 
 
 ===! "Plot"
 
-    [![example_pie_6](docs/examples/data_distribution/pie/pie_6.svg)](examples/data_distribution/pie/pie_6.cpp)
+[![example_pie_5](docs/examples/data_distribution/pie/pie_5.svg)](examples/data_distribution/pie/pie_5.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/data_distribution/pie/pie_6.cpp"
-    ```
+```cpp
+--8<-- "examples/data_distribution/pie/pie_5.cpp"
+```
+
+
+
+===! "Plot"
+
+[![example_pie_6](docs/examples/data_distribution/pie/pie_6.svg)](examples/data_distribution/pie/pie_6.cpp)
+
+=== "C++"
+
+```cpp
+--8<-- "examples/data_distribution/pie/pie_6.cpp"
+```
 
 
 
@@ -2496,83 +2495,83 @@ More examples:
 
 ===! "Plot"
 
-    [![example_heatmap_1](docs/examples/data_distribution/heatmap/heatmap_1.png)](examples/data_distribution/heatmap/heatmap_1.cpp)
+[![example_heatmap_1](docs/examples/data_distribution/heatmap/heatmap_1.png)](examples/data_distribution/heatmap/heatmap_1.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/data_distribution/heatmap/heatmap_1.cpp"
-    ```
+```cpp
+--8<-- "examples/data_distribution/heatmap/heatmap_1.cpp"
+```
 
 **More examples**
 
 ===! "Plot"
 
-    [![example_heatmap_2](docs/examples/data_distribution/heatmap/heatmap_2.png)](examples/data_distribution/heatmap/heatmap_2.cpp)
+[![example_heatmap_2](docs/examples/data_distribution/heatmap/heatmap_2.png)](examples/data_distribution/heatmap/heatmap_2.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/data_distribution/heatmap/heatmap_2.cpp"
-    ```
+```cpp
+--8<-- "examples/data_distribution/heatmap/heatmap_2.cpp"
+```
 
 
 
 ===! "Plot"
 
-    [![example_heatmap_3](docs/examples/data_distribution/heatmap/heatmap_3.png)](examples/data_distribution/heatmap/heatmap_3.cpp)
+[![example_heatmap_3](docs/examples/data_distribution/heatmap/heatmap_3.png)](examples/data_distribution/heatmap/heatmap_3.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/data_distribution/heatmap/heatmap_3.cpp"
-    ```
+```cpp
+--8<-- "examples/data_distribution/heatmap/heatmap_3.cpp"
+```
 
 
 ===! "Plot"
 
-    [![example_heatmap_4](docs/examples/data_distribution/heatmap/heatmap_4.png)](examples/data_distribution/heatmap/heatmap_4.cpp)
+[![example_heatmap_4](docs/examples/data_distribution/heatmap/heatmap_4.png)](examples/data_distribution/heatmap/heatmap_4.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/data_distribution/heatmap/heatmap_4.cpp"
-    ```
-
-
-
-===! "Plot"
-
-    [![example_heatmap_5](docs/examples/data_distribution/heatmap/heatmap_5.png)](examples/data_distribution/heatmap/heatmap_5.cpp)
-
-=== "C++"
-
-    ```cpp
-    --8<-- "examples/data_distribution/heatmap/heatmap_5.cpp"
-    ```
-
-
-===! "Plot"
-
-    [![example_heatmap_6](docs/examples/data_distribution/heatmap/heatmap_6.png)](examples/data_distribution/heatmap/heatmap_6.cpp)
-
-=== "C++"
-
-    ```cpp
-    --8<-- "examples/data_distribution/heatmap/heatmap_6.cpp"
-    ```
+```cpp
+--8<-- "examples/data_distribution/heatmap/heatmap_4.cpp"
+```
 
 
 
 ===! "Plot"
 
-    [![example_heatmap_7](docs/examples/data_distribution/heatmap/heatmap_7.png)](examples/data_distribution/heatmap/heatmap_7.cpp)
+[![example_heatmap_5](docs/examples/data_distribution/heatmap/heatmap_5.png)](examples/data_distribution/heatmap/heatmap_5.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/data_distribution/heatmap/heatmap_7.cpp"
-    ```
+```cpp
+--8<-- "examples/data_distribution/heatmap/heatmap_5.cpp"
+```
+
+
+===! "Plot"
+
+[![example_heatmap_6](docs/examples/data_distribution/heatmap/heatmap_6.png)](examples/data_distribution/heatmap/heatmap_6.cpp)
+
+=== "C++"
+
+```cpp
+--8<-- "examples/data_distribution/heatmap/heatmap_6.cpp"
+```
+
+
+
+===! "Plot"
+
+[![example_heatmap_7](docs/examples/data_distribution/heatmap/heatmap_7.png)](examples/data_distribution/heatmap/heatmap_7.cpp)
+
+=== "C++"
+
+```cpp
+--8<-- "examples/data_distribution/heatmap/heatmap_7.cpp"
+```
 
 
 
@@ -2596,49 +2595,49 @@ More examples:
 
 ===! "Plot"
 
-    [![example_wordcloud_1](docs/examples/data_distribution/wordcloud/wordcloud_1.png)](examples/data_distribution/wordcloud/wordcloud_1.cpp)
+[![example_wordcloud_1](docs/examples/data_distribution/wordcloud/wordcloud_1.png)](examples/data_distribution/wordcloud/wordcloud_1.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/data_distribution/wordcloud/wordcloud_1.cpp"
-    ```
+```cpp
+--8<-- "examples/data_distribution/wordcloud/wordcloud_1.cpp"
+```
 
 **More examples**
 
 ===! "Plot"
 
-    [![example_wordcloud_3](docs/examples/data_distribution/wordcloud/wordcloud_3.png)](examples/data_distribution/wordcloud/wordcloud_3.cpp)
+[![example_wordcloud_3](docs/examples/data_distribution/wordcloud/wordcloud_3.png)](examples/data_distribution/wordcloud/wordcloud_3.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/data_distribution/wordcloud/wordcloud_3.cpp"
-    ```
+```cpp
+--8<-- "examples/data_distribution/wordcloud/wordcloud_3.cpp"
+```
 
 
 
 ===! "Plot"
 
-    [![example_wordcloud_4](docs/examples/data_distribution/wordcloud/wordcloud_4.png)](examples/data_distribution/wordcloud/wordcloud_4.cpp)
+[![example_wordcloud_4](docs/examples/data_distribution/wordcloud/wordcloud_4.png)](examples/data_distribution/wordcloud/wordcloud_4.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/data_distribution/wordcloud/wordcloud_4.cpp"
-    ```
+```cpp
+--8<-- "examples/data_distribution/wordcloud/wordcloud_4.cpp"
+```
 
 
 
 ===! "Plot"
 
-    [![example_wordcloud_4](docs/examples/data_distribution/wordcloud/wordcloud_4.png)](examples/data_distribution/wordcloud/wordcloud_4.cpp)
+[![example_wordcloud_4](docs/examples/data_distribution/wordcloud/wordcloud_4.png)](examples/data_distribution/wordcloud/wordcloud_4.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/data_distribution/wordcloud/wordcloud_4.cpp"
-    ```
+```cpp
+--8<-- "examples/data_distribution/wordcloud/wordcloud_4.cpp"
+```
 
 
 
@@ -2674,152 +2673,152 @@ More examples:
 
 ===! "Plot"
 
-    [![example_bar_1](docs/examples/discrete_data/bar/bar_1.png)](examples/discrete_data/bar/bar_1.cpp)
+[![example_bar_1](docs/examples/discrete_data/bar/bar_1.png)](examples/discrete_data/bar/bar_1.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/discrete_data/bar/bar_1.cpp"
-    ```
+```cpp
+--8<-- "examples/discrete_data/bar/bar_1.cpp"
+```
 
 **More examples**
 
 ===! "Plot"
 
-    [![example_bar_2](docs/examples/discrete_data/bar/bar_2.png)](examples/discrete_data/bar/bar_2.cpp)
+[![example_bar_2](docs/examples/discrete_data/bar/bar_2.png)](examples/discrete_data/bar/bar_2.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/discrete_data/bar/bar_2.cpp"
-    ```
+```cpp
+--8<-- "examples/discrete_data/bar/bar_2.cpp"
+```
 
 
 
 ===! "Plot"
 
-    [![example_bar_3](docs/examples/discrete_data/bar/bar_3.png)](examples/discrete_data/bar/bar_3.cpp)
+[![example_bar_3](docs/examples/discrete_data/bar/bar_3.png)](examples/discrete_data/bar/bar_3.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/discrete_data/bar/bar_3.cpp"
-    ```
+```cpp
+--8<-- "examples/discrete_data/bar/bar_3.cpp"
+```
 
 
 ===! "Plot"
 
-    [![example_bar_4](docs/examples/discrete_data/bar/bar_4.png)](examples/discrete_data/bar/bar_4.cpp)
+[![example_bar_4](docs/examples/discrete_data/bar/bar_4.png)](examples/discrete_data/bar/bar_4.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/discrete_data/bar/bar_4.cpp"
-    ```
-
-
-
-===! "Plot"
-
-    [![example_bar_5](docs/examples/discrete_data/bar/bar_5.png)](examples/discrete_data/bar/bar_5.cpp)
-
-=== "C++"
-
-    ```cpp
-    --8<-- "examples/discrete_data/bar/bar_5.cpp"
-    ```
-
-
-===! "Plot"
-
-    [![example_bar_6](docs/examples/discrete_data/bar/bar_6.png)](examples/discrete_data/bar/bar_6.cpp)
-
-=== "C++"
-
-    ```cpp
-    --8<-- "examples/discrete_data/bar/bar_6.cpp"
-    ```
+```cpp
+--8<-- "examples/discrete_data/bar/bar_4.cpp"
+```
 
 
 
 ===! "Plot"
 
-    [![example_bar_7](docs/examples/discrete_data/bar/bar_7.svg)](examples/discrete_data/bar/bar_7.cpp)
+[![example_bar_5](docs/examples/discrete_data/bar/bar_5.png)](examples/discrete_data/bar/bar_5.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/discrete_data/bar/bar_7.cpp"
-    ```
+```cpp
+--8<-- "examples/discrete_data/bar/bar_5.cpp"
+```
 
 
 ===! "Plot"
 
-    [![example_bar_8](docs/examples/discrete_data/bar/bar_8.png)](examples/discrete_data/bar/bar_8.cpp)
+[![example_bar_6](docs/examples/discrete_data/bar/bar_6.png)](examples/discrete_data/bar/bar_6.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/discrete_data/bar/bar_8.cpp"
-    ```
-
-
-
-===! "Plot"
-
-    [![example_bar_9](docs/examples/discrete_data/bar/bar_9.png)](examples/discrete_data/bar/bar_9.cpp)
-
-=== "C++"
-
-    ```cpp
-    --8<-- "examples/discrete_data/bar/bar_9.cpp"
-    ```
-
-
-===! "Plot"
-
-    [![example_bar_10](docs/examples/discrete_data/bar/bar_10.png)](examples/discrete_data/bar/bar_10.cpp)
-
-=== "C++"
-
-    ```cpp
-    --8<-- "examples/discrete_data/bar/bar_10.cpp"
-    ```
+```cpp
+--8<-- "examples/discrete_data/bar/bar_6.cpp"
+```
 
 
 
 ===! "Plot"
 
-    [![example_bar_11](docs/examples/discrete_data/bar/bar_11.png)](examples/discrete_data/bar/bar_11.cpp)
+[![example_bar_7](docs/examples/discrete_data/bar/bar_7.svg)](examples/discrete_data/bar/bar_7.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/discrete_data/bar/bar_11.cpp"
-    ```
+```cpp
+--8<-- "examples/discrete_data/bar/bar_7.cpp"
+```
 
 
 ===! "Plot"
 
-    [![example_bar_12](docs/examples/discrete_data/bar/bar_12.png)](examples/discrete_data/bar/bar_12.cpp)
+[![example_bar_8](docs/examples/discrete_data/bar/bar_8.png)](examples/discrete_data/bar/bar_8.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/discrete_data/bar/bar_12.cpp"
-    ```
+```cpp
+--8<-- "examples/discrete_data/bar/bar_8.cpp"
+```
 
 
 
 ===! "Plot"
 
-    [![example_bar_13](docs/examples/discrete_data/bar/bar_13.png)](examples/discrete_data/bar/bar_13.cpp)
+[![example_bar_9](docs/examples/discrete_data/bar/bar_9.png)](examples/discrete_data/bar/bar_9.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/discrete_data/bar/bar_13.cpp"
-    ```
+```cpp
+--8<-- "examples/discrete_data/bar/bar_9.cpp"
+```
+
+
+===! "Plot"
+
+[![example_bar_10](docs/examples/discrete_data/bar/bar_10.png)](examples/discrete_data/bar/bar_10.cpp)
+
+=== "C++"
+
+```cpp
+--8<-- "examples/discrete_data/bar/bar_10.cpp"
+```
+
+
+
+===! "Plot"
+
+[![example_bar_11](docs/examples/discrete_data/bar/bar_11.png)](examples/discrete_data/bar/bar_11.cpp)
+
+=== "C++"
+
+```cpp
+--8<-- "examples/discrete_data/bar/bar_11.cpp"
+```
+
+
+===! "Plot"
+
+[![example_bar_12](docs/examples/discrete_data/bar/bar_12.png)](examples/discrete_data/bar/bar_12.cpp)
+
+=== "C++"
+
+```cpp
+--8<-- "examples/discrete_data/bar/bar_12.cpp"
+```
+
+
+
+===! "Plot"
+
+[![example_bar_13](docs/examples/discrete_data/bar/bar_13.png)](examples/discrete_data/bar/bar_13.cpp)
+
+=== "C++"
+
+```cpp
+--8<-- "examples/discrete_data/bar/bar_13.cpp"
+```
 
 
 
@@ -2843,49 +2842,49 @@ More examples:
 
 ===! "Plot"
 
-    [![example_pareto_1](docs/examples/discrete_data/pareto/pareto_1.svg)](examples/discrete_data/pareto/pareto_1.cpp)
+[![example_pareto_1](docs/examples/discrete_data/pareto/pareto_1.svg)](examples/discrete_data/pareto/pareto_1.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/discrete_data/pareto/pareto_1.cpp"
-    ```
+```cpp
+--8<-- "examples/discrete_data/pareto/pareto_1.cpp"
+```
 
 **More examples**
 
 ===! "Plot"
 
-    [![example_pareto_2](docs/examples/discrete_data/pareto/pareto_2.svg)](examples/discrete_data/pareto/pareto_2.cpp)
+[![example_pareto_2](docs/examples/discrete_data/pareto/pareto_2.svg)](examples/discrete_data/pareto/pareto_2.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/discrete_data/pareto/pareto_2.cpp"
-    ```
+```cpp
+--8<-- "examples/discrete_data/pareto/pareto_2.cpp"
+```
 
 
 
 ===! "Plot"
 
-    [![example_pareto_3](docs/examples/discrete_data/pareto/pareto_3.svg)](examples/discrete_data/pareto/pareto_3.cpp)
+[![example_pareto_3](docs/examples/discrete_data/pareto/pareto_3.svg)](examples/discrete_data/pareto/pareto_3.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/discrete_data/pareto/pareto_3.cpp"
-    ```
+```cpp
+--8<-- "examples/discrete_data/pareto/pareto_3.cpp"
+```
 
 
 
 ===! "Plot"
 
-    [![example_pareto_4](docs/examples/discrete_data/pareto/pareto_4.svg)](examples/discrete_data/pareto/pareto_4.cpp)
+[![example_pareto_4](docs/examples/discrete_data/pareto/pareto_4.svg)](examples/discrete_data/pareto/pareto_4.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/discrete_data/pareto/pareto_4.cpp"
-    ```
+```cpp
+--8<-- "examples/discrete_data/pareto/pareto_4.cpp"
+```
 
 
 
@@ -2914,106 +2913,106 @@ More examples:
 
 ===! "Plot"
 
-    [![example_stem_1](docs/examples/discrete_data/stem/stem_1.svg)](examples/discrete_data/stem/stem_1.cpp)
+[![example_stem_1](docs/examples/discrete_data/stem/stem_1.svg)](examples/discrete_data/stem/stem_1.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/discrete_data/stem/stem_1.cpp"
-    ```
+```cpp
+--8<-- "examples/discrete_data/stem/stem_1.cpp"
+```
 
 **More examples**
 
 ===! "Plot"
 
-    [![example_stem_2](docs/examples/discrete_data/stem/stem_2.svg)](examples/discrete_data/stem/stem_2.cpp)
+[![example_stem_2](docs/examples/discrete_data/stem/stem_2.svg)](examples/discrete_data/stem/stem_2.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/discrete_data/stem/stem_2.cpp"
-    ```
+```cpp
+--8<-- "examples/discrete_data/stem/stem_2.cpp"
+```
 
 
 
 ===! "Plot"
 
-    [![example_stem_3](docs/examples/discrete_data/stem/stem_3.svg)](examples/discrete_data/stem/stem_3.cpp)
+[![example_stem_3](docs/examples/discrete_data/stem/stem_3.svg)](examples/discrete_data/stem/stem_3.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/discrete_data/stem/stem_3.cpp"
-    ```
+```cpp
+--8<-- "examples/discrete_data/stem/stem_3.cpp"
+```
 
 
 ===! "Plot"
 
-    [![example_stem_4](docs/examples/discrete_data/stem/stem_4.svg)](examples/discrete_data/stem/stem_4.cpp)
+[![example_stem_4](docs/examples/discrete_data/stem/stem_4.svg)](examples/discrete_data/stem/stem_4.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/discrete_data/stem/stem_4.cpp"
-    ```
-
-
-
-===! "Plot"
-
-    [![example_stem_5](docs/examples/discrete_data/stem/stem_5.svg)](examples/discrete_data/stem/stem_5.cpp)
-
-=== "C++"
-
-    ```cpp
-    --8<-- "examples/discrete_data/stem/stem_5.cpp"
-    ```
-
-
-===! "Plot"
-
-    [![example_stem_6](docs/examples/discrete_data/stem/stem_6.svg)](examples/discrete_data/stem/stem_6.cpp)
-
-=== "C++"
-
-    ```cpp
-    --8<-- "examples/discrete_data/stem/stem_6.cpp"
-    ```
+```cpp
+--8<-- "examples/discrete_data/stem/stem_4.cpp"
+```
 
 
 
 ===! "Plot"
 
-    [![example_stem_7](docs/examples/discrete_data/stem/stem_7.svg)](examples/discrete_data/stem/stem_7.cpp)
+[![example_stem_5](docs/examples/discrete_data/stem/stem_5.svg)](examples/discrete_data/stem/stem_5.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/discrete_data/stem/stem_7.cpp"
-    ```
+```cpp
+--8<-- "examples/discrete_data/stem/stem_5.cpp"
+```
 
 
 ===! "Plot"
 
-    [![example_stem_8](docs/examples/discrete_data/stem/stem_8.svg)](examples/discrete_data/stem/stem_8.cpp)
+[![example_stem_6](docs/examples/discrete_data/stem/stem_6.svg)](examples/discrete_data/stem/stem_6.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/discrete_data/stem/stem_8.cpp"
-    ```
+```cpp
+--8<-- "examples/discrete_data/stem/stem_6.cpp"
+```
 
 
 
 ===! "Plot"
 
-    [![example_stem_9](docs/examples/discrete_data/stem/stem_9.svg)](examples/discrete_data/stem/stem_9.cpp)
+[![example_stem_7](docs/examples/discrete_data/stem/stem_7.svg)](examples/discrete_data/stem/stem_7.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/discrete_data/stem/stem_9.cpp"
-    ```
+```cpp
+--8<-- "examples/discrete_data/stem/stem_7.cpp"
+```
+
+
+===! "Plot"
+
+[![example_stem_8](docs/examples/discrete_data/stem/stem_8.svg)](examples/discrete_data/stem/stem_8.cpp)
+
+=== "C++"
+
+```cpp
+--8<-- "examples/discrete_data/stem/stem_8.cpp"
+```
+
+
+
+===! "Plot"
+
+[![example_stem_9](docs/examples/discrete_data/stem/stem_9.svg)](examples/discrete_data/stem/stem_9.cpp)
+
+=== "C++"
+
+```cpp
+--8<-- "examples/discrete_data/stem/stem_9.cpp"
+```
 
 
 
@@ -3038,129 +3037,129 @@ More examples:
 
 ===! "Plot"
 
-    [![example_stem3_1](docs/examples/discrete_data/stem3/stem3_1.svg)](examples/discrete_data/stem3/stem3_1.cpp)
+[![example_stem3_1](docs/examples/discrete_data/stem3/stem3_1.svg)](examples/discrete_data/stem3/stem3_1.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/discrete_data/stem3/stem3_1.cpp"
-    ```
+```cpp
+--8<-- "examples/discrete_data/stem3/stem3_1.cpp"
+```
 
 **More examples**
 
 ===! "Plot"
 
-    [![example_stem3_2](docs/examples/discrete_data/stem3/stem3_2.svg)](examples/discrete_data/stem3/stem3_2.cpp)
+[![example_stem3_2](docs/examples/discrete_data/stem3/stem3_2.svg)](examples/discrete_data/stem3/stem3_2.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/discrete_data/stem3/stem3_2.cpp"
-    ```
+```cpp
+--8<-- "examples/discrete_data/stem3/stem3_2.cpp"
+```
 
 
 
 ===! "Plot"
 
-    [![example_stem3_3](docs/examples/discrete_data/stem3/stem3_3.svg)](examples/discrete_data/stem3/stem3_3.cpp)
+[![example_stem3_3](docs/examples/discrete_data/stem3/stem3_3.svg)](examples/discrete_data/stem3/stem3_3.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/discrete_data/stem3/stem3_3.cpp"
-    ```
+```cpp
+--8<-- "examples/discrete_data/stem3/stem3_3.cpp"
+```
 
 
 ===! "Plot"
 
-    [![example_stem3_4](docs/examples/discrete_data/stem3/stem3_4.svg)](examples/discrete_data/stem3/stem3_4.cpp)
+[![example_stem3_4](docs/examples/discrete_data/stem3/stem3_4.svg)](examples/discrete_data/stem3/stem3_4.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/discrete_data/stem3/stem3_4.cpp"
-    ```
-
-
-
-===! "Plot"
-
-    [![example_stem3_5](docs/examples/discrete_data/stem3/stem3_5.svg)](examples/discrete_data/stem3/stem3_5.cpp)
-
-=== "C++"
-
-    ```cpp
-    --8<-- "examples/discrete_data/stem3/stem3_5.cpp"
-    ```
-
-
-===! "Plot"
-
-    [![example_stem3_6](docs/examples/discrete_data/stem3/stem3_6.svg)](examples/discrete_data/stem3/stem3_6.cpp)
-
-=== "C++"
-
-    ```cpp
-    --8<-- "examples/discrete_data/stem3/stem3_6.cpp"
-    ```
+```cpp
+--8<-- "examples/discrete_data/stem3/stem3_4.cpp"
+```
 
 
 
 ===! "Plot"
 
-    [![example_stem3_7](docs/examples/discrete_data/stem3/stem3_7.svg)](examples/discrete_data/stem3/stem3_7.cpp)
+[![example_stem3_5](docs/examples/discrete_data/stem3/stem3_5.svg)](examples/discrete_data/stem3/stem3_5.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/discrete_data/stem3/stem3_7.cpp"
-    ```
+```cpp
+--8<-- "examples/discrete_data/stem3/stem3_5.cpp"
+```
 
 
 ===! "Plot"
 
-    [![example_stem3_8](docs/examples/discrete_data/stem3/stem3_8.svg)](examples/discrete_data/stem3/stem3_8.cpp)
+[![example_stem3_6](docs/examples/discrete_data/stem3/stem3_6.svg)](examples/discrete_data/stem3/stem3_6.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/discrete_data/stem3/stem3_8.cpp"
-    ```
-
-
-
-===! "Plot"
-
-    [![example_stem3_9](docs/examples/discrete_data/stem3/stem3_9.svg)](examples/discrete_data/stem3/stem3_9.cpp)
-
-=== "C++"
-
-    ```cpp
-    --8<-- "examples/discrete_data/stem3/stem3_9.cpp"
-    ```
-
-
-===! "Plot"
-
-    [![example_stem3_10](docs/examples/discrete_data/stem3/stem3_10.svg)](examples/discrete_data/stem3/stem3_10.cpp)
-
-=== "C++"
-
-    ```cpp
-    --8<-- "examples/discrete_data/stem3/stem3_10.cpp"
-    ```
+```cpp
+--8<-- "examples/discrete_data/stem3/stem3_6.cpp"
+```
 
 
 
 ===! "Plot"
 
-    [![example_stem3_11](docs/examples/discrete_data/stem3/stem3_11.svg)](examples/discrete_data/stem3/stem3_11.cpp)
+[![example_stem3_7](docs/examples/discrete_data/stem3/stem3_7.svg)](examples/discrete_data/stem3/stem3_7.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/discrete_data/stem3/stem3_11.cpp"
-    ```
+```cpp
+--8<-- "examples/discrete_data/stem3/stem3_7.cpp"
+```
+
+
+===! "Plot"
+
+[![example_stem3_8](docs/examples/discrete_data/stem3/stem3_8.svg)](examples/discrete_data/stem3/stem3_8.cpp)
+
+=== "C++"
+
+```cpp
+--8<-- "examples/discrete_data/stem3/stem3_8.cpp"
+```
+
+
+
+===! "Plot"
+
+[![example_stem3_9](docs/examples/discrete_data/stem3/stem3_9.svg)](examples/discrete_data/stem3/stem3_9.cpp)
+
+=== "C++"
+
+```cpp
+--8<-- "examples/discrete_data/stem3/stem3_9.cpp"
+```
+
+
+===! "Plot"
+
+[![example_stem3_10](docs/examples/discrete_data/stem3/stem3_10.svg)](examples/discrete_data/stem3/stem3_10.cpp)
+
+=== "C++"
+
+```cpp
+--8<-- "examples/discrete_data/stem3/stem3_10.cpp"
+```
+
+
+
+===! "Plot"
+
+[![example_stem3_11](docs/examples/discrete_data/stem3/stem3_11.svg)](examples/discrete_data/stem3/stem3_11.cpp)
+
+=== "C++"
+
+```cpp
+--8<-- "examples/discrete_data/stem3/stem3_11.cpp"
+```
 
 
 
@@ -3191,84 +3190,84 @@ More examples:
 
 ===! "Plot"
 
-    [![example_geoplot_1](docs/examples/geography/geoplot/geoplot_1.png)](examples/geography/geoplot/geoplot_1.cpp)
+[![example_geoplot_1](docs/examples/geography/geoplot/geoplot_1.png)](examples/geography/geoplot/geoplot_1.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/geography/geoplot/geoplot_1.cpp"
-    ```
+```cpp
+--8<-- "examples/geography/geoplot/geoplot_1.cpp"
+```
 
 **More examples**
 
 
 ===! "Plot"
 
-    [![example_geoplot_2](docs/examples/geography/geoplot/geoplot_2.png)](examples/geography/geoplot/geoplot_2.cpp)
+[![example_geoplot_2](docs/examples/geography/geoplot/geoplot_2.png)](examples/geography/geoplot/geoplot_2.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/geography/geoplot/geoplot_2.cpp"
-    ```
+```cpp
+--8<-- "examples/geography/geoplot/geoplot_2.cpp"
+```
 
 
 
 ===! "Plot"
 
-    [![example_geoplot_3](docs/examples/geography/geoplot/geoplot_3.png)](examples/geography/geoplot/geoplot_3.cpp)
+[![example_geoplot_3](docs/examples/geography/geoplot/geoplot_3.png)](examples/geography/geoplot/geoplot_3.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/geography/geoplot/geoplot_3.cpp"
-    ```
+```cpp
+--8<-- "examples/geography/geoplot/geoplot_3.cpp"
+```
 
 
 ===! "Plot"
 
-    [![example_geoplot_4](docs/examples/geography/geoplot/geoplot_4.png)](examples/geography/geoplot/geoplot_4.cpp)
+[![example_geoplot_4](docs/examples/geography/geoplot/geoplot_4.png)](examples/geography/geoplot/geoplot_4.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/geography/geoplot/geoplot_4.cpp"
-    ```
-
-
-
-===! "Plot"
-
-    [![example_geoplot_5](docs/examples/geography/geoplot/geoplot_5.png)](examples/geography/geoplot/geoplot_5.cpp)
-
-=== "C++"
-
-    ```cpp
-    --8<-- "examples/geography/geoplot/geoplot_5.cpp"
-    ```
-
-
-===! "Plot"
-
-    [![example_geoplot_6](docs/examples/geography/geoplot/geoplot_6.png)](examples/geography/geoplot/geoplot_6.cpp)
-
-=== "C++"
-
-    ```cpp
-    --8<-- "examples/geography/geoplot/geoplot_6.cpp"
-    ```
+```cpp
+--8<-- "examples/geography/geoplot/geoplot_4.cpp"
+```
 
 
 
 ===! "Plot"
 
-    [![example_geoplot_7](docs/examples/geography/geoplot/geoplot_7.png)](examples/geography/geoplot/geoplot_7.cpp)
+[![example_geoplot_5](docs/examples/geography/geoplot/geoplot_5.png)](examples/geography/geoplot/geoplot_5.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/geography/geoplot/geoplot_7.cpp"
-    ```
+```cpp
+--8<-- "examples/geography/geoplot/geoplot_5.cpp"
+```
+
+
+===! "Plot"
+
+[![example_geoplot_6](docs/examples/geography/geoplot/geoplot_6.png)](examples/geography/geoplot/geoplot_6.cpp)
+
+=== "C++"
+
+```cpp
+--8<-- "examples/geography/geoplot/geoplot_6.cpp"
+```
+
+
+
+===! "Plot"
+
+[![example_geoplot_7](docs/examples/geography/geoplot/geoplot_7.png)](examples/geography/geoplot/geoplot_7.cpp)
+
+=== "C++"
+
+```cpp
+--8<-- "examples/geography/geoplot/geoplot_7.cpp"
+```
 
 
 
@@ -3306,26 +3305,26 @@ More examples:
 
 ===! "Plot"
 
-    [![example_geoscatter_1](docs/examples/geography/geoscatter/geoscatter_1.png)](examples/geography/geoscatter/geoscatter_1.cpp)
+[![example_geoscatter_1](docs/examples/geography/geoscatter/geoscatter_1.png)](examples/geography/geoscatter/geoscatter_1.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/geography/geoscatter/geoscatter_1.cpp"
-    ```
+```cpp
+--8<-- "examples/geography/geoscatter/geoscatter_1.cpp"
+```
 
 **More examples**
 
 
 ===! "Plot"
 
-    [![example_geoscatter_2](docs/examples/geography/geoscatter/geoscatter_2.png)](examples/geography/geoscatter/geoscatter_2.cpp)
+[![example_geoscatter_2](docs/examples/geography/geoscatter/geoscatter_2.png)](examples/geography/geoscatter/geoscatter_2.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/geography/geoscatter/geoscatter_2.cpp"
-    ```
+```cpp
+--8<-- "examples/geography/geoscatter/geoscatter_2.cpp"
+```
 
   
 #### Geobubble
@@ -3349,26 +3348,26 @@ More examples:
 
 ===! "Plot"
 
-    [![example_geobubble_1](docs/examples/geography/geobubble/geobubble_1.png)](examples/geography/geobubble/geobubble_1.cpp)
+[![example_geobubble_1](docs/examples/geography/geobubble/geobubble_1.png)](examples/geography/geobubble/geobubble_1.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/geography/geobubble/geobubble_1.cpp"
-    ```
+```cpp
+--8<-- "examples/geography/geobubble/geobubble_1.cpp"
+```
 
 **More examples**
 
 
 ===! "Plot"
 
-    [![example_geobubble_2](docs/examples/geography/geobubble/geobubble_2.png)](examples/geography/geobubble/geobubble_2.cpp)
+[![example_geobubble_2](docs/examples/geography/geobubble/geobubble_2.png)](examples/geography/geobubble/geobubble_2.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/geography/geobubble/geobubble_2.cpp"
-    ```
+```cpp
+--8<-- "examples/geography/geobubble/geobubble_2.cpp"
+```
 
 
   
@@ -3388,13 +3387,13 @@ geodensityplot(lat, lon);
 
 === "Plot"
 
-    [![example_geodensityplot_1](docs/examples/geography/geodensityplot/geodensityplot_1.png)](examples/geography/geodensityplot/geodensityplot_1.cpp)
+[![example_geodensityplot_1](docs/examples/geography/geodensityplot/geodensityplot_1.png)](examples/geography/geodensityplot/geodensityplot_1.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/geography/geodensityplot/geodensityplot_1.cpp"
-    ```
+```cpp
+--8<-- "examples/geography/geodensityplot/geodensityplot_1.cpp"
+```
 
 ### Polar Plots
 
@@ -3422,96 +3421,96 @@ More examples:
 
 ===! "Plot"
 
-    [![example_polarplot_1](docs/examples/polar_plots/polarplot/polarplot_1.svg)](examples/polar_plots/polarplot/polarplot_1.cpp)
+[![example_polarplot_1](docs/examples/polar_plots/polarplot/polarplot_1.svg)](examples/polar_plots/polarplot/polarplot_1.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/polar_plots/polarplot/polarplot_1.cpp"
-    ```
+```cpp
+--8<-- "examples/polar_plots/polarplot/polarplot_1.cpp"
+```
 
 **More examples**
 
 
 ===! "Plot"
 
-    [![example_polarplot_2](docs/examples/polar_plots/polarplot/polarplot_2.svg)](examples/polar_plots/polarplot/polarplot_2.cpp)
+[![example_polarplot_2](docs/examples/polar_plots/polarplot/polarplot_2.svg)](examples/polar_plots/polarplot/polarplot_2.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/polar_plots/polarplot/polarplot_2.cpp"
-    ```
+```cpp
+--8<-- "examples/polar_plots/polarplot/polarplot_2.cpp"
+```
 
 
 
 ===! "Plot"
 
-    [![example_polarplot_3](docs/examples/polar_plots/polarplot/polarplot_3.svg)](examples/polar_plots/polarplot/polarplot_3.cpp)
+[![example_polarplot_3](docs/examples/polar_plots/polarplot/polarplot_3.svg)](examples/polar_plots/polarplot/polarplot_3.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/polar_plots/polarplot/polarplot_3.cpp"
-    ```
+```cpp
+--8<-- "examples/polar_plots/polarplot/polarplot_3.cpp"
+```
 
 
 ===! "Plot"
 
-    [![example_polarplot_4](docs/examples/polar_plots/polarplot/polarplot_4.svg)](examples/polar_plots/polarplot/polarplot_4.cpp)
+[![example_polarplot_4](docs/examples/polar_plots/polarplot/polarplot_4.svg)](examples/polar_plots/polarplot/polarplot_4.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/polar_plots/polarplot/polarplot_4.cpp"
-    ```
-
-
-
-===! "Plot"
-
-    [![example_polarplot_5](docs/examples/polar_plots/polarplot/polarplot_5.svg)](examples/polar_plots/polarplot/polarplot_5.cpp)
-
-=== "C++"
-
-    ```cpp
-    --8<-- "examples/polar_plots/polarplot/polarplot_5.cpp"
-    ```
-
-
-===! "Plot"
-
-    [![example_polarplot_6](docs/examples/polar_plots/polarplot/polarplot_6.svg)](examples/polar_plots/polarplot/polarplot_6.cpp)
-
-=== "C++"
-
-    ```cpp
-    --8<-- "examples/polar_plots/polarplot/polarplot_6.cpp"
-    ```
+```cpp
+--8<-- "examples/polar_plots/polarplot/polarplot_4.cpp"
+```
 
 
 
 ===! "Plot"
 
-    [![example_polarplot_7](docs/examples/polar_plots/polarplot/polarplot_7.svg)](examples/polar_plots/polarplot/polarplot_7.cpp)
+[![example_polarplot_5](docs/examples/polar_plots/polarplot/polarplot_5.svg)](examples/polar_plots/polarplot/polarplot_5.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/polar_plots/polarplot/polarplot_7.cpp"
-    ```
+```cpp
+--8<-- "examples/polar_plots/polarplot/polarplot_5.cpp"
+```
+
+
+===! "Plot"
+
+[![example_polarplot_6](docs/examples/polar_plots/polarplot/polarplot_6.svg)](examples/polar_plots/polarplot/polarplot_6.cpp)
+
+=== "C++"
+
+```cpp
+--8<-- "examples/polar_plots/polarplot/polarplot_6.cpp"
+```
 
 
 
 ===! "Plot"
 
-    [![example_polarplot_8](docs/examples/polar_plots/polarplot/polarplot_8.svg)](examples/polar_plots/polarplot/polarplot_8.cpp)
+[![example_polarplot_7](docs/examples/polar_plots/polarplot/polarplot_7.svg)](examples/polar_plots/polarplot/polarplot_7.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/polar_plots/polarplot/polarplot_8.cpp"
-    ```
+```cpp
+--8<-- "examples/polar_plots/polarplot/polarplot_7.cpp"
+```
+
+
+
+===! "Plot"
+
+[![example_polarplot_8](docs/examples/polar_plots/polarplot/polarplot_8.svg)](examples/polar_plots/polarplot/polarplot_8.cpp)
+
+=== "C++"
+
+```cpp
+--8<-- "examples/polar_plots/polarplot/polarplot_8.cpp"
+```
 
 
 
@@ -3541,72 +3540,72 @@ More examples:
 
 ===! "Plot"
 
-    [![example_polarscatter_1](docs/examples/polar_plots/polarscatter/polarscatter_1.svg)](examples/polar_plots/polarscatter/polarscatter_1.cpp)
+[![example_polarscatter_1](docs/examples/polar_plots/polarscatter/polarscatter_1.svg)](examples/polar_plots/polarscatter/polarscatter_1.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/polar_plots/polarscatter/polarscatter_1.cpp"
-    ```
+```cpp
+--8<-- "examples/polar_plots/polarscatter/polarscatter_1.cpp"
+```
 
 **More examples**
 
 ===! "Plot"
 
-    [![example_polarscatter_2](docs/examples/polar_plots/polarscatter/polarscatter_2.svg)](examples/polar_plots/polarscatter/polarscatter_2.cpp)
+[![example_polarscatter_2](docs/examples/polar_plots/polarscatter/polarscatter_2.svg)](examples/polar_plots/polarscatter/polarscatter_2.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/polar_plots/polarscatter/polarscatter_2.cpp"
-    ```
+```cpp
+--8<-- "examples/polar_plots/polarscatter/polarscatter_2.cpp"
+```
 
 
 
 ===! "Plot"
 
-    [![example_polarscatter_3](docs/examples/polar_plots/polarscatter/polarscatter_3.svg)](examples/polar_plots/polarscatter/polarscatter_3.cpp)
+[![example_polarscatter_3](docs/examples/polar_plots/polarscatter/polarscatter_3.svg)](examples/polar_plots/polarscatter/polarscatter_3.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/polar_plots/polarscatter/polarscatter_3.cpp"
-    ```
+```cpp
+--8<-- "examples/polar_plots/polarscatter/polarscatter_3.cpp"
+```
 
 
 ===! "Plot"
 
-    [![example_polarscatter_4](docs/examples/polar_plots/polarscatter/polarscatter_4.svg)](examples/polar_plots/polarscatter/polarscatter_4.cpp)
+[![example_polarscatter_4](docs/examples/polar_plots/polarscatter/polarscatter_4.svg)](examples/polar_plots/polarscatter/polarscatter_4.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/polar_plots/polarscatter/polarscatter_4.cpp"
-    ```
-
-
-
-===! "Plot"
-
-    [![example_polarscatter_5](docs/examples/polar_plots/polarscatter/polarscatter_5.svg)](examples/polar_plots/polarscatter/polarscatter_5.cpp)
-
-=== "C++"
-
-    ```cpp
-    --8<-- "examples/polar_plots/polarscatter/polarscatter_5.cpp"
-    ```
+```cpp
+--8<-- "examples/polar_plots/polarscatter/polarscatter_4.cpp"
+```
 
 
 
 ===! "Plot"
 
-    [![example_polarscatter_6](docs/examples/polar_plots/polarscatter/polarscatter_6.svg)](examples/polar_plots/polarscatter/polarscatter_6.cpp)
+[![example_polarscatter_5](docs/examples/polar_plots/polarscatter/polarscatter_5.svg)](examples/polar_plots/polarscatter/polarscatter_5.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/polar_plots/polarscatter/polarscatter_6.cpp"
-    ```
+```cpp
+--8<-- "examples/polar_plots/polarscatter/polarscatter_5.cpp"
+```
+
+
+
+===! "Plot"
+
+[![example_polarscatter_6](docs/examples/polar_plots/polarscatter/polarscatter_6.svg)](examples/polar_plots/polarscatter/polarscatter_6.cpp)
+
+=== "C++"
+
+```cpp
+--8<-- "examples/polar_plots/polarscatter/polarscatter_6.cpp"
+```
 
 
 
@@ -3631,61 +3630,61 @@ More examples:
 
 ===! "Plot"
 
-    [![example_polarhistogram_1](docs/examples/polar_plots/polarhistogram/polarhistogram_1.svg)](examples/polar_plots/polarhistogram/polarhistogram_1.cpp)
+[![example_polarhistogram_1](docs/examples/polar_plots/polarhistogram/polarhistogram_1.svg)](examples/polar_plots/polarhistogram/polarhistogram_1.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/polar_plots/polarhistogram/polarhistogram_1.cpp"
-    ```
+```cpp
+--8<-- "examples/polar_plots/polarhistogram/polarhistogram_1.cpp"
+```
 
 **More examples**
 
 
 ===! "Plot"
 
-    [![example_polarhistogram_2](docs/examples/polar_plots/polarhistogram/polarhistogram_2.svg)](examples/polar_plots/polarhistogram/polarhistogram_2.cpp)
+[![example_polarhistogram_2](docs/examples/polar_plots/polarhistogram/polarhistogram_2.svg)](examples/polar_plots/polarhistogram/polarhistogram_2.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/polar_plots/polarhistogram/polarhistogram_2.cpp"
-    ```
+```cpp
+--8<-- "examples/polar_plots/polarhistogram/polarhistogram_2.cpp"
+```
 
 
 
 ===! "Plot"
 
-    [![example_polarhistogram_3](docs/examples/polar_plots/polarhistogram/polarhistogram_3.svg)](examples/polar_plots/polarhistogram/polarhistogram_3.cpp)
+[![example_polarhistogram_3](docs/examples/polar_plots/polarhistogram/polarhistogram_3.svg)](examples/polar_plots/polarhistogram/polarhistogram_3.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/polar_plots/polarhistogram/polarhistogram_3.cpp"
-    ```
+```cpp
+--8<-- "examples/polar_plots/polarhistogram/polarhistogram_3.cpp"
+```
 
 
 ===! "Plot"
 
-    [![example_polarhistogram_4](docs/examples/polar_plots/polarhistogram/polarhistogram_4.svg)](examples/polar_plots/polarhistogram/polarhistogram_4.cpp)
+[![example_polarhistogram_4](docs/examples/polar_plots/polarhistogram/polarhistogram_4.svg)](examples/polar_plots/polarhistogram/polarhistogram_4.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/polar_plots/polarhistogram/polarhistogram_4.cpp"
-    ```
+```cpp
+--8<-- "examples/polar_plots/polarhistogram/polarhistogram_4.cpp"
+```
 
 
 
 ===! "Plot"
 
-    [![example_polarhistogram_5](docs/examples/polar_plots/polarhistogram/polarhistogram_5.svg)](examples/polar_plots/polarhistogram/polarhistogram_5.cpp)
+[![example_polarhistogram_5](docs/examples/polar_plots/polarhistogram/polarhistogram_5.svg)](examples/polar_plots/polarhistogram/polarhistogram_5.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/polar_plots/polarhistogram/polarhistogram_5.cpp"
-    ```
+```cpp
+--8<-- "examples/polar_plots/polarhistogram/polarhistogram_5.cpp"
+```
 
 
 
@@ -3713,26 +3712,26 @@ More examples:
 
 ===! "Plot"
 
-    [![example_compass_1](docs/examples/polar_plots/compass/compass_1.svg)](examples/polar_plots/compass/compass_1.cpp)
+[![example_compass_1](docs/examples/polar_plots/compass/compass_1.svg)](examples/polar_plots/compass/compass_1.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/polar_plots/compass/compass_1.cpp"
-    ```
+```cpp
+--8<-- "examples/polar_plots/compass/compass_1.cpp"
+```
 
 **More examples**
 
 
 ===! "Plot"
 
-    [![example_compass_2](docs/examples/polar_plots/compass/compass_2.svg)](examples/polar_plots/compass/compass_2.cpp)
+[![example_compass_2](docs/examples/polar_plots/compass/compass_2.svg)](examples/polar_plots/compass/compass_2.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/polar_plots/compass/compass_2.cpp"
-    ```
+```cpp
+--8<-- "examples/polar_plots/compass/compass_2.cpp"
+```
 
 
 
@@ -3758,26 +3757,26 @@ More examples:
 
 ===! "Plot"
 
-    [![example_ezpolar_1](docs/examples/polar_plots/ezpolar/ezpolar_1.svg)](examples/polar_plots/ezpolar/ezpolar_1.cpp)
+[![example_ezpolar_1](docs/examples/polar_plots/ezpolar/ezpolar_1.svg)](examples/polar_plots/ezpolar/ezpolar_1.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/polar_plots/ezpolar/ezpolar_1.cpp"
-    ```
+```cpp
+--8<-- "examples/polar_plots/ezpolar/ezpolar_1.cpp"
+```
 
 **More examples**
 
 
 ===! "Plot"
 
-    [![example_ezpolar_2](docs/examples/polar_plots/ezpolar/ezpolar_2.svg)](examples/polar_plots/ezpolar/ezpolar_2.cpp)
+[![example_ezpolar_2](docs/examples/polar_plots/ezpolar/ezpolar_2.svg)](examples/polar_plots/ezpolar/ezpolar_2.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/polar_plots/ezpolar/ezpolar_2.cpp"
-    ```
+```cpp
+--8<-- "examples/polar_plots/ezpolar/ezpolar_2.cpp"
+```
 
 
 ### Contour Plots
@@ -3806,96 +3805,96 @@ More examples:
 
 ===! "Plot"
 
-    [![example_contour_1](docs/examples/contour_plots/contour/contour_1.svg)](examples/contour_plots/contour/contour_1.cpp)
+[![example_contour_1](docs/examples/contour_plots/contour/contour_1.svg)](examples/contour_plots/contour/contour_1.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/contour_plots/contour/contour_1.cpp"
-    ```
+```cpp
+--8<-- "examples/contour_plots/contour/contour_1.cpp"
+```
 
 **More examples**
 
 
 ===! "Plot"
 
-    [![example_contour_2](docs/examples/contour_plots/contour/contour_2.svg)](examples/contour_plots/contour/contour_2.cpp)
+[![example_contour_2](docs/examples/contour_plots/contour/contour_2.svg)](examples/contour_plots/contour/contour_2.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/contour_plots/contour/contour_2.cpp"
-    ```
+```cpp
+--8<-- "examples/contour_plots/contour/contour_2.cpp"
+```
 
 
 
 ===! "Plot"
 
-    [![example_contour_3](docs/examples/contour_plots/contour/contour_3.svg)](examples/contour_plots/contour/contour_3.cpp)
+[![example_contour_3](docs/examples/contour_plots/contour/contour_3.svg)](examples/contour_plots/contour/contour_3.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/contour_plots/contour/contour_3.cpp"
-    ```
+```cpp
+--8<-- "examples/contour_plots/contour/contour_3.cpp"
+```
 
 
 ===! "Plot"
 
-    [![example_contour_4](docs/examples/contour_plots/contour/contour_4.svg)](examples/contour_plots/contour/contour_4.cpp)
+[![example_contour_4](docs/examples/contour_plots/contour/contour_4.svg)](examples/contour_plots/contour/contour_4.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/contour_plots/contour/contour_4.cpp"
-    ```
-
-
-
-===! "Plot"
-
-    [![example_contour_5](docs/examples/contour_plots/contour/contour_5.svg)](examples/contour_plots/contour/contour_5.cpp)
-
-=== "C++"
-
-    ```cpp
-    --8<-- "examples/contour_plots/contour/contour_5.cpp"
-    ```
-
-
-===! "Plot"
-
-    [![example_contour_6](docs/examples/contour_plots/contour/contour_6.svg)](examples/contour_plots/contour/contour_6.cpp)
-
-=== "C++"
-
-    ```cpp
-    --8<-- "examples/contour_plots/contour/contour_6.cpp"
-    ```
+```cpp
+--8<-- "examples/contour_plots/contour/contour_4.cpp"
+```
 
 
 
 ===! "Plot"
 
-    [![example_contour_7](docs/examples/contour_plots/contour/contour_7.svg)](examples/contour_plots/contour/contour_7.cpp)
+[![example_contour_5](docs/examples/contour_plots/contour/contour_5.svg)](examples/contour_plots/contour/contour_5.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/contour_plots/contour/contour_7.cpp"
-    ```
+```cpp
+--8<-- "examples/contour_plots/contour/contour_5.cpp"
+```
+
+
+===! "Plot"
+
+[![example_contour_6](docs/examples/contour_plots/contour/contour_6.svg)](examples/contour_plots/contour/contour_6.cpp)
+
+=== "C++"
+
+```cpp
+--8<-- "examples/contour_plots/contour/contour_6.cpp"
+```
 
 
 
 ===! "Plot"
 
-    [![example_contour_8](docs/examples/contour_plots/contour/contour_8.svg)](examples/contour_plots/contour/contour_8.cpp)
+[![example_contour_7](docs/examples/contour_plots/contour/contour_7.svg)](examples/contour_plots/contour/contour_7.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/contour_plots/contour/contour_8.cpp"
-    ```
+```cpp
+--8<-- "examples/contour_plots/contour/contour_7.cpp"
+```
+
+
+
+===! "Plot"
+
+[![example_contour_8](docs/examples/contour_plots/contour/contour_8.svg)](examples/contour_plots/contour/contour_8.cpp)
+
+=== "C++"
+
+```cpp
+--8<-- "examples/contour_plots/contour/contour_8.cpp"
+```
 
 
 
@@ -3930,72 +3929,72 @@ More examples:
 
 ===! "Plot"
 
-    [![example_contourf_1](docs/examples/contour_plots/contourf/contourf_1.svg)](examples/contour_plots/contourf/contourf_1.cpp)
+[![example_contourf_1](docs/examples/contour_plots/contourf/contourf_1.svg)](examples/contour_plots/contourf/contourf_1.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/contour_plots/contourf/contourf_1.cpp"
-    ```
+```cpp
+--8<-- "examples/contour_plots/contourf/contourf_1.cpp"
+```
 
 **More examples**
 
 ===! "Plot"
 
-    [![example_contourf_2](docs/examples/contour_plots/contourf/contourf_2.png)](examples/contour_plots/contourf/contourf_2.cpp)
+[![example_contourf_2](docs/examples/contour_plots/contourf/contourf_2.png)](examples/contour_plots/contourf/contourf_2.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/contour_plots/contourf/contourf_2.cpp"
-    ```
+```cpp
+--8<-- "examples/contour_plots/contourf/contourf_2.cpp"
+```
 
 
 
 ===! "Plot"
 
-    [![example_contourf_3](docs/examples/contour_plots/contourf/contourf_3.png)](examples/contour_plots/contourf/contourf_3.cpp)
+[![example_contourf_3](docs/examples/contour_plots/contourf/contourf_3.png)](examples/contour_plots/contourf/contourf_3.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/contour_plots/contourf/contourf_3.cpp"
-    ```
+```cpp
+--8<-- "examples/contour_plots/contourf/contourf_3.cpp"
+```
 
 
 ===! "Plot"
 
-    [![example_contourf_4](docs/examples/contour_plots/contourf/contourf_4.png)](examples/contour_plots/contourf/contourf_4.cpp)
+[![example_contourf_4](docs/examples/contour_plots/contourf/contourf_4.png)](examples/contour_plots/contourf/contourf_4.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/contour_plots/contourf/contourf_4.cpp"
-    ```
-
-
-
-===! "Plot"
-
-    [![example_contourf_5](docs/examples/contour_plots/contourf/contourf_5.png)](examples/contour_plots/contourf/contourf_5.cpp)
-
-=== "C++"
-
-    ```cpp
-    --8<-- "examples/contour_plots/contourf/contourf_5.cpp"
-    ```
+```cpp
+--8<-- "examples/contour_plots/contourf/contourf_4.cpp"
+```
 
 
 
 ===! "Plot"
 
-    [![example_contourf_6](docs/examples/contour_plots/contourf/contourf_6.svg)](examples/contour_plots/contourf/contourf_6.cpp)
+[![example_contourf_5](docs/examples/contour_plots/contourf/contourf_5.png)](examples/contour_plots/contourf/contourf_5.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/contour_plots/contourf/contourf_6.cpp"
-    ```
+```cpp
+--8<-- "examples/contour_plots/contourf/contourf_5.cpp"
+```
+
+
+
+===! "Plot"
+
+[![example_contourf_6](docs/examples/contour_plots/contourf/contourf_6.svg)](examples/contour_plots/contourf/contourf_6.cpp)
+
+=== "C++"
+
+```cpp
+--8<-- "examples/contour_plots/contourf/contourf_6.cpp"
+```
 
 
 
@@ -4020,130 +4019,130 @@ More examples:
 
 ===! "Plot"
 
-    [![example_fcontour_1](docs/examples/contour_plots/fcontour/fcontour_1.svg)](examples/contour_plots/fcontour/fcontour_1.cpp)
+[![example_fcontour_1](docs/examples/contour_plots/fcontour/fcontour_1.svg)](examples/contour_plots/fcontour/fcontour_1.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/contour_plots/fcontour/fcontour_1.cpp"
-    ```
+```cpp
+--8<-- "examples/contour_plots/fcontour/fcontour_1.cpp"
+```
 
 **More examples**
 
 
 ===! "Plot"
 
-    [![example_fcontour_2](docs/examples/contour_plots/fcontour/fcontour_2.svg)](examples/contour_plots/fcontour/fcontour_2.cpp)
+[![example_fcontour_2](docs/examples/contour_plots/fcontour/fcontour_2.svg)](examples/contour_plots/fcontour/fcontour_2.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/contour_plots/fcontour/fcontour_2.cpp"
-    ```
+```cpp
+--8<-- "examples/contour_plots/fcontour/fcontour_2.cpp"
+```
 
 
 
 ===! "Plot"
 
-    [![example_fcontour_3](docs/examples/contour_plots/fcontour/fcontour_3.svg)](examples/contour_plots/fcontour/fcontour_3.cpp)
+[![example_fcontour_3](docs/examples/contour_plots/fcontour/fcontour_3.svg)](examples/contour_plots/fcontour/fcontour_3.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/contour_plots/fcontour/fcontour_3.cpp"
-    ```
+```cpp
+--8<-- "examples/contour_plots/fcontour/fcontour_3.cpp"
+```
 
 
 ===! "Plot"
 
-    [![example_fcontour_4](docs/examples/contour_plots/fcontour/fcontour_4.svg)](examples/contour_plots/fcontour/fcontour_4.cpp)
+[![example_fcontour_4](docs/examples/contour_plots/fcontour/fcontour_4.svg)](examples/contour_plots/fcontour/fcontour_4.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/contour_plots/fcontour/fcontour_4.cpp"
-    ```
-
-
-
-===! "Plot"
-
-    [![example_fcontour_5](docs/examples/contour_plots/fcontour/fcontour_5.svg)](examples/contour_plots/fcontour/fcontour_5.cpp)
-
-=== "C++"
-
-    ```cpp
-    --8<-- "examples/contour_plots/fcontour/fcontour_5.cpp"
-    ```
-
-
-===! "Plot"
-
-    [![example_fcontour_6](docs/examples/contour_plots/fcontour/fcontour_6.png)](examples/contour_plots/fcontour/fcontour_6.cpp)
-
-=== "C++"
-
-    ```cpp
-    --8<-- "examples/contour_plots/fcontour/fcontour_6.cpp"
-    ```
+```cpp
+--8<-- "examples/contour_plots/fcontour/fcontour_4.cpp"
+```
 
 
 
 ===! "Plot"
 
-    [![example_fcontour_7](docs/examples/contour_plots/fcontour/fcontour_7.png)](examples/contour_plots/fcontour/fcontour_7.cpp)
+[![example_fcontour_5](docs/examples/contour_plots/fcontour/fcontour_5.svg)](examples/contour_plots/fcontour/fcontour_5.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/contour_plots/fcontour/fcontour_7.cpp"
-    ```
+```cpp
+--8<-- "examples/contour_plots/fcontour/fcontour_5.cpp"
+```
 
 
 ===! "Plot"
 
-    [![example_fcontour_8](docs/examples/contour_plots/fcontour/fcontour_8.svg)](examples/contour_plots/fcontour/fcontour_8.cpp)
+[![example_fcontour_6](docs/examples/contour_plots/fcontour/fcontour_6.png)](examples/contour_plots/fcontour/fcontour_6.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/contour_plots/fcontour/fcontour_8.cpp"
-    ```
-
-
-
-===! "Plot"
-
-    [![example_fcontour_9](docs/examples/contour_plots/fcontour/fcontour_9.png)](examples/contour_plots/fcontour/fcontour_9.cpp)
-
-=== "C++"
-
-    ```cpp
-    --8<-- "examples/contour_plots/fcontour/fcontour_9.cpp"
-    ```
-
-
-===! "Plot"
-
-    [![example_fcontour_10](docs/examples/contour_plots/fcontour/fcontour_10.png)](examples/contour_plots/fcontour/fcontour_10.cpp)
-
-=== "C++"
-
-    ```cpp
-    --8<-- "examples/contour_plots/fcontour/fcontour_10.cpp"
-    ```
+```cpp
+--8<-- "examples/contour_plots/fcontour/fcontour_6.cpp"
+```
 
 
 
 ===! "Plot"
 
-    [![example_fcontour_11](docs/examples/contour_plots/fcontour/fcontour_11.png)](examples/contour_plots/fcontour/fcontour_11.cpp)
+[![example_fcontour_7](docs/examples/contour_plots/fcontour/fcontour_7.png)](examples/contour_plots/fcontour/fcontour_7.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/contour_plots/fcontour/fcontour_11.cpp"
-    ```
+```cpp
+--8<-- "examples/contour_plots/fcontour/fcontour_7.cpp"
+```
+
+
+===! "Plot"
+
+[![example_fcontour_8](docs/examples/contour_plots/fcontour/fcontour_8.svg)](examples/contour_plots/fcontour/fcontour_8.cpp)
+
+=== "C++"
+
+```cpp
+--8<-- "examples/contour_plots/fcontour/fcontour_8.cpp"
+```
+
+
+
+===! "Plot"
+
+[![example_fcontour_9](docs/examples/contour_plots/fcontour/fcontour_9.png)](examples/contour_plots/fcontour/fcontour_9.cpp)
+
+=== "C++"
+
+```cpp
+--8<-- "examples/contour_plots/fcontour/fcontour_9.cpp"
+```
+
+
+===! "Plot"
+
+[![example_fcontour_10](docs/examples/contour_plots/fcontour/fcontour_10.png)](examples/contour_plots/fcontour/fcontour_10.cpp)
+
+=== "C++"
+
+```cpp
+--8<-- "examples/contour_plots/fcontour/fcontour_10.cpp"
+```
+
+
+
+===! "Plot"
+
+[![example_fcontour_11](docs/examples/contour_plots/fcontour/fcontour_11.png)](examples/contour_plots/fcontour/fcontour_11.cpp)
+
+=== "C++"
+
+```cpp
+--8<-- "examples/contour_plots/fcontour/fcontour_11.cpp"
+```
 
 
 
@@ -4176,62 +4175,62 @@ More examples:
 
 ===! "Plot"
 
-    [![example_quiver_1](docs/examples/vector_fields/quiver/quiver_1.svg)](examples/vector_fields/quiver/quiver_1.cpp)
+[![example_quiver_1](docs/examples/vector_fields/quiver/quiver_1.svg)](examples/vector_fields/quiver/quiver_1.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/vector_fields/quiver/quiver_1.cpp"
-    ```
+```cpp
+--8<-- "examples/vector_fields/quiver/quiver_1.cpp"
+```
 
 **More examples**
 
 
 ===! "Plot"
 
-    [![example_quiver_2](docs/examples/vector_fields/quiver/quiver_2.svg)](examples/vector_fields/quiver/quiver_2.cpp)
+[![example_quiver_2](docs/examples/vector_fields/quiver/quiver_2.svg)](examples/vector_fields/quiver/quiver_2.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/vector_fields/quiver/quiver_2.cpp"
-    ```
+```cpp
+--8<-- "examples/vector_fields/quiver/quiver_2.cpp"
+```
 
 
 
 ===! "Plot"
 
-    [![example_quiver_3](docs/examples/vector_fields/quiver/quiver_3.svg)](examples/vector_fields/quiver/quiver_3.cpp)
+[![example_quiver_3](docs/examples/vector_fields/quiver/quiver_3.svg)](examples/vector_fields/quiver/quiver_3.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/vector_fields/quiver/quiver_3.cpp"
-    ```
+```cpp
+--8<-- "examples/vector_fields/quiver/quiver_3.cpp"
+```
 
 
 
 ===! "Plot"
 
-    [![example_quiver_4](docs/examples/vector_fields/quiver/quiver_4.svg)](examples/vector_fields/quiver/quiver_4.cpp)
+[![example_quiver_4](docs/examples/vector_fields/quiver/quiver_4.svg)](examples/vector_fields/quiver/quiver_4.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/vector_fields/quiver/quiver_4.cpp"
-    ```
+```cpp
+--8<-- "examples/vector_fields/quiver/quiver_4.cpp"
+```
 
 
 
 ===! "Plot"
 
-    [![example_quiver_6](docs/examples/vector_fields/quiver/quiver_6.svg)](examples/vector_fields/quiver/quiver_6.cpp)
+[![example_quiver_6](docs/examples/vector_fields/quiver/quiver_6.svg)](examples/vector_fields/quiver/quiver_6.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/vector_fields/quiver/quiver_6.cpp"
-    ```
+```cpp
+--8<-- "examples/vector_fields/quiver/quiver_6.cpp"
+```
 
 
 
@@ -4257,25 +4256,25 @@ quiver3(Z, U, V, W);
 
 ===! "Plot"
 
-    [![example_quiver3_1](docs/examples/vector_fields/quiver3/quiver3_1.svg)](examples/vector_fields/quiver3/quiver3_1.cpp)
+[![example_quiver3_1](docs/examples/vector_fields/quiver3/quiver3_1.svg)](examples/vector_fields/quiver3/quiver3_1.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/vector_fields/quiver3/quiver3_1.cpp"
-    ```
+```cpp
+--8<-- "examples/vector_fields/quiver3/quiver3_1.cpp"
+```
 
 
 
 ===! "Plot"
 
-    [![example_quiver3_2](docs/examples/vector_fields/quiver3/quiver3_2.svg)](examples/vector_fields/quiver3/quiver3_2.cpp)
+[![example_quiver3_2](docs/examples/vector_fields/quiver3/quiver3_2.svg)](examples/vector_fields/quiver3/quiver3_2.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/vector_fields/quiver3/quiver3_2.cpp"
-    ```
+```cpp
+--8<-- "examples/vector_fields/quiver3/quiver3_2.cpp"
+```
 
 
 #### Feather
@@ -4294,13 +4293,13 @@ feather(u, v);
 
 ===! "Plot"
 
-    [![example_feather_1](docs/examples/vector_fields/feather/feather_1.svg)](examples/vector_fields/feather/feather_1.cpp)
+[![example_feather_1](docs/examples/vector_fields/feather/feather_1.svg)](examples/vector_fields/feather/feather_1.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/vector_fields/feather/feather_1.cpp"
-    ```
+```cpp
+--8<-- "examples/vector_fields/feather/feather_1.cpp"
+```
 
 
 ### Surfaces
@@ -4329,72 +4328,72 @@ More examples:
 
 ===! "Plot"
 
-    [![example_surf_1](docs/examples/surfaces/surf/surf_1.png)](examples/surfaces/surf/surf_1.cpp)
+[![example_surf_1](docs/examples/surfaces/surf/surf_1.png)](examples/surfaces/surf/surf_1.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/surfaces/surf/surf_1.cpp"
-    ```
+```cpp
+--8<-- "examples/surfaces/surf/surf_1.cpp"
+```
 
 **More examples**
 
 ===! "Plot"
 
-    [![example_surf_2](docs/examples/surfaces/surf/surf_2.svg)](examples/surfaces/surf/surf_2.cpp)
+[![example_surf_2](docs/examples/surfaces/surf/surf_2.svg)](examples/surfaces/surf/surf_2.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/surfaces/surf/surf_2.cpp"
-    ```
+```cpp
+--8<-- "examples/surfaces/surf/surf_2.cpp"
+```
 
 
 
 ===! "Plot"
 
-    [![example_surf_3](docs/examples/surfaces/surf/surf_3.svg)](examples/surfaces/surf/surf_3.cpp)
+[![example_surf_3](docs/examples/surfaces/surf/surf_3.svg)](examples/surfaces/surf/surf_3.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/surfaces/surf/surf_3.cpp"
-    ```
+```cpp
+--8<-- "examples/surfaces/surf/surf_3.cpp"
+```
 
 
 ===! "Plot"
 
-    [![example_surf_4](docs/examples/surfaces/surf/surf_4.svg)](examples/surfaces/surf/surf_4.cpp)
+[![example_surf_4](docs/examples/surfaces/surf/surf_4.svg)](examples/surfaces/surf/surf_4.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/surfaces/surf/surf_4.cpp"
-    ```
-
-
-
-===! "Plot"
-
-    [![example_surf_5](docs/examples/surfaces/surf/surf_5.svg)](examples/surfaces/surf/surf_5.cpp)
-
-=== "C++"
-
-    ```cpp
-    --8<-- "examples/surfaces/surf/surf_5.cpp"
-    ```
+```cpp
+--8<-- "examples/surfaces/surf/surf_4.cpp"
+```
 
 
 
 ===! "Plot"
 
-    [![example_surf_6](docs/examples/surfaces/surf/surf_6.svg)](examples/surfaces/surf/surf_6.cpp)
+[![example_surf_5](docs/examples/surfaces/surf/surf_5.svg)](examples/surfaces/surf/surf_5.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/surfaces/surf/surf_6.cpp"
-    ```
+```cpp
+--8<-- "examples/surfaces/surf/surf_5.cpp"
+```
+
+
+
+===! "Plot"
+
+[![example_surf_6](docs/examples/surfaces/surf/surf_6.svg)](examples/surfaces/surf/surf_6.cpp)
+
+=== "C++"
+
+```cpp
+--8<-- "examples/surfaces/surf/surf_6.cpp"
+```
 
 
   
@@ -4418,49 +4417,49 @@ More examples:
 
 ===! "Plot"
 
-    [![example_surfc_1](docs/examples/surfaces/surfc/surfc_1.png)](examples/surfaces/surfc/surfc_1.cpp)
+[![example_surfc_1](docs/examples/surfaces/surfc/surfc_1.png)](examples/surfaces/surfc/surfc_1.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/surfaces/surfc/surfc_1.cpp"
-    ```
+```cpp
+--8<-- "examples/surfaces/surfc/surfc_1.cpp"
+```
 
 **More examples**
 
 ===! "Plot"
 
-    [![example_surfc_2](docs/examples/surfaces/surfc/surfc_2.svg)](examples/surfaces/surfc/surfc_2.cpp)
+[![example_surfc_2](docs/examples/surfaces/surfc/surfc_2.svg)](examples/surfaces/surfc/surfc_2.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/surfaces/surfc/surfc_2.cpp"
-    ```
+```cpp
+--8<-- "examples/surfaces/surfc/surfc_2.cpp"
+```
 
 
 
 ===! "Plot"
 
-    [![example_surfc_3](docs/examples/surfaces/surfc/surfc_3.png)](examples/surfaces/surfc/surfc_3.cpp)
+[![example_surfc_3](docs/examples/surfaces/surfc/surfc_3.png)](examples/surfaces/surfc/surfc_3.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/surfaces/surfc/surfc_3.cpp"
-    ```
+```cpp
+--8<-- "examples/surfaces/surfc/surfc_3.cpp"
+```
 
 
 
 ===! "Plot"
 
-    [![example_surfc_4](docs/examples/surfaces/surfc/surfc_4.png)](examples/surfaces/surfc/surfc_4.cpp)
+[![example_surfc_4](docs/examples/surfaces/surfc/surfc_4.png)](examples/surfaces/surfc/surfc_4.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/surfaces/surfc/surfc_4.cpp"
-    ```
+```cpp
+--8<-- "examples/surfaces/surfc/surfc_4.cpp"
+```
 
 
 
@@ -4484,49 +4483,49 @@ More examples:
 
 ===! "Plot"
 
-    [![example_mesh_1](docs/examples/surfaces/mesh/mesh_1.png)](examples/surfaces/mesh/mesh_1.cpp)
+[![example_mesh_1](docs/examples/surfaces/mesh/mesh_1.png)](examples/surfaces/mesh/mesh_1.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/surfaces/mesh/mesh_1.cpp"
-    ```
+```cpp
+--8<-- "examples/surfaces/mesh/mesh_1.cpp"
+```
 
 **More examples**
 
 ===! "Plot"
 
-    [![example_mesh_2](docs/examples/surfaces/mesh/mesh_2.png)](examples/surfaces/mesh/mesh_2.cpp)
+[![example_mesh_2](docs/examples/surfaces/mesh/mesh_2.png)](examples/surfaces/mesh/mesh_2.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/surfaces/mesh/mesh_2.cpp"
-    ```
+```cpp
+--8<-- "examples/surfaces/mesh/mesh_2.cpp"
+```
 
 
 
 ===! "Plot"
 
-    [![example_mesh_3](docs/examples/surfaces/mesh/mesh_3.svg)](examples/surfaces/mesh/mesh_3.cpp)
+[![example_mesh_3](docs/examples/surfaces/mesh/mesh_3.svg)](examples/surfaces/mesh/mesh_3.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/surfaces/mesh/mesh_3.cpp"
-    ```
+```cpp
+--8<-- "examples/surfaces/mesh/mesh_3.cpp"
+```
 
 
 
 ===! "Plot"
 
-    [![example_mesh_4](docs/examples/surfaces/mesh/mesh_4.svg)](examples/surfaces/mesh/mesh_4.cpp)
+[![example_mesh_4](docs/examples/surfaces/mesh/mesh_4.svg)](examples/surfaces/mesh/mesh_4.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/surfaces/mesh/mesh_4.cpp"
-    ```
+```cpp
+--8<-- "examples/surfaces/mesh/mesh_4.cpp"
+```
 
 
   
@@ -4550,37 +4549,37 @@ More examples:
 
 ===! "Plot"
 
-    [![example_meshc_1](docs/examples/surfaces/meshc/meshc_1.png)](examples/surfaces/meshc/meshc_1.cpp)
+[![example_meshc_1](docs/examples/surfaces/meshc/meshc_1.png)](examples/surfaces/meshc/meshc_1.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/surfaces/meshc/meshc_1.cpp"
-    ```
+```cpp
+--8<-- "examples/surfaces/meshc/meshc_1.cpp"
+```
 
 **More examples**
 
 ===! "Plot"
 
-    [![example_meshc_2](docs/examples/surfaces/meshc/meshc_2.png)](examples/surfaces/meshc/meshc_2.cpp)
+[![example_meshc_2](docs/examples/surfaces/meshc/meshc_2.png)](examples/surfaces/meshc/meshc_2.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/surfaces/meshc/meshc_2.cpp"
-    ```
+```cpp
+--8<-- "examples/surfaces/meshc/meshc_2.cpp"
+```
 
 
 
 ===! "Plot"
 
-    [![example_meshc_3](docs/examples/surfaces/meshc/meshc_3.png)](examples/surfaces/meshc/meshc_3.cpp)
+[![example_meshc_3](docs/examples/surfaces/meshc/meshc_3.png)](examples/surfaces/meshc/meshc_3.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/surfaces/meshc/meshc_3.cpp"
-    ```
+```cpp
+--8<-- "examples/surfaces/meshc/meshc_3.cpp"
+```
 
 
 
@@ -4604,37 +4603,37 @@ More examples:
 
 ===! "Plot"
 
-    [![example_meshz_1](docs/examples/surfaces/meshz/meshz_1.png)](examples/surfaces/meshz/meshz_1.cpp)
+[![example_meshz_1](docs/examples/surfaces/meshz/meshz_1.png)](examples/surfaces/meshz/meshz_1.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/surfaces/meshz/meshz_1.cpp"
-    ```
+```cpp
+--8<-- "examples/surfaces/meshz/meshz_1.cpp"
+```
 
 **More examples**
 
 ===! "Plot"
 
-    [![example_meshz_2](docs/examples/surfaces/meshz/meshz_2.png)](examples/surfaces/meshz/meshz_2.cpp)
+[![example_meshz_2](docs/examples/surfaces/meshz/meshz_2.png)](examples/surfaces/meshz/meshz_2.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/surfaces/meshz/meshz_2.cpp"
-    ```
+```cpp
+--8<-- "examples/surfaces/meshz/meshz_2.cpp"
+```
 
 
 
 ===! "Plot"
 
-    [![example_meshz_3](docs/examples/surfaces/meshz/meshz_3.png)](examples/surfaces/meshz/meshz_3.cpp)
+[![example_meshz_3](docs/examples/surfaces/meshz/meshz_3.png)](examples/surfaces/meshz/meshz_3.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/surfaces/meshz/meshz_3.cpp"
-    ```
+```cpp
+--8<-- "examples/surfaces/meshz/meshz_3.cpp"
+```
 
 
 
@@ -4659,95 +4658,95 @@ More examples:
 
 ===! "Plot"
 
-    [![example_fsurf_1](docs/examples/surfaces/fsurf/fsurf_1.png)](examples/surfaces/fsurf/fsurf_1.cpp)
+[![example_fsurf_1](docs/examples/surfaces/fsurf/fsurf_1.png)](examples/surfaces/fsurf/fsurf_1.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/surfaces/fsurf/fsurf_1.cpp"
-    ```
+```cpp
+--8<-- "examples/surfaces/fsurf/fsurf_1.cpp"
+```
 
 **More examples**
 
 ===! "Plot"
 
-    [![example_fsurf_2](docs/examples/surfaces/fsurf/fsurf_2.png)](examples/surfaces/fsurf/fsurf_2.cpp)
+[![example_fsurf_2](docs/examples/surfaces/fsurf/fsurf_2.png)](examples/surfaces/fsurf/fsurf_2.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/surfaces/fsurf/fsurf_2.cpp"
-    ```
+```cpp
+--8<-- "examples/surfaces/fsurf/fsurf_2.cpp"
+```
 
 
 
 ===! "Plot"
 
-    [![example_fsurf_3](docs/examples/surfaces/fsurf/fsurf_3.png)](examples/surfaces/fsurf/fsurf_3.cpp)
+[![example_fsurf_3](docs/examples/surfaces/fsurf/fsurf_3.png)](examples/surfaces/fsurf/fsurf_3.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/surfaces/fsurf/fsurf_3.cpp"
-    ```
+```cpp
+--8<-- "examples/surfaces/fsurf/fsurf_3.cpp"
+```
 
 
 ===! "Plot"
 
-    [![example_fsurf_4](docs/examples/surfaces/fsurf/fsurf_4.png)](examples/surfaces/fsurf/fsurf_4.cpp)
+[![example_fsurf_4](docs/examples/surfaces/fsurf/fsurf_4.png)](examples/surfaces/fsurf/fsurf_4.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/surfaces/fsurf/fsurf_4.cpp"
-    ```
-
-
-
-===! "Plot"
-
-    [![example_fsurf_5](docs/examples/surfaces/fsurf/fsurf_5.png)](examples/surfaces/fsurf/fsurf_5.cpp)
-
-=== "C++"
-
-    ```cpp
-    --8<-- "examples/surfaces/fsurf/fsurf_5.cpp"
-    ```
-
-
-===! "Plot"
-
-    [![example_fsurf_6](docs/examples/surfaces/fsurf/fsurf_6.png)](examples/surfaces/fsurf/fsurf_6.cpp)
-
-=== "C++"
-
-    ```cpp
-    --8<-- "examples/surfaces/fsurf/fsurf_6.cpp"
-    ```
+```cpp
+--8<-- "examples/surfaces/fsurf/fsurf_4.cpp"
+```
 
 
 
 ===! "Plot"
 
-    [![example_fsurf_7](docs/examples/surfaces/fsurf/fsurf_7.png)](examples/surfaces/fsurf/fsurf_7.cpp)
+[![example_fsurf_5](docs/examples/surfaces/fsurf/fsurf_5.png)](examples/surfaces/fsurf/fsurf_5.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/surfaces/fsurf/fsurf_7.cpp"
-    ```
+```cpp
+--8<-- "examples/surfaces/fsurf/fsurf_5.cpp"
+```
+
+
+===! "Plot"
+
+[![example_fsurf_6](docs/examples/surfaces/fsurf/fsurf_6.png)](examples/surfaces/fsurf/fsurf_6.cpp)
+
+=== "C++"
+
+```cpp
+--8<-- "examples/surfaces/fsurf/fsurf_6.cpp"
+```
 
 
 
 ===! "Plot"
 
-    [![example_fsurf_8](docs/examples/surfaces/fsurf/fsurf_8.png)](examples/surfaces/fsurf/fsurf_8.cpp)
+[![example_fsurf_7](docs/examples/surfaces/fsurf/fsurf_7.png)](examples/surfaces/fsurf/fsurf_7.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/surfaces/fsurf/fsurf_8.cpp"
-    ```
+```cpp
+--8<-- "examples/surfaces/fsurf/fsurf_7.cpp"
+```
+
+
+
+===! "Plot"
+
+[![example_fsurf_8](docs/examples/surfaces/fsurf/fsurf_8.png)](examples/surfaces/fsurf/fsurf_8.cpp)
+
+=== "C++"
+
+```cpp
+--8<-- "examples/surfaces/fsurf/fsurf_8.cpp"
+```
 
 
 
@@ -4772,49 +4771,49 @@ More examples:
 
 ===! "Plot"
 
-    [![example_fmesh_1](docs/examples/surfaces/fmesh/fmesh_1.png)](examples/surfaces/fmesh/fmesh_1.cpp)
+[![example_fmesh_1](docs/examples/surfaces/fmesh/fmesh_1.png)](examples/surfaces/fmesh/fmesh_1.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/surfaces/fmesh/fmesh_1.cpp"
-    ```
+```cpp
+--8<-- "examples/surfaces/fmesh/fmesh_1.cpp"
+```
 
 **More examples**
 
 ===! "Plot"
 
-    [![example_fmesh_2](docs/examples/surfaces/fmesh/fmesh_2.svg)](examples/surfaces/fmesh/fmesh_2.cpp)
+[![example_fmesh_2](docs/examples/surfaces/fmesh/fmesh_2.svg)](examples/surfaces/fmesh/fmesh_2.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/surfaces/fmesh/fmesh_2.cpp"
-    ```
+```cpp
+--8<-- "examples/surfaces/fmesh/fmesh_2.cpp"
+```
 
 
 
 ===! "Plot"
 
-    [![example_fmesh_3](docs/examples/surfaces/fmesh/fmesh_3.png)](examples/surfaces/fmesh/fmesh_3.cpp)
+[![example_fmesh_3](docs/examples/surfaces/fmesh/fmesh_3.png)](examples/surfaces/fmesh/fmesh_3.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/surfaces/fmesh/fmesh_3.cpp"
-    ```
+```cpp
+--8<-- "examples/surfaces/fmesh/fmesh_3.cpp"
+```
 
 
 
 ===! "Plot"
 
-    [![example_fmesh_4](docs/examples/surfaces/fmesh/fmesh_4.png)](examples/surfaces/fmesh/fmesh_4.cpp)
+[![example_fmesh_4](docs/examples/surfaces/fmesh/fmesh_4.png)](examples/surfaces/fmesh/fmesh_4.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/surfaces/fmesh/fmesh_4.cpp"
-    ```
+```cpp
+--8<-- "examples/surfaces/fmesh/fmesh_4.cpp"
+```
 
 
 
@@ -4839,37 +4838,37 @@ More examples:
 
 ===! "Plot"
 
-    [![example_waterfall_1](docs/examples/surfaces/waterfall/waterfall_1.png)](examples/surfaces/waterfall/waterfall_1.cpp)
+[![example_waterfall_1](docs/examples/surfaces/waterfall/waterfall_1.png)](examples/surfaces/waterfall/waterfall_1.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/surfaces/waterfall/waterfall_1.cpp"
-    ```
+```cpp
+--8<-- "examples/surfaces/waterfall/waterfall_1.cpp"
+```
 
 **More examples**
 
 ===! "Plot"
 
-    [![example_waterfall_2](docs/examples/surfaces/waterfall/waterfall_2.png)](examples/surfaces/waterfall/waterfall_2.cpp)
+[![example_waterfall_2](docs/examples/surfaces/waterfall/waterfall_2.png)](examples/surfaces/waterfall/waterfall_2.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/surfaces/waterfall/waterfall_2.cpp"
-    ```
+```cpp
+--8<-- "examples/surfaces/waterfall/waterfall_2.cpp"
+```
 
 
 
 ===! "Plot"
 
-    [![example_waterfall_3](docs/examples/surfaces/waterfall/waterfall_3.svg)](examples/surfaces/waterfall/waterfall_3.cpp)
+[![example_waterfall_3](docs/examples/surfaces/waterfall/waterfall_3.svg)](examples/surfaces/waterfall/waterfall_3.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/surfaces/waterfall/waterfall_3.cpp"
-    ```
+```cpp
+--8<-- "examples/surfaces/waterfall/waterfall_3.cpp"
+```
 
 
   
@@ -4893,37 +4892,37 @@ More examples:
 
 ===! "Plot"
 
-    [![example_fence_1](docs/examples/surfaces/fence/fence_1.png)](examples/surfaces/fence/fence_1.cpp)
+[![example_fence_1](docs/examples/surfaces/fence/fence_1.png)](examples/surfaces/fence/fence_1.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/surfaces/fence/fence_1.cpp"
-    ```
+```cpp
+--8<-- "examples/surfaces/fence/fence_1.cpp"
+```
 
 **More examples**
 
 ===! "Plot"
 
-    [![example_fence_2](docs/examples/surfaces/fence/fence_2.png)](examples/surfaces/fence/fence_2.cpp)
+[![example_fence_2](docs/examples/surfaces/fence/fence_2.png)](examples/surfaces/fence/fence_2.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/surfaces/fence/fence_2.cpp"
-    ```
+```cpp
+--8<-- "examples/surfaces/fence/fence_2.cpp"
+```
 
 
 
 ===! "Plot"
 
-    [![example_fence_3](docs/examples/surfaces/fence/fence_3.png)](examples/surfaces/fence/fence_3.cpp)
+[![example_fence_3](docs/examples/surfaces/fence/fence_3.png)](examples/surfaces/fence/fence_3.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/surfaces/fence/fence_3.cpp"
-    ```
+```cpp
+--8<-- "examples/surfaces/fence/fence_3.cpp"
+```
 
 
 
@@ -4948,45 +4947,45 @@ More examples:
 
 ===! "Plot"
 
-    [![example_ribbon_1](docs/examples/surfaces/ribbon/ribbon_1.png)](examples/surfaces/ribbon/ribbon_1.cpp)
+[![example_ribbon_1](docs/examples/surfaces/ribbon/ribbon_1.png)](examples/surfaces/ribbon/ribbon_1.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/surfaces/ribbon/ribbon_1.cpp"
-    ```
+```cpp
+--8<-- "examples/surfaces/ribbon/ribbon_1.cpp"
+```
 
 **More examples**
 
 ===! "Plot"
 
-    [![example_ribbon_2](docs/examples/surfaces/ribbon/ribbon_2.png)](examples/surfaces/ribbon/ribbon_2.cpp)
+[![example_ribbon_2](docs/examples/surfaces/ribbon/ribbon_2.png)](examples/surfaces/ribbon/ribbon_2.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/surfaces/ribbon/ribbon_2.cpp"
-    ```
+```cpp
+--8<-- "examples/surfaces/ribbon/ribbon_2.cpp"
+```
 
 ===! "Plot"
 
-    [![example_ribbon_3](docs/examples/surfaces/ribbon/ribbon_3.svg)](examples/surfaces/ribbon/ribbon_3.cpp)
+[![example_ribbon_3](docs/examples/surfaces/ribbon/ribbon_3.svg)](examples/surfaces/ribbon/ribbon_3.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/surfaces/ribbon/ribbon_3.cpp"
-    ```
+```cpp
+--8<-- "examples/surfaces/ribbon/ribbon_3.cpp"
+```
 
 ===! "Plot"
 
-    [![example_ribbon_4](docs/examples/surfaces/ribbon/ribbon_4.png)](examples/surfaces/ribbon/ribbon_4.cpp)
+[![example_ribbon_4](docs/examples/surfaces/ribbon/ribbon_4.png)](examples/surfaces/ribbon/ribbon_4.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/surfaces/ribbon/ribbon_4.cpp"
-    ```
+```cpp
+--8<-- "examples/surfaces/ribbon/ribbon_4.cpp"
+```
 
 
 
@@ -5016,60 +5015,60 @@ More examples:
 
 ===! "Plot"
 
-    [![example_graph_1](docs/examples/graphs/graph/graph_1.svg)](examples/graphs/graph/graph_1.cpp)
+[![example_graph_1](docs/examples/graphs/graph/graph_1.svg)](examples/graphs/graph/graph_1.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/graphs/graph/graph_1.cpp"
-    ```
+```cpp
+--8<-- "examples/graphs/graph/graph_1.cpp"
+```
 
 **More examples**
 
 ===! "Plot"
 
-    [![example_graph_2](docs/examples/graphs/graph/graph_2.svg)](examples/graphs/graph/graph_2.cpp)
+[![example_graph_2](docs/examples/graphs/graph/graph_2.svg)](examples/graphs/graph/graph_2.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/graphs/graph/graph_2.cpp"
-    ```
+```cpp
+--8<-- "examples/graphs/graph/graph_2.cpp"
+```
 
 
 
 ===! "Plot"
 
-    [![example_graph_3](docs/examples/graphs/graph/graph_3.svg)](examples/graphs/graph/graph_3.cpp)
+[![example_graph_3](docs/examples/graphs/graph/graph_3.svg)](examples/graphs/graph/graph_3.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/graphs/graph/graph_3.cpp"
-    ```
+```cpp
+--8<-- "examples/graphs/graph/graph_3.cpp"
+```
 
 
 ===! "Plot"
 
-    [![example_graph_4](docs/examples/graphs/graph/graph_4.svg)](examples/graphs/graph/graph_4.cpp)
+[![example_graph_4](docs/examples/graphs/graph/graph_4.svg)](examples/graphs/graph/graph_4.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/graphs/graph/graph_4.cpp"
-    ```
+```cpp
+--8<-- "examples/graphs/graph/graph_4.cpp"
+```
 
 
 
 ===! "Plot"
 
-    [![example_graph_5](docs/examples/graphs/graph/graph_5.svg)](examples/graphs/graph/graph_5.cpp)
+[![example_graph_5](docs/examples/graphs/graph/graph_5.svg)](examples/graphs/graph/graph_5.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/graphs/graph/graph_5.cpp"
-    ```
+```cpp
+--8<-- "examples/graphs/graph/graph_5.cpp"
+```
 
 
 
@@ -5099,37 +5098,37 @@ More examples:
 
 ===! "Plot"
 
-    [![example_digraph_1](docs/examples/graphs/digraph/digraph_1.svg)](examples/graphs/digraph/digraph_1.cpp)
+[![example_digraph_1](docs/examples/graphs/digraph/digraph_1.svg)](examples/graphs/digraph/digraph_1.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/graphs/digraph/digraph_1.cpp"
-    ```
+```cpp
+--8<-- "examples/graphs/digraph/digraph_1.cpp"
+```
 
 **More examples**
 
 ===! "Plot"
 
-    [![example_digraph_2](docs/examples/graphs/digraph/digraph_2.svg)](examples/graphs/digraph/digraph_2.cpp)
+[![example_digraph_2](docs/examples/graphs/digraph/digraph_2.svg)](examples/graphs/digraph/digraph_2.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/graphs/digraph/digraph_2.cpp"
-    ```
+```cpp
+--8<-- "examples/graphs/digraph/digraph_2.cpp"
+```
 
 
 
 ===! "Plot"
 
-    [![example_digraph_3](docs/examples/graphs/digraph/digraph_3.svg)](examples/graphs/digraph/digraph_3.cpp)
+[![example_digraph_3](docs/examples/graphs/digraph/digraph_3.svg)](examples/graphs/digraph/digraph_3.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/graphs/digraph/digraph_3.cpp"
-    ```
+```cpp
+--8<-- "examples/graphs/digraph/digraph_3.cpp"
+```
 
 
 
@@ -5159,129 +5158,129 @@ More examples:
 
 ===! "Plot"
 
-    [![example_imshow_1](docs/examples/images/imshow/imshow_1.png)](examples/images/imshow/imshow_1.cpp)
+[![example_imshow_1](docs/examples/images/imshow/imshow_1.png)](examples/images/imshow/imshow_1.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/images/imshow/imshow_1.cpp"
-    ```
+```cpp
+--8<-- "examples/images/imshow/imshow_1.cpp"
+```
 
 **More examples**
 
 ===! "Plot"
 
-    [![example_imshow_2](docs/examples/images/imshow/imshow_2.png)](examples/images/imshow/imshow_2.cpp)
+[![example_imshow_2](docs/examples/images/imshow/imshow_2.png)](examples/images/imshow/imshow_2.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/images/imshow/imshow_2.cpp"
-    ```
+```cpp
+--8<-- "examples/images/imshow/imshow_2.cpp"
+```
 
 
 
 ===! "Plot"
 
-    [![example_imshow_3](docs/examples/images/imshow/imshow_3.svg)](examples/images/imshow/imshow_3.cpp)
+[![example_imshow_3](docs/examples/images/imshow/imshow_3.svg)](examples/images/imshow/imshow_3.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/images/imshow/imshow_3.cpp"
-    ```
+```cpp
+--8<-- "examples/images/imshow/imshow_3.cpp"
+```
 
 
 ===! "Plot"
 
-    [![example_imshow_4](docs/examples/images/imshow/imshow_4.png)](examples/images/imshow/imshow_4.cpp)
+[![example_imshow_4](docs/examples/images/imshow/imshow_4.png)](examples/images/imshow/imshow_4.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/images/imshow/imshow_4.cpp"
-    ```
-
-
-
-===! "Plot"
-
-    [![example_imshow_5](docs/examples/images/imshow/imshow_5.png)](examples/images/imshow/imshow_5.cpp)
-
-=== "C++"
-
-    ```cpp
-    --8<-- "examples/images/imshow/imshow_5.cpp"
-    ```
-
-
-===! "Plot"
-
-    [![example_imshow_6](docs/examples/images/imshow/imshow_6.png)](examples/images/imshow/imshow_6.cpp)
-
-=== "C++"
-
-    ```cpp
-    --8<-- "examples/images/imshow/imshow_6.cpp"
-    ```
+```cpp
+--8<-- "examples/images/imshow/imshow_4.cpp"
+```
 
 
 
 ===! "Plot"
 
-    [![example_imshow_7](docs/examples/images/imshow/imshow_7.png)](examples/images/imshow/imshow_7.cpp)
+[![example_imshow_5](docs/examples/images/imshow/imshow_5.png)](examples/images/imshow/imshow_5.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/images/imshow/imshow_7.cpp"
-    ```
+```cpp
+--8<-- "examples/images/imshow/imshow_5.cpp"
+```
 
 
 ===! "Plot"
 
-    [![example_imshow_8](docs/examples/images/imshow/imshow_8.png)](examples/images/imshow/imshow_8.cpp)
+[![example_imshow_6](docs/examples/images/imshow/imshow_6.png)](examples/images/imshow/imshow_6.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/images/imshow/imshow_8.cpp"
-    ```
-
-
-
-===! "Plot"
-
-    [![example_imshow_9](docs/examples/images/imshow/imshow_9.svg)](examples/images/imshow/imshow_9.cpp)
-
-=== "C++"
-
-    ```cpp
-    --8<-- "examples/images/imshow/imshow_9.cpp"
-    ```
-
-
-===! "Plot"
-
-    [![example_imshow_10](docs/examples/images/imshow/imshow_10.svg)](examples/images/imshow/imshow_10.cpp)
-
-=== "C++"
-
-    ```cpp
-    --8<-- "examples/images/imshow/imshow_10.cpp"
-    ```
+```cpp
+--8<-- "examples/images/imshow/imshow_6.cpp"
+```
 
 
 
 ===! "Plot"
 
-    [![example_imshow_11](docs/examples/images/imshow/imshow_11.png)](examples/images/imshow/imshow_11.cpp)
+[![example_imshow_7](docs/examples/images/imshow/imshow_7.png)](examples/images/imshow/imshow_7.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/images/imshow/imshow_11.cpp"
-    ```
+```cpp
+--8<-- "examples/images/imshow/imshow_7.cpp"
+```
+
+
+===! "Plot"
+
+[![example_imshow_8](docs/examples/images/imshow/imshow_8.png)](examples/images/imshow/imshow_8.cpp)
+
+=== "C++"
+
+```cpp
+--8<-- "examples/images/imshow/imshow_8.cpp"
+```
+
+
+
+===! "Plot"
+
+[![example_imshow_9](docs/examples/images/imshow/imshow_9.svg)](examples/images/imshow/imshow_9.cpp)
+
+=== "C++"
+
+```cpp
+--8<-- "examples/images/imshow/imshow_9.cpp"
+```
+
+
+===! "Plot"
+
+[![example_imshow_10](docs/examples/images/imshow/imshow_10.svg)](examples/images/imshow/imshow_10.cpp)
+
+=== "C++"
+
+```cpp
+--8<-- "examples/images/imshow/imshow_10.cpp"
+```
+
+
+
+===! "Plot"
+
+[![example_imshow_11](docs/examples/images/imshow/imshow_11.png)](examples/images/imshow/imshow_11.cpp)
+
+=== "C++"
+
+```cpp
+--8<-- "examples/images/imshow/imshow_11.cpp"
+```
 
 
 
@@ -5311,60 +5310,60 @@ More examples:
 
 ===! "Plot"
 
-    [![example_image_1](docs/examples/images/image/image_1.png)](examples/images/image/image_1.cpp)
+[![example_image_1](docs/examples/images/image/image_1.png)](examples/images/image/image_1.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/images/image/image_1.cpp"
-    ```
+```cpp
+--8<-- "examples/images/image/image_1.cpp"
+```
 
 **More examples**
 
 ===! "Plot"
 
-    [![example_image_2](docs/examples/images/image/image_2.png)](examples/images/image/image_2.cpp)
+[![example_image_2](docs/examples/images/image/image_2.png)](examples/images/image/image_2.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/images/image/image_2.cpp"
-    ```
+```cpp
+--8<-- "examples/images/image/image_2.cpp"
+```
 
 
 
 ===! "Plot"
 
-    [![example_image_3](docs/examples/images/image/image_3.png)](examples/images/image/image_3.cpp)
+[![example_image_3](docs/examples/images/image/image_3.png)](examples/images/image/image_3.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/images/image/image_3.cpp"
-    ```
+```cpp
+--8<-- "examples/images/image/image_3.cpp"
+```
 
 
 ===! "Plot"
 
-    [![example_image_4](docs/examples/images/image/image_4.png)](examples/images/image/image_4.cpp)
+[![example_image_4](docs/examples/images/image/image_4.png)](examples/images/image/image_4.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/images/image/image_4.cpp"
-    ```
+```cpp
+--8<-- "examples/images/image/image_4.cpp"
+```
 
 
 
 ===! "Plot"
 
-    [![example_image_5](docs/examples/images/image/image_5.png)](examples/images/image/image_5.cpp)
+[![example_image_5](docs/examples/images/image/image_5.png)](examples/images/image/image_5.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/images/image/image_5.cpp"
-    ```
+```cpp
+--8<-- "examples/images/image/image_5.cpp"
+```
 
 
 
@@ -5388,49 +5387,49 @@ More examples:
 
 ===! "Plot"
 
-    [![example_imagesc_1](docs/examples/images/imagesc/imagesc_1.png)](examples/images/imagesc/imagesc_1.cpp)
+[![example_imagesc_1](docs/examples/images/imagesc/imagesc_1.png)](examples/images/imagesc/imagesc_1.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/images/imagesc/imagesc_1.cpp"
-    ```
+```cpp
+--8<-- "examples/images/imagesc/imagesc_1.cpp"
+```
 
 **More examples**
 
 ===! "Plot"
 
-    [![example_imagesc_2](docs/examples/images/imagesc/imagesc_2.png)](examples/images/imagesc/imagesc_2.cpp)
+[![example_imagesc_2](docs/examples/images/imagesc/imagesc_2.png)](examples/images/imagesc/imagesc_2.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/images/imagesc/imagesc_2.cpp"
-    ```
+```cpp
+--8<-- "examples/images/imagesc/imagesc_2.cpp"
+```
 
 
 
 ===! "Plot"
 
-    [![example_imagesc_3](docs/examples/images/imagesc/imagesc_3.png)](examples/images/imagesc/imagesc_3.cpp)
+[![example_imagesc_3](docs/examples/images/imagesc/imagesc_3.png)](examples/images/imagesc/imagesc_3.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/images/imagesc/imagesc_3.cpp"
-    ```
+```cpp
+--8<-- "examples/images/imagesc/imagesc_3.cpp"
+```
 
 
 
 ===! "Plot"
 
-    [![example_imagesc_4](docs/examples/images/imagesc/imagesc_4.png)](examples/images/imagesc/imagesc_4.cpp)
+[![example_imagesc_4](docs/examples/images/imagesc/imagesc_4.png)](examples/images/imagesc/imagesc_4.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/images/imagesc/imagesc_4.cpp"
-    ```
+```cpp
+--8<-- "examples/images/imagesc/imagesc_4.cpp"
+```
 
 
 
@@ -5463,95 +5462,95 @@ More examples:
 
 ===! "Plot"
 
-    [![example_text_1](docs/examples/annotations/text/text_1.svg)](examples/annotations/text/text_1.cpp)
+[![example_text_1](docs/examples/annotations/text/text_1.svg)](examples/annotations/text/text_1.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/annotations/text/text_1.cpp"
-    ```
+```cpp
+--8<-- "examples/annotations/text/text_1.cpp"
+```
 
 **More examples**
 
 ===! "Plot"
 
-    [![example_text_2](docs/examples/annotations/text/text_2.svg)](examples/annotations/text/text_2.cpp)
+[![example_text_2](docs/examples/annotations/text/text_2.svg)](examples/annotations/text/text_2.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/annotations/text/text_2.cpp"
-    ```
+```cpp
+--8<-- "examples/annotations/text/text_2.cpp"
+```
 
 
 
 ===! "Plot"
 
-    [![example_text_3](docs/examples/annotations/text/text_3.svg)](examples/annotations/text/text_3.cpp)
+[![example_text_3](docs/examples/annotations/text/text_3.svg)](examples/annotations/text/text_3.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/annotations/text/text_3.cpp"
-    ```
+```cpp
+--8<-- "examples/annotations/text/text_3.cpp"
+```
 
 
 ===! "Plot"
 
-    [![example_text_4](docs/examples/annotations/text/text_4.svg)](examples/annotations/text/text_4.cpp)
+[![example_text_4](docs/examples/annotations/text/text_4.svg)](examples/annotations/text/text_4.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/annotations/text/text_4.cpp"
-    ```
-
-
-
-===! "Plot"
-
-    [![example_text_5](docs/examples/annotations/text/text_5.svg)](examples/annotations/text/text_5.cpp)
-
-=== "C++"
-
-    ```cpp
-    --8<-- "examples/annotations/text/text_5.cpp"
-    ```
-
-
-===! "Plot"
-
-    [![example_text_6](docs/examples/annotations/text/text_6.svg)](examples/annotations/text/text_6.cpp)
-
-=== "C++"
-
-    ```cpp
-    --8<-- "examples/annotations/text/text_6.cpp"
-    ```
+```cpp
+--8<-- "examples/annotations/text/text_4.cpp"
+```
 
 
 
 ===! "Plot"
 
-    [![example_text_7](docs/examples/annotations/text/text_7.svg)](examples/annotations/text/text_7.cpp)
+[![example_text_5](docs/examples/annotations/text/text_5.svg)](examples/annotations/text/text_5.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/annotations/text/text_7.cpp"
-    ```
+```cpp
+--8<-- "examples/annotations/text/text_5.cpp"
+```
+
+
+===! "Plot"
+
+[![example_text_6](docs/examples/annotations/text/text_6.svg)](examples/annotations/text/text_6.cpp)
+
+=== "C++"
+
+```cpp
+--8<-- "examples/annotations/text/text_6.cpp"
+```
 
 
 
 ===! "Plot"
 
-    [![example_text_8](docs/examples/annotations/text/text_8.svg)](examples/annotations/text/text_8.cpp)
+[![example_text_7](docs/examples/annotations/text/text_7.svg)](examples/annotations/text/text_7.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/annotations/text/text_8.cpp"
-    ```
+```cpp
+--8<-- "examples/annotations/text/text_7.cpp"
+```
+
+
+
+===! "Plot"
+
+[![example_text_8](docs/examples/annotations/text/text_8.svg)](examples/annotations/text/text_8.cpp)
+
+=== "C++"
+
+```cpp
+--8<-- "examples/annotations/text/text_8.cpp"
+```
 
 
 
@@ -5577,26 +5576,26 @@ More examples:
 
 ===! "Plot"
 
-    [![example_textarrow_1](docs/examples/annotations/textarrow/textarrow_1.svg)](examples/annotations/textarrow/textarrow_1.cpp)
+[![example_textarrow_1](docs/examples/annotations/textarrow/textarrow_1.svg)](examples/annotations/textarrow/textarrow_1.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/annotations/textarrow/textarrow_1.cpp"
-    ```
+```cpp
+--8<-- "examples/annotations/textarrow/textarrow_1.cpp"
+```
 
 **More examples**
 
 
 ===! "Plot"
 
-    [![example_textarrow_2](docs/examples/annotations/textarrow/textarrow_2.svg)](examples/annotations/textarrow/textarrow_2.cpp)
+[![example_textarrow_2](docs/examples/annotations/textarrow/textarrow_2.svg)](examples/annotations/textarrow/textarrow_2.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/annotations/textarrow/textarrow_2.cpp"
-    ```
+```cpp
+--8<-- "examples/annotations/textarrow/textarrow_2.cpp"
+```
 
 
   
@@ -5620,60 +5619,60 @@ More examples:
 
 ===! "Plot"
 
-    [![example_rectangle_1](docs/examples/annotations/rectangle/rectangle_1.svg)](examples/annotations/rectangle/rectangle_1.cpp)
+[![example_rectangle_1](docs/examples/annotations/rectangle/rectangle_1.svg)](examples/annotations/rectangle/rectangle_1.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/annotations/rectangle/rectangle_1.cpp"
-    ```
+```cpp
+--8<-- "examples/annotations/rectangle/rectangle_1.cpp"
+```
 
 **More examples**
 
 ===! "Plot"
 
-    [![example_rectangle_2](docs/examples/annotations/rectangle/rectangle_2.png)](examples/annotations/rectangle/rectangle_2.cpp)
+[![example_rectangle_2](docs/examples/annotations/rectangle/rectangle_2.png)](examples/annotations/rectangle/rectangle_2.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/annotations/rectangle/rectangle_2.cpp"
-    ```
+```cpp
+--8<-- "examples/annotations/rectangle/rectangle_2.cpp"
+```
 
 
 
 ===! "Plot"
 
-    [![example_rectangle_3](docs/examples/annotations/rectangle/rectangle_3.svg)](examples/annotations/rectangle/rectangle_3.cpp)
+[![example_rectangle_3](docs/examples/annotations/rectangle/rectangle_3.svg)](examples/annotations/rectangle/rectangle_3.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/annotations/rectangle/rectangle_3.cpp"
-    ```
+```cpp
+--8<-- "examples/annotations/rectangle/rectangle_3.cpp"
+```
 
 
 ===! "Plot"
 
-    [![example_rectangle_4](docs/examples/annotations/rectangle/rectangle_4.png)](examples/annotations/rectangle/rectangle_4.cpp)
+[![example_rectangle_4](docs/examples/annotations/rectangle/rectangle_4.png)](examples/annotations/rectangle/rectangle_4.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/annotations/rectangle/rectangle_4.cpp"
-    ```
+```cpp
+--8<-- "examples/annotations/rectangle/rectangle_4.cpp"
+```
 
 
 
 ===! "Plot"
 
-    [![example_rectangle_5](docs/examples/annotations/rectangle/rectangle_5.png)](examples/annotations/rectangle/rectangle_5.cpp)
+[![example_rectangle_5](docs/examples/annotations/rectangle/rectangle_5.png)](examples/annotations/rectangle/rectangle_5.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/annotations/rectangle/rectangle_5.cpp"
-    ```
+```cpp
+--8<-- "examples/annotations/rectangle/rectangle_5.cpp"
+```
 
 
 
@@ -5696,13 +5695,13 @@ polygon(x0, y0, color);
 
 ===! "Plot"
 
-    [![example_fill_1](docs/examples/annotations/fill/fill_1.svg)](examples/annotations/fill/fill_1.cpp)
+[![example_fill_1](docs/examples/annotations/fill/fill_1.svg)](examples/annotations/fill/fill_1.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/annotations/fill/fill_1.cpp"
-    ```
+```cpp
+--8<-- "examples/annotations/fill/fill_1.cpp"
+```
 
 ### Ellipse
 
@@ -5720,13 +5719,13 @@ ellipse(x, y, w, h);
 
 ===! "Plot"
 
-    [![example_ellipse_1](docs/examples/annotations/ellipse/ellipse_1.svg)](examples/annotations/ellipse/ellipse_1.cpp)
+[![example_ellipse_1](docs/examples/annotations/ellipse/ellipse_1.svg)](examples/annotations/ellipse/ellipse_1.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/annotations/ellipse/ellipse_1.cpp"
-    ```
+```cpp
+--8<-- "examples/annotations/ellipse/ellipse_1.cpp"
+```
 
 ### Textbox
 
@@ -5744,13 +5743,13 @@ textbox(x, y, w, h, str);
 
 ===! "Plot"
 
-    [![example_textbox_1](docs/examples/annotations/textbox/textbox_1.svg)](examples/annotations/textbox/textbox_1.cpp)
+[![example_textbox_1](docs/examples/annotations/textbox/textbox_1.svg)](examples/annotations/textbox/textbox_1.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/annotations/textbox/textbox_1.cpp"
-    ```
+```cpp
+--8<-- "examples/annotations/textbox/textbox_1.cpp"
+```
 
 ### Arrow
 
@@ -5773,26 +5772,26 @@ More examples:
 
 ===! "Plot"
 
-    [![example_arrow_1](docs/examples/annotations/arrow/arrow_1.svg)](examples/annotations/arrow/arrow_1.cpp)
+[![example_arrow_1](docs/examples/annotations/arrow/arrow_1.svg)](examples/annotations/arrow/arrow_1.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/annotations/arrow/arrow_1.cpp"
-    ```
+```cpp
+--8<-- "examples/annotations/arrow/arrow_1.cpp"
+```
 
 **More examples**
 
 
 ===! "Plot"
 
-    [![example_arrow_2](docs/examples/annotations/arrow/arrow_2.svg)](examples/annotations/arrow/arrow_2.cpp)
+[![example_arrow_2](docs/examples/annotations/arrow/arrow_2.svg)](examples/annotations/arrow/arrow_2.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/annotations/arrow/arrow_2.cpp"
-    ```
+```cpp
+--8<-- "examples/annotations/arrow/arrow_2.cpp"
+```
 
 
   
@@ -5812,13 +5811,13 @@ line(x1, y1, x2, y2);
 
 ===! "Plot"
 
-    [![example_line_1](docs/examples/annotations/line/line_1.svg)](examples/annotations/line/line_1.cpp)
+[![example_line_1](docs/examples/annotations/line/line_1.svg)](examples/annotations/line/line_1.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/annotations/line/line_1.cpp"
-    ```
+```cpp
+--8<-- "examples/annotations/line/line_1.cpp"
+```
 
 ## Appearance
 
@@ -5857,95 +5856,95 @@ More examples:
 
 ===! "Plot"
 
-    [![example_title_1](docs/examples/appearance/labels/title/title_1.svg)](examples/appearance/labels/title/title_1.cpp)
+[![example_title_1](docs/examples/appearance/labels/title/title_1.svg)](examples/appearance/labels/title/title_1.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/appearance/labels/title/title_1.cpp"
-    ```
+```cpp
+--8<-- "examples/appearance/labels/title/title_1.cpp"
+```
 
 **More examples**
 
 ===! "Plot"
 
-    [![example_title_2](docs/examples/appearance/labels/title/title_2.svg)](examples/appearance/labels/title/title_2.cpp)
+[![example_title_2](docs/examples/appearance/labels/title/title_2.svg)](examples/appearance/labels/title/title_2.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/appearance/labels/title/title_2.cpp"
-    ```
+```cpp
+--8<-- "examples/appearance/labels/title/title_2.cpp"
+```
 
 
 
 ===! "Plot"
 
-    [![example_title_3](docs/examples/appearance/labels/title/title_3.svg)](examples/appearance/labels/title/title_3.cpp)
+[![example_title_3](docs/examples/appearance/labels/title/title_3.svg)](examples/appearance/labels/title/title_3.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/appearance/labels/title/title_3.cpp"
-    ```
+```cpp
+--8<-- "examples/appearance/labels/title/title_3.cpp"
+```
 
 
 ===! "Plot"
 
-    [![example_title_4](docs/examples/appearance/labels/title/title_4.svg)](examples/appearance/labels/title/title_4.cpp)
+[![example_title_4](docs/examples/appearance/labels/title/title_4.svg)](examples/appearance/labels/title/title_4.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/appearance/labels/title/title_4.cpp"
-    ```
-
-
-
-===! "Plot"
-
-    [![example_title_5](docs/examples/appearance/labels/title/title_5.svg)](examples/appearance/labels/title/title_5.cpp)
-
-=== "C++"
-
-    ```cpp
-    --8<-- "examples/appearance/labels/title/title_5.cpp"
-    ```
-
-
-===! "Plot"
-
-    [![example_title_6](docs/examples/appearance/labels/title/title_6.svg)](examples/appearance/labels/title/title_6.cpp)
-
-=== "C++"
-
-    ```cpp
-    --8<-- "examples/appearance/labels/title/title_6.cpp"
-    ```
+```cpp
+--8<-- "examples/appearance/labels/title/title_4.cpp"
+```
 
 
 
 ===! "Plot"
 
-    [![example_title_7](docs/examples/appearance/labels/title/title_7.svg)](examples/appearance/labels/title/title_7.cpp)
+[![example_title_5](docs/examples/appearance/labels/title/title_5.svg)](examples/appearance/labels/title/title_5.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/appearance/labels/title/title_7.cpp"
-    ```
+```cpp
+--8<-- "examples/appearance/labels/title/title_5.cpp"
+```
+
+
+===! "Plot"
+
+[![example_title_6](docs/examples/appearance/labels/title/title_6.svg)](examples/appearance/labels/title/title_6.cpp)
+
+=== "C++"
+
+```cpp
+--8<-- "examples/appearance/labels/title/title_6.cpp"
+```
 
 
 
 ===! "Plot"
 
-    [![example_title_8](docs/examples/appearance/labels/title/title_8.svg)](examples/appearance/labels/title/title_8.cpp)
+[![example_title_7](docs/examples/appearance/labels/title/title_7.svg)](examples/appearance/labels/title/title_7.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/appearance/labels/title/title_8.cpp"
-    ```
+```cpp
+--8<-- "examples/appearance/labels/title/title_7.cpp"
+```
+
+
+
+===! "Plot"
+
+[![example_title_8](docs/examples/appearance/labels/title/title_8.svg)](examples/appearance/labels/title/title_8.cpp)
+
+=== "C++"
+
+```cpp
+--8<-- "examples/appearance/labels/title/title_8.cpp"
+```
 
 
 
@@ -5971,26 +5970,26 @@ More examples:
 
 ===! "Plot"
 
-    [![example_sgtitle_1](docs/examples/appearance/labels/sgtitle/sgtitle_1.png)](examples/appearance/labels/sgtitle/sgtitle_1.cpp)
+[![example_sgtitle_1](docs/examples/appearance/labels/sgtitle/sgtitle_1.png)](examples/appearance/labels/sgtitle/sgtitle_1.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/appearance/labels/sgtitle/sgtitle_1.cpp"
-    ```
+```cpp
+--8<-- "examples/appearance/labels/sgtitle/sgtitle_1.cpp"
+```
 
 **More examples**
 
 
 ===! "Plot"
 
-    [![example_sgtitle_2](docs/examples/appearance/labels/sgtitle/sgtitle_2.svg)](examples/appearance/labels/sgtitle/sgtitle_2.cpp)
+[![example_sgtitle_2](docs/examples/appearance/labels/sgtitle/sgtitle_2.svg)](examples/appearance/labels/sgtitle/sgtitle_2.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/appearance/labels/sgtitle/sgtitle_2.cpp"
-    ```
+```cpp
+--8<-- "examples/appearance/labels/sgtitle/sgtitle_2.cpp"
+```
 
 
   
@@ -6014,95 +6013,95 @@ More examples:
 
 ===! "Plot"
 
-    [![example_xlabel_1](docs/examples/appearance/labels/xlabel/xlabel_1.svg)](examples/appearance/labels/xlabel/xlabel_1.cpp)
+[![example_xlabel_1](docs/examples/appearance/labels/xlabel/xlabel_1.svg)](examples/appearance/labels/xlabel/xlabel_1.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/appearance/labels/xlabel/xlabel_1.cpp"
-    ```
+```cpp
+--8<-- "examples/appearance/labels/xlabel/xlabel_1.cpp"
+```
 
 **More examples**
 
 ===! "Plot"
 
-    [![example_xlabel_2](docs/examples/appearance/labels/xlabel/xlabel_2.svg)](examples/appearance/labels/xlabel/xlabel_2.cpp)
+[![example_xlabel_2](docs/examples/appearance/labels/xlabel/xlabel_2.svg)](examples/appearance/labels/xlabel/xlabel_2.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/appearance/labels/xlabel/xlabel_2.cpp"
-    ```
+```cpp
+--8<-- "examples/appearance/labels/xlabel/xlabel_2.cpp"
+```
 
 
 
 ===! "Plot"
 
-    [![example_xlabel_3](docs/examples/appearance/labels/xlabel/xlabel_3.svg)](examples/appearance/labels/xlabel/xlabel_3.cpp)
+[![example_xlabel_3](docs/examples/appearance/labels/xlabel/xlabel_3.svg)](examples/appearance/labels/xlabel/xlabel_3.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/appearance/labels/xlabel/xlabel_3.cpp"
-    ```
+```cpp
+--8<-- "examples/appearance/labels/xlabel/xlabel_3.cpp"
+```
 
 
 ===! "Plot"
 
-    [![example_xlabel_4](docs/examples/appearance/labels/xlabel/xlabel_4.svg)](examples/appearance/labels/xlabel/xlabel_4.cpp)
+[![example_xlabel_4](docs/examples/appearance/labels/xlabel/xlabel_4.svg)](examples/appearance/labels/xlabel/xlabel_4.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/appearance/labels/xlabel/xlabel_4.cpp"
-    ```
-
-
-
-===! "Plot"
-
-    [![example_xlabel_5](docs/examples/appearance/labels/xlabel/xlabel_5.svg)](examples/appearance/labels/xlabel/xlabel_5.cpp)
-
-=== "C++"
-
-    ```cpp
-    --8<-- "examples/appearance/labels/xlabel/xlabel_5.cpp"
-    ```
-
-
-===! "Plot"
-
-    [![example_xlabel_6](docs/examples/appearance/labels/xlabel/xlabel_6.svg)](examples/appearance/labels/xlabel/xlabel_6.cpp)
-
-=== "C++"
-
-    ```cpp
-    --8<-- "examples/appearance/labels/xlabel/xlabel_6.cpp"
-    ```
+```cpp
+--8<-- "examples/appearance/labels/xlabel/xlabel_4.cpp"
+```
 
 
 
 ===! "Plot"
 
-    [![example_xlabel_7](docs/examples/appearance/labels/xlabel/xlabel_7.svg)](examples/appearance/labels/xlabel/xlabel_7.cpp)
+[![example_xlabel_5](docs/examples/appearance/labels/xlabel/xlabel_5.svg)](examples/appearance/labels/xlabel/xlabel_5.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/appearance/labels/xlabel/xlabel_7.cpp"
-    ```
+```cpp
+--8<-- "examples/appearance/labels/xlabel/xlabel_5.cpp"
+```
+
+
+===! "Plot"
+
+[![example_xlabel_6](docs/examples/appearance/labels/xlabel/xlabel_6.svg)](examples/appearance/labels/xlabel/xlabel_6.cpp)
+
+=== "C++"
+
+```cpp
+--8<-- "examples/appearance/labels/xlabel/xlabel_6.cpp"
+```
 
 
 
 ===! "Plot"
 
-    [![example_xlabel_8](docs/examples/appearance/labels/xlabel/xlabel_8.svg)](examples/appearance/labels/xlabel/xlabel_8.cpp)
+[![example_xlabel_7](docs/examples/appearance/labels/xlabel/xlabel_7.svg)](examples/appearance/labels/xlabel/xlabel_7.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/appearance/labels/xlabel/xlabel_8.cpp"
-    ```
+```cpp
+--8<-- "examples/appearance/labels/xlabel/xlabel_7.cpp"
+```
+
+
+
+===! "Plot"
+
+[![example_xlabel_8](docs/examples/appearance/labels/xlabel/xlabel_8.svg)](examples/appearance/labels/xlabel/xlabel_8.cpp)
+
+=== "C++"
+
+```cpp
+--8<-- "examples/appearance/labels/xlabel/xlabel_8.cpp"
+```
 
 
 
@@ -6126,95 +6125,95 @@ More examples:
 
 ===! "Plot"
 
-    [![example_ylabel_1](docs/examples/appearance/labels/ylabel/ylabel_1.svg)](examples/appearance/labels/ylabel/ylabel_1.cpp)
+[![example_ylabel_1](docs/examples/appearance/labels/ylabel/ylabel_1.svg)](examples/appearance/labels/ylabel/ylabel_1.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/appearance/labels/ylabel/ylabel_1.cpp"
-    ```
+```cpp
+--8<-- "examples/appearance/labels/ylabel/ylabel_1.cpp"
+```
 
 **More examples**
 
 ===! "Plot"
 
-    [![example_ylabel_2](docs/examples/appearance/labels/ylabel/ylabel_2.svg)](examples/appearance/labels/ylabel/ylabel_2.cpp)
+[![example_ylabel_2](docs/examples/appearance/labels/ylabel/ylabel_2.svg)](examples/appearance/labels/ylabel/ylabel_2.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/appearance/labels/ylabel/ylabel_2.cpp"
-    ```
+```cpp
+--8<-- "examples/appearance/labels/ylabel/ylabel_2.cpp"
+```
 
 
 
 ===! "Plot"
 
-    [![example_ylabel_3](docs/examples/appearance/labels/ylabel/ylabel_3.svg)](examples/appearance/labels/ylabel/ylabel_3.cpp)
+[![example_ylabel_3](docs/examples/appearance/labels/ylabel/ylabel_3.svg)](examples/appearance/labels/ylabel/ylabel_3.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/appearance/labels/ylabel/ylabel_3.cpp"
-    ```
+```cpp
+--8<-- "examples/appearance/labels/ylabel/ylabel_3.cpp"
+```
 
 
 ===! "Plot"
 
-    [![example_ylabel_4](docs/examples/appearance/labels/ylabel/ylabel_4.svg)](examples/appearance/labels/ylabel/ylabel_4.cpp)
+[![example_ylabel_4](docs/examples/appearance/labels/ylabel/ylabel_4.svg)](examples/appearance/labels/ylabel/ylabel_4.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/appearance/labels/ylabel/ylabel_4.cpp"
-    ```
-
-
-
-===! "Plot"
-
-    [![example_ylabel_5](docs/examples/appearance/labels/ylabel/ylabel_5.svg)](examples/appearance/labels/ylabel/ylabel_5.cpp)
-
-=== "C++"
-
-    ```cpp
-    --8<-- "examples/appearance/labels/ylabel/ylabel_5.cpp"
-    ```
-
-
-===! "Plot"
-
-    [![example_ylabel_6](docs/examples/appearance/labels/ylabel/ylabel_6.svg)](examples/appearance/labels/ylabel/ylabel_6.cpp)
-
-=== "C++"
-
-    ```cpp
-    --8<-- "examples/appearance/labels/ylabel/ylabel_6.cpp"
-    ```
+```cpp
+--8<-- "examples/appearance/labels/ylabel/ylabel_4.cpp"
+```
 
 
 
 ===! "Plot"
 
-    [![example_ylabel_7](docs/examples/appearance/labels/ylabel/ylabel_7.svg)](examples/appearance/labels/ylabel/ylabel_7.cpp)
+[![example_ylabel_5](docs/examples/appearance/labels/ylabel/ylabel_5.svg)](examples/appearance/labels/ylabel/ylabel_5.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/appearance/labels/ylabel/ylabel_7.cpp"
-    ```
+```cpp
+--8<-- "examples/appearance/labels/ylabel/ylabel_5.cpp"
+```
+
+
+===! "Plot"
+
+[![example_ylabel_6](docs/examples/appearance/labels/ylabel/ylabel_6.svg)](examples/appearance/labels/ylabel/ylabel_6.cpp)
+
+=== "C++"
+
+```cpp
+--8<-- "examples/appearance/labels/ylabel/ylabel_6.cpp"
+```
 
 
 
 ===! "Plot"
 
-    [![example_ylabel_8](docs/examples/appearance/labels/ylabel/ylabel_8.svg)](examples/appearance/labels/ylabel/ylabel_8.cpp)
+[![example_ylabel_7](docs/examples/appearance/labels/ylabel/ylabel_7.svg)](examples/appearance/labels/ylabel/ylabel_7.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/appearance/labels/ylabel/ylabel_8.cpp"
-    ```
+```cpp
+--8<-- "examples/appearance/labels/ylabel/ylabel_7.cpp"
+```
+
+
+
+===! "Plot"
+
+[![example_ylabel_8](docs/examples/appearance/labels/ylabel/ylabel_8.svg)](examples/appearance/labels/ylabel/ylabel_8.cpp)
+
+=== "C++"
+
+```cpp
+--8<-- "examples/appearance/labels/ylabel/ylabel_8.cpp"
+```
 
 
 
@@ -6239,37 +6238,37 @@ More examples:
 
 ===! "Plot"
 
-    [![example_zlabel_1](docs/examples/appearance/labels/zlabel/zlabel_1.png)](examples/appearance/labels/zlabel/zlabel_1.cpp)
+[![example_zlabel_1](docs/examples/appearance/labels/zlabel/zlabel_1.png)](examples/appearance/labels/zlabel/zlabel_1.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/appearance/labels/zlabel/zlabel_1.cpp"
-    ```
+```cpp
+--8<-- "examples/appearance/labels/zlabel/zlabel_1.cpp"
+```
 
 **More examples**
 
 ===! "Plot"
 
-    [![example_zlabel_2](docs/examples/appearance/labels/zlabel/zlabel_2.png)](examples/appearance/labels/zlabel/zlabel_2.cpp)
+[![example_zlabel_2](docs/examples/appearance/labels/zlabel/zlabel_2.png)](examples/appearance/labels/zlabel/zlabel_2.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/appearance/labels/zlabel/zlabel_2.cpp"
-    ```
+```cpp
+--8<-- "examples/appearance/labels/zlabel/zlabel_2.cpp"
+```
 
 
 
 ===! "Plot"
 
-    [![example_zlabel_3](docs/examples/appearance/labels/zlabel/zlabel_3.png)](examples/appearance/labels/zlabel/zlabel_3.cpp)
+[![example_zlabel_3](docs/examples/appearance/labels/zlabel/zlabel_3.png)](examples/appearance/labels/zlabel/zlabel_3.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/appearance/labels/zlabel/zlabel_3.cpp"
-    ```
+```cpp
+--8<-- "examples/appearance/labels/zlabel/zlabel_3.cpp"
+```
 
 #### Legend
 
@@ -6291,95 +6290,95 @@ More examples:
 
 ===! "Plot"
 
-    [![example_legend_1](docs/examples/appearance/labels/legend/legend_1.svg)](examples/appearance/labels/legend/legend_1.cpp)
+[![example_legend_1](docs/examples/appearance/labels/legend/legend_1.svg)](examples/appearance/labels/legend/legend_1.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/appearance/labels/legend/legend_1.cpp"
-    ```
+```cpp
+--8<-- "examples/appearance/labels/legend/legend_1.cpp"
+```
 
 **More examples**
 
 ===! "Plot"
 
-    [![example_legend_2](docs/examples/appearance/labels/legend/legend_2.svg)](examples/appearance/labels/legend/legend_2.cpp)
+[![example_legend_2](docs/examples/appearance/labels/legend/legend_2.svg)](examples/appearance/labels/legend/legend_2.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/appearance/labels/legend/legend_2.cpp"
-    ```
+```cpp
+--8<-- "examples/appearance/labels/legend/legend_2.cpp"
+```
 
 
 
 ===! "Plot"
 
-    [![example_legend_3](docs/examples/appearance/labels/legend/legend_3.svg)](examples/appearance/labels/legend/legend_3.cpp)
+[![example_legend_3](docs/examples/appearance/labels/legend/legend_3.svg)](examples/appearance/labels/legend/legend_3.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/appearance/labels/legend/legend_3.cpp"
-    ```
+```cpp
+--8<-- "examples/appearance/labels/legend/legend_3.cpp"
+```
 
 
 ===! "Plot"
 
-    [![example_legend_4](docs/examples/appearance/labels/legend/legend_4.svg)](examples/appearance/labels/legend/legend_4.cpp)
+[![example_legend_4](docs/examples/appearance/labels/legend/legend_4.svg)](examples/appearance/labels/legend/legend_4.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/appearance/labels/legend/legend_4.cpp"
-    ```
-
-
-
-===! "Plot"
-
-    [![example_legend_5](docs/examples/appearance/labels/legend/legend_5.svg)](examples/appearance/labels/legend/legend_5.cpp)
-
-=== "C++"
-
-    ```cpp
-    --8<-- "examples/appearance/labels/legend/legend_5.cpp"
-    ```
-
-
-===! "Plot"
-
-    [![example_legend_6](docs/examples/appearance/labels/legend/legend_6.svg)](examples/appearance/labels/legend/legend_6.cpp)
-
-=== "C++"
-
-    ```cpp
-    --8<-- "examples/appearance/labels/legend/legend_6.cpp"
-    ```
+```cpp
+--8<-- "examples/appearance/labels/legend/legend_4.cpp"
+```
 
 
 
 ===! "Plot"
 
-    [![example_legend_7](docs/examples/appearance/labels/legend/legend_7.svg)](examples/appearance/labels/legend/legend_7.cpp)
+[![example_legend_5](docs/examples/appearance/labels/legend/legend_5.svg)](examples/appearance/labels/legend/legend_5.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/appearance/labels/legend/legend_7.cpp"
-    ```
+```cpp
+--8<-- "examples/appearance/labels/legend/legend_5.cpp"
+```
+
+
+===! "Plot"
+
+[![example_legend_6](docs/examples/appearance/labels/legend/legend_6.svg)](examples/appearance/labels/legend/legend_6.cpp)
+
+=== "C++"
+
+```cpp
+--8<-- "examples/appearance/labels/legend/legend_6.cpp"
+```
 
 
 
 ===! "Plot"
 
-    [![example_legend_8](docs/examples/appearance/labels/legend/legend_8.svg)](examples/appearance/labels/legend/legend_8.cpp)
+[![example_legend_7](docs/examples/appearance/labels/legend/legend_7.svg)](examples/appearance/labels/legend/legend_7.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/appearance/labels/legend/legend_8.cpp"
-    ```
+```cpp
+--8<-- "examples/appearance/labels/legend/legend_7.cpp"
+```
+
+
+
+===! "Plot"
+
+[![example_legend_8](docs/examples/appearance/labels/legend/legend_8.svg)](examples/appearance/labels/legend/legend_8.cpp)
+
+=== "C++"
+
+```cpp
+--8<-- "examples/appearance/labels/legend/legend_8.cpp"
+```
 
 
 
@@ -6406,72 +6405,72 @@ More examples:
 
 ===! "Plot"
 
-    [![example_xlim_1](docs/examples/appearance/axis/xlim/xlim_1.svg)](examples/appearance/axis/xlim/xlim_1.cpp)
+[![example_xlim_1](docs/examples/appearance/axis/xlim/xlim_1.svg)](examples/appearance/axis/xlim/xlim_1.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/appearance/axis/xlim/xlim_1.cpp"
-    ```
+```cpp
+--8<-- "examples/appearance/axis/xlim/xlim_1.cpp"
+```
 
 **More examples**
 
 ===! "Plot"
 
-    [![example_xlim_2](docs/examples/appearance/axis/xlim/xlim_2.png)](examples/appearance/axis/xlim/xlim_2.cpp)
+[![example_xlim_2](docs/examples/appearance/axis/xlim/xlim_2.png)](examples/appearance/axis/xlim/xlim_2.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/appearance/axis/xlim/xlim_2.cpp"
-    ```
+```cpp
+--8<-- "examples/appearance/axis/xlim/xlim_2.cpp"
+```
 
 
 
 ===! "Plot"
 
-    [![example_xlim_3](docs/examples/appearance/axis/xlim/xlim_3.svg)](examples/appearance/axis/xlim/xlim_3.cpp)
+[![example_xlim_3](docs/examples/appearance/axis/xlim/xlim_3.svg)](examples/appearance/axis/xlim/xlim_3.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/appearance/axis/xlim/xlim_3.cpp"
-    ```
+```cpp
+--8<-- "examples/appearance/axis/xlim/xlim_3.cpp"
+```
 
 
 ===! "Plot"
 
-    [![example_xlim_4](docs/examples/appearance/axis/xlim/xlim_4.svg)](examples/appearance/axis/xlim/xlim_4.cpp)
+[![example_xlim_4](docs/examples/appearance/axis/xlim/xlim_4.svg)](examples/appearance/axis/xlim/xlim_4.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/appearance/axis/xlim/xlim_4.cpp"
-    ```
-
-
-
-===! "Plot"
-
-    [![example_xlim_5](docs/examples/appearance/axis/xlim/xlim_5.svg)](examples/appearance/axis/xlim/xlim_5.cpp)
-
-=== "C++"
-
-    ```cpp
-    --8<-- "examples/appearance/axis/xlim/xlim_5.cpp"
-    ```
+```cpp
+--8<-- "examples/appearance/axis/xlim/xlim_4.cpp"
+```
 
 
 
 ===! "Plot"
 
-    [![example_xlim_6](docs/examples/appearance/axis/xlim/xlim_6.svg)](examples/appearance/axis/xlim/xlim_6.cpp)
+[![example_xlim_5](docs/examples/appearance/axis/xlim/xlim_5.svg)](examples/appearance/axis/xlim/xlim_5.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/appearance/axis/xlim/xlim_6.cpp"
-    ```
+```cpp
+--8<-- "examples/appearance/axis/xlim/xlim_5.cpp"
+```
+
+
+
+===! "Plot"
+
+[![example_xlim_6](docs/examples/appearance/axis/xlim/xlim_6.svg)](examples/appearance/axis/xlim/xlim_6.cpp)
+
+=== "C++"
+
+```cpp
+--8<-- "examples/appearance/axis/xlim/xlim_6.cpp"
+```
 
 
 
@@ -6496,72 +6495,72 @@ More examples:
 
 ===! "Plot"
 
-    [![example_ylim_1](docs/examples/appearance/axis/ylim/ylim_1.svg)](examples/appearance/axis/ylim/ylim_1.cpp)
+[![example_ylim_1](docs/examples/appearance/axis/ylim/ylim_1.svg)](examples/appearance/axis/ylim/ylim_1.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/appearance/axis/ylim/ylim_1.cpp"
-    ```
+```cpp
+--8<-- "examples/appearance/axis/ylim/ylim_1.cpp"
+```
 
 **More examples**
 
 ===! "Plot"
 
-    [![example_ylim_2](docs/examples/appearance/axis/ylim/ylim_2.png)](examples/appearance/axis/ylim/ylim_2.cpp)
+[![example_ylim_2](docs/examples/appearance/axis/ylim/ylim_2.png)](examples/appearance/axis/ylim/ylim_2.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/appearance/axis/ylim/ylim_2.cpp"
-    ```
+```cpp
+--8<-- "examples/appearance/axis/ylim/ylim_2.cpp"
+```
 
 
 
 ===! "Plot"
 
-    [![example_ylim_3](docs/examples/appearance/axis/ylim/ylim_3.svg)](examples/appearance/axis/ylim/ylim_3.cpp)
+[![example_ylim_3](docs/examples/appearance/axis/ylim/ylim_3.svg)](examples/appearance/axis/ylim/ylim_3.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/appearance/axis/ylim/ylim_3.cpp"
-    ```
+```cpp
+--8<-- "examples/appearance/axis/ylim/ylim_3.cpp"
+```
 
 
 ===! "Plot"
 
-    [![example_ylim_4](docs/examples/appearance/axis/ylim/ylim_4.svg)](examples/appearance/axis/ylim/ylim_4.cpp)
+[![example_ylim_4](docs/examples/appearance/axis/ylim/ylim_4.svg)](examples/appearance/axis/ylim/ylim_4.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/appearance/axis/ylim/ylim_4.cpp"
-    ```
-
-
-
-===! "Plot"
-
-    [![example_ylim_5](docs/examples/appearance/axis/ylim/ylim_5.svg)](examples/appearance/axis/ylim/ylim_5.cpp)
-
-=== "C++"
-
-    ```cpp
-    --8<-- "examples/appearance/axis/ylim/ylim_5.cpp"
-    ```
+```cpp
+--8<-- "examples/appearance/axis/ylim/ylim_4.cpp"
+```
 
 
 
 ===! "Plot"
 
-    [![example_ylim_6](docs/examples/appearance/axis/ylim/ylim_6.svg)](examples/appearance/axis/ylim/ylim_6.cpp)
+[![example_ylim_5](docs/examples/appearance/axis/ylim/ylim_5.svg)](examples/appearance/axis/ylim/ylim_5.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/appearance/axis/ylim/ylim_6.cpp"
-    ```
+```cpp
+--8<-- "examples/appearance/axis/ylim/ylim_5.cpp"
+```
+
+
+
+===! "Plot"
+
+[![example_ylim_6](docs/examples/appearance/axis/ylim/ylim_6.svg)](examples/appearance/axis/ylim/ylim_6.cpp)
+
+=== "C++"
+
+```cpp
+--8<-- "examples/appearance/axis/ylim/ylim_6.cpp"
+```
 
 
 
@@ -6586,72 +6585,72 @@ More examples:
 
 ===! "Plot"
 
-    [![example_zlim_1](docs/examples/appearance/axis/zlim/zlim_1.png)](examples/appearance/axis/zlim/zlim_1.cpp)
+[![example_zlim_1](docs/examples/appearance/axis/zlim/zlim_1.png)](examples/appearance/axis/zlim/zlim_1.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/appearance/axis/zlim/zlim_1.cpp"
-    ```
+```cpp
+--8<-- "examples/appearance/axis/zlim/zlim_1.cpp"
+```
 
 **More examples**
 
 ===! "Plot"
 
-    [![example_zlim_2](docs/examples/appearance/axis/zlim/zlim_2.png)](examples/appearance/axis/zlim/zlim_2.cpp)
+[![example_zlim_2](docs/examples/appearance/axis/zlim/zlim_2.png)](examples/appearance/axis/zlim/zlim_2.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/appearance/axis/zlim/zlim_2.cpp"
-    ```
+```cpp
+--8<-- "examples/appearance/axis/zlim/zlim_2.cpp"
+```
 
 
 
 ===! "Plot"
 
-    [![example_zlim_3](docs/examples/appearance/axis/zlim/zlim_3.png)](examples/appearance/axis/zlim/zlim_3.cpp)
+[![example_zlim_3](docs/examples/appearance/axis/zlim/zlim_3.png)](examples/appearance/axis/zlim/zlim_3.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/appearance/axis/zlim/zlim_3.cpp"
-    ```
+```cpp
+--8<-- "examples/appearance/axis/zlim/zlim_3.cpp"
+```
 
 
 ===! "Plot"
 
-    [![example_zlim_4](docs/examples/appearance/axis/zlim/zlim_4.svg)](examples/appearance/axis/zlim/zlim_4.cpp)
+[![example_zlim_4](docs/examples/appearance/axis/zlim/zlim_4.svg)](examples/appearance/axis/zlim/zlim_4.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/appearance/axis/zlim/zlim_4.cpp"
-    ```
-
-
-
-===! "Plot"
-
-    [![example_zlim_5](docs/examples/appearance/axis/zlim/zlim_5.svg)](examples/appearance/axis/zlim/zlim_5.cpp)
-
-=== "C++"
-
-    ```cpp
-    --8<-- "examples/appearance/axis/zlim/zlim_5.cpp"
-    ```
+```cpp
+--8<-- "examples/appearance/axis/zlim/zlim_4.cpp"
+```
 
 
 
 ===! "Plot"
 
-    [![example_zlim_6](docs/examples/appearance/axis/zlim/zlim_6.svg)](examples/appearance/axis/zlim/zlim_6.cpp)
+[![example_zlim_5](docs/examples/appearance/axis/zlim/zlim_5.svg)](examples/appearance/axis/zlim/zlim_5.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/appearance/axis/zlim/zlim_6.cpp"
-    ```
+```cpp
+--8<-- "examples/appearance/axis/zlim/zlim_5.cpp"
+```
+
+
+
+===! "Plot"
+
+[![example_zlim_6](docs/examples/appearance/axis/zlim/zlim_6.svg)](examples/appearance/axis/zlim/zlim_6.cpp)
+
+=== "C++"
+
+```cpp
+--8<-- "examples/appearance/axis/zlim/zlim_6.cpp"
+```
 
 
 
@@ -6676,95 +6675,95 @@ More examples:
 
 ===! "Plot"
 
-    [![example_axis_1](docs/examples/appearance/axis/axis/axis_1.svg)](examples/appearance/axis/axis/axis_1.cpp)
+[![example_axis_1](docs/examples/appearance/axis/axis/axis_1.svg)](examples/appearance/axis/axis/axis_1.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/appearance/axis/axis/axis_1.cpp"
-    ```
+```cpp
+--8<-- "examples/appearance/axis/axis/axis_1.cpp"
+```
 
 **More examples**
 
 ===! "Plot"
 
-    [![example_axis_2](docs/examples/appearance/axis/axis/axis_2.svg)](examples/appearance/axis/axis/axis_2.cpp)
+[![example_axis_2](docs/examples/appearance/axis/axis/axis_2.svg)](examples/appearance/axis/axis/axis_2.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/appearance/axis/axis/axis_2.cpp"
-    ```
+```cpp
+--8<-- "examples/appearance/axis/axis/axis_2.cpp"
+```
 
 
 
 ===! "Plot"
 
-    [![example_axis_3](docs/examples/appearance/axis/axis/axis_3.svg)](examples/appearance/axis/axis/axis_3.cpp)
+[![example_axis_3](docs/examples/appearance/axis/axis/axis_3.svg)](examples/appearance/axis/axis/axis_3.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/appearance/axis/axis/axis_3.cpp"
-    ```
+```cpp
+--8<-- "examples/appearance/axis/axis/axis_3.cpp"
+```
 
 
 ===! "Plot"
 
-    [![example_axis_4](docs/examples/appearance/axis/axis/axis_4.png)](examples/appearance/axis/axis/axis_4.cpp)
+[![example_axis_4](docs/examples/appearance/axis/axis/axis_4.png)](examples/appearance/axis/axis/axis_4.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/appearance/axis/axis/axis_4.cpp"
-    ```
-
-
-
-===! "Plot"
-
-    [![example_axis_5](docs/examples/appearance/axis/axis/axis_5.png)](examples/appearance/axis/axis/axis_5.cpp)
-
-=== "C++"
-
-    ```cpp
-    --8<-- "examples/appearance/axis/axis/axis_5.cpp"
-    ```
-
-
-===! "Plot"
-
-    [![example_axis_6](docs/examples/appearance/axis/axis/axis_6.png)](examples/appearance/axis/axis/axis_6.cpp)
-
-=== "C++"
-
-    ```cpp
-    --8<-- "examples/appearance/axis/axis/axis_6.cpp"
-    ```
+```cpp
+--8<-- "examples/appearance/axis/axis/axis_4.cpp"
+```
 
 
 
 ===! "Plot"
 
-    [![example_axis_7](docs/examples/appearance/axis/axis/axis_7.svg)](examples/appearance/axis/axis/axis_7.cpp)
+[![example_axis_5](docs/examples/appearance/axis/axis/axis_5.png)](examples/appearance/axis/axis/axis_5.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/appearance/axis/axis/axis_7.cpp"
-    ```
+```cpp
+--8<-- "examples/appearance/axis/axis/axis_5.cpp"
+```
+
+
+===! "Plot"
+
+[![example_axis_6](docs/examples/appearance/axis/axis/axis_6.png)](examples/appearance/axis/axis/axis_6.cpp)
+
+=== "C++"
+
+```cpp
+--8<-- "examples/appearance/axis/axis/axis_6.cpp"
+```
 
 
 
 ===! "Plot"
 
-    [![example_axis_8](docs/examples/appearance/axis/axis/axis_8.svg)](examples/appearance/axis/axis/axis_8.cpp)
+[![example_axis_7](docs/examples/appearance/axis/axis/axis_7.svg)](examples/appearance/axis/axis/axis_7.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/appearance/axis/axis/axis_8.cpp"
-    ```
+```cpp
+--8<-- "examples/appearance/axis/axis/axis_7.cpp"
+```
+
+
+
+===! "Plot"
+
+[![example_axis_8](docs/examples/appearance/axis/axis/axis_8.svg)](examples/appearance/axis/axis/axis_8.cpp)
+
+=== "C++"
+
+```cpp
+--8<-- "examples/appearance/axis/axis/axis_8.cpp"
+```
 
 
 
@@ -6789,37 +6788,37 @@ More examples:
 
 ===! "Plot"
 
-    [![example_box_1](docs/examples/appearance/axis/box/box_1.png)](examples/appearance/axis/box/box_1.cpp)
+[![example_box_1](docs/examples/appearance/axis/box/box_1.png)](examples/appearance/axis/box/box_1.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/appearance/axis/box/box_1.cpp"
-    ```
+```cpp
+--8<-- "examples/appearance/axis/box/box_1.cpp"
+```
 
 **More examples**
 
 ===! "Plot"
 
-    [![example_box_2](docs/examples/appearance/axis/box/box_2.png)](examples/appearance/axis/box/box_2.cpp)
+[![example_box_2](docs/examples/appearance/axis/box/box_2.png)](examples/appearance/axis/box/box_2.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/appearance/axis/box/box_2.cpp"
-    ```
+```cpp
+--8<-- "examples/appearance/axis/box/box_2.cpp"
+```
 
 
 
 ===! "Plot"
 
-    [![example_box_3](docs/examples/appearance/axis/box/box_3.svg)](examples/appearance/axis/box/box_3.cpp)
+[![example_box_3](docs/examples/appearance/axis/box/box_3.svg)](examples/appearance/axis/box/box_3.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/appearance/axis/box/box_3.cpp"
-    ```
+```cpp
+--8<-- "examples/appearance/axis/box/box_3.cpp"
+```
 
 
 
@@ -6846,49 +6845,49 @@ More examples:
 
 ===! "Plot"
 
-    [![example_grid_1](docs/examples/appearance/grid/grid/grid_1.svg)](examples/appearance/grid/grid/grid_1.cpp)
+[![example_grid_1](docs/examples/appearance/grid/grid/grid_1.svg)](examples/appearance/grid/grid/grid_1.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/appearance/grid/grid/grid_1.cpp"
-    ```
+```cpp
+--8<-- "examples/appearance/grid/grid/grid_1.cpp"
+```
 
 **More examples**
 
 ===! "Plot"
 
-    [![example_grid_2](docs/examples/appearance/grid/grid/grid_2.png)](examples/appearance/grid/grid/grid_2.cpp)
+[![example_grid_2](docs/examples/appearance/grid/grid/grid_2.png)](examples/appearance/grid/grid/grid_2.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/appearance/grid/grid/grid_2.cpp"
-    ```
+```cpp
+--8<-- "examples/appearance/grid/grid/grid_2.cpp"
+```
 
 
 
 ===! "Plot"
 
-    [![example_grid_3](docs/examples/appearance/grid/grid/grid_3.svg)](examples/appearance/grid/grid/grid_3.cpp)
+[![example_grid_3](docs/examples/appearance/grid/grid/grid_3.svg)](examples/appearance/grid/grid/grid_3.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/appearance/grid/grid/grid_3.cpp"
-    ```
+```cpp
+--8<-- "examples/appearance/grid/grid/grid_3.cpp"
+```
 
 
 
 ===! "Plot"
 
-    [![example_grid_4](docs/examples/appearance/grid/grid/grid_4.svg)](examples/appearance/grid/grid/grid_4.cpp)
+[![example_grid_4](docs/examples/appearance/grid/grid/grid_4.svg)](examples/appearance/grid/grid/grid_4.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/appearance/grid/grid/grid_4.cpp"
-    ```
+```cpp
+--8<-- "examples/appearance/grid/grid/grid_4.cpp"
+```
 
 
 
@@ -6913,95 +6912,95 @@ More examples:
 
 ===! "Plot"
 
-    [![example_xticks_1](docs/examples/appearance/grid/xticks/xticks_1.svg)](examples/appearance/grid/xticks/xticks_1.cpp)
+[![example_xticks_1](docs/examples/appearance/grid/xticks/xticks_1.svg)](examples/appearance/grid/xticks/xticks_1.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/appearance/grid/xticks/xticks_1.cpp"
-    ```
+```cpp
+--8<-- "examples/appearance/grid/xticks/xticks_1.cpp"
+```
 
 **More examples**
 
 ===! "Plot"
 
-    [![example_xticks_2](docs/examples/appearance/grid/xticks/xticks_2.svg)](examples/appearance/grid/xticks/xticks_2.cpp)
+[![example_xticks_2](docs/examples/appearance/grid/xticks/xticks_2.svg)](examples/appearance/grid/xticks/xticks_2.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/appearance/grid/xticks/xticks_2.cpp"
-    ```
+```cpp
+--8<-- "examples/appearance/grid/xticks/xticks_2.cpp"
+```
 
 
 
 ===! "Plot"
 
-    [![example_xticks_3](docs/examples/appearance/grid/xticks/xticks_3.svg)](examples/appearance/grid/xticks/xticks_3.cpp)
+[![example_xticks_3](docs/examples/appearance/grid/xticks/xticks_3.svg)](examples/appearance/grid/xticks/xticks_3.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/appearance/grid/xticks/xticks_3.cpp"
-    ```
+```cpp
+--8<-- "examples/appearance/grid/xticks/xticks_3.cpp"
+```
 
 
 ===! "Plot"
 
-    [![example_xticks_4](docs/examples/appearance/grid/xticks/xticks_4.svg)](examples/appearance/grid/xticks/xticks_4.cpp)
+[![example_xticks_4](docs/examples/appearance/grid/xticks/xticks_4.svg)](examples/appearance/grid/xticks/xticks_4.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/appearance/grid/xticks/xticks_4.cpp"
-    ```
-
-
-
-===! "Plot"
-
-    [![example_xticks_5](docs/examples/appearance/grid/xticks/xticks_5.svg)](examples/appearance/grid/xticks/xticks_5.cpp)
-
-=== "C++"
-
-    ```cpp
-    --8<-- "examples/appearance/grid/xticks/xticks_5.cpp"
-    ```
-
-
-===! "Plot"
-
-    [![example_xticks_6](docs/examples/appearance/grid/xticks/xticks_6.svg)](examples/appearance/grid/xticks/xticks_6.cpp)
-
-=== "C++"
-
-    ```cpp
-    --8<-- "examples/appearance/grid/xticks/xticks_6.cpp"
-    ```
+```cpp
+--8<-- "examples/appearance/grid/xticks/xticks_4.cpp"
+```
 
 
 
 ===! "Plot"
 
-    [![example_xticks_7](docs/examples/appearance/grid/xticks/xticks_7.svg)](examples/appearance/grid/xticks/xticks_7.cpp)
+[![example_xticks_5](docs/examples/appearance/grid/xticks/xticks_5.svg)](examples/appearance/grid/xticks/xticks_5.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/appearance/grid/xticks/xticks_7.cpp"
-    ```
+```cpp
+--8<-- "examples/appearance/grid/xticks/xticks_5.cpp"
+```
+
+
+===! "Plot"
+
+[![example_xticks_6](docs/examples/appearance/grid/xticks/xticks_6.svg)](examples/appearance/grid/xticks/xticks_6.cpp)
+
+=== "C++"
+
+```cpp
+--8<-- "examples/appearance/grid/xticks/xticks_6.cpp"
+```
 
 
 
 ===! "Plot"
 
-    [![example_xticks_8](docs/examples/appearance/grid/xticks/xticks_8.svg)](examples/appearance/grid/xticks/xticks_8.cpp)
+[![example_xticks_7](docs/examples/appearance/grid/xticks/xticks_7.svg)](examples/appearance/grid/xticks/xticks_7.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/appearance/grid/xticks/xticks_8.cpp"
-    ```
+```cpp
+--8<-- "examples/appearance/grid/xticks/xticks_7.cpp"
+```
+
+
+
+===! "Plot"
+
+[![example_xticks_8](docs/examples/appearance/grid/xticks/xticks_8.svg)](examples/appearance/grid/xticks/xticks_8.cpp)
+
+=== "C++"
+
+```cpp
+--8<-- "examples/appearance/grid/xticks/xticks_8.cpp"
+```
 
 
   
@@ -7025,95 +7024,95 @@ More examples:
 
 ===! "Plot"
 
-    [![example_yticks_1](docs/examples/appearance/grid/yticks/yticks_1.svg)](examples/appearance/grid/yticks/yticks_1.cpp)
+[![example_yticks_1](docs/examples/appearance/grid/yticks/yticks_1.svg)](examples/appearance/grid/yticks/yticks_1.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/appearance/grid/yticks/yticks_1.cpp"
-    ```
+```cpp
+--8<-- "examples/appearance/grid/yticks/yticks_1.cpp"
+```
 
 **More examples**
 
 ===! "Plot"
 
-    [![example_yticks_2](docs/examples/appearance/grid/yticks/yticks_2.svg)](examples/appearance/grid/yticks/yticks_2.cpp)
+[![example_yticks_2](docs/examples/appearance/grid/yticks/yticks_2.svg)](examples/appearance/grid/yticks/yticks_2.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/appearance/grid/yticks/yticks_2.cpp"
-    ```
+```cpp
+--8<-- "examples/appearance/grid/yticks/yticks_2.cpp"
+```
 
 
 
 ===! "Plot"
 
-    [![example_yticks_3](docs/examples/appearance/grid/yticks/yticks_3.svg)](examples/appearance/grid/yticks/yticks_3.cpp)
+[![example_yticks_3](docs/examples/appearance/grid/yticks/yticks_3.svg)](examples/appearance/grid/yticks/yticks_3.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/appearance/grid/yticks/yticks_3.cpp"
-    ```
+```cpp
+--8<-- "examples/appearance/grid/yticks/yticks_3.cpp"
+```
 
 
 ===! "Plot"
 
-    [![example_yticks_4](docs/examples/appearance/grid/yticks/yticks_4.svg)](examples/appearance/grid/yticks/yticks_4.cpp)
+[![example_yticks_4](docs/examples/appearance/grid/yticks/yticks_4.svg)](examples/appearance/grid/yticks/yticks_4.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/appearance/grid/yticks/yticks_4.cpp"
-    ```
-
-
-
-===! "Plot"
-
-    [![example_yticks_5](docs/examples/appearance/grid/yticks/yticks_5.svg)](examples/appearance/grid/yticks/yticks_5.cpp)
-
-=== "C++"
-
-    ```cpp
-    --8<-- "examples/appearance/grid/yticks/yticks_5.cpp"
-    ```
-
-
-===! "Plot"
-
-    [![example_yticks_6](docs/examples/appearance/grid/yticks/yticks_6.svg)](examples/appearance/grid/yticks/yticks_6.cpp)
-
-=== "C++"
-
-    ```cpp
-    --8<-- "examples/appearance/grid/yticks/yticks_6.cpp"
-    ```
+```cpp
+--8<-- "examples/appearance/grid/yticks/yticks_4.cpp"
+```
 
 
 
 ===! "Plot"
 
-    [![example_yticks_7](docs/examples/appearance/grid/yticks/yticks_7.svg)](examples/appearance/grid/yticks/yticks_7.cpp)
+[![example_yticks_5](docs/examples/appearance/grid/yticks/yticks_5.svg)](examples/appearance/grid/yticks/yticks_5.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/appearance/grid/yticks/yticks_7.cpp"
-    ```
+```cpp
+--8<-- "examples/appearance/grid/yticks/yticks_5.cpp"
+```
+
+
+===! "Plot"
+
+[![example_yticks_6](docs/examples/appearance/grid/yticks/yticks_6.svg)](examples/appearance/grid/yticks/yticks_6.cpp)
+
+=== "C++"
+
+```cpp
+--8<-- "examples/appearance/grid/yticks/yticks_6.cpp"
+```
 
 
 
 ===! "Plot"
 
-    [![example_yticks_8](docs/examples/appearance/grid/yticks/yticks_8.svg)](examples/appearance/grid/yticks/yticks_8.cpp)
+[![example_yticks_7](docs/examples/appearance/grid/yticks/yticks_7.svg)](examples/appearance/grid/yticks/yticks_7.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/appearance/grid/yticks/yticks_8.cpp"
-    ```
+```cpp
+--8<-- "examples/appearance/grid/yticks/yticks_7.cpp"
+```
+
+
+
+===! "Plot"
+
+[![example_yticks_8](docs/examples/appearance/grid/yticks/yticks_8.svg)](examples/appearance/grid/yticks/yticks_8.cpp)
+
+=== "C++"
+
+```cpp
+--8<-- "examples/appearance/grid/yticks/yticks_8.cpp"
+```
 
 
 
@@ -7137,72 +7136,72 @@ More examples:
 
 ===! "Plot"
 
-    [![example_zticks_1](docs/examples/appearance/grid/zticks/zticks_1.png)](examples/appearance/grid/zticks/zticks_1.cpp)
+[![example_zticks_1](docs/examples/appearance/grid/zticks/zticks_1.png)](examples/appearance/grid/zticks/zticks_1.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/appearance/grid/zticks/zticks_1.cpp"
-    ```
+```cpp
+--8<-- "examples/appearance/grid/zticks/zticks_1.cpp"
+```
 
 **More examples**
 
 ===! "Plot"
 
-    [![example_zticks_2](docs/examples/appearance/grid/zticks/zticks_2.png)](examples/appearance/grid/zticks/zticks_2.cpp)
+[![example_zticks_2](docs/examples/appearance/grid/zticks/zticks_2.png)](examples/appearance/grid/zticks/zticks_2.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/appearance/grid/zticks/zticks_2.cpp"
-    ```
+```cpp
+--8<-- "examples/appearance/grid/zticks/zticks_2.cpp"
+```
 
 
 
 ===! "Plot"
 
-    [![example_zticks_3](docs/examples/appearance/grid/zticks/zticks_3.png)](examples/appearance/grid/zticks/zticks_3.cpp)
+[![example_zticks_3](docs/examples/appearance/grid/zticks/zticks_3.png)](examples/appearance/grid/zticks/zticks_3.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/appearance/grid/zticks/zticks_3.cpp"
-    ```
+```cpp
+--8<-- "examples/appearance/grid/zticks/zticks_3.cpp"
+```
 
 
 ===! "Plot"
 
-    [![example_zticks_4](docs/examples/appearance/grid/zticks/zticks_4.svg)](examples/appearance/grid/zticks/zticks_4.cpp)
+[![example_zticks_4](docs/examples/appearance/grid/zticks/zticks_4.svg)](examples/appearance/grid/zticks/zticks_4.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/appearance/grid/zticks/zticks_4.cpp"
-    ```
-
-
-
-===! "Plot"
-
-    [![example_zticks_5](docs/examples/appearance/grid/zticks/zticks_5.svg)](examples/appearance/grid/zticks/zticks_5.cpp)
-
-=== "C++"
-
-    ```cpp
-    --8<-- "examples/appearance/grid/zticks/zticks_5.cpp"
-    ```
+```cpp
+--8<-- "examples/appearance/grid/zticks/zticks_4.cpp"
+```
 
 
 
 ===! "Plot"
 
-    [![example_zticks_6](docs/examples/appearance/grid/zticks/zticks_6.png)](examples/appearance/grid/zticks/zticks_6.cpp)
+[![example_zticks_5](docs/examples/appearance/grid/zticks/zticks_5.svg)](examples/appearance/grid/zticks/zticks_5.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/appearance/grid/zticks/zticks_6.cpp"
-    ```
+```cpp
+--8<-- "examples/appearance/grid/zticks/zticks_5.cpp"
+```
+
+
+
+===! "Plot"
+
+[![example_zticks_6](docs/examples/appearance/grid/zticks/zticks_6.png)](examples/appearance/grid/zticks/zticks_6.cpp)
+
+=== "C++"
+
+```cpp
+--8<-- "examples/appearance/grid/zticks/zticks_6.cpp"
+```
 
 
 
@@ -7226,49 +7225,49 @@ More examples:
 
 ===! "Plot"
 
-    [![example_xticklabels_1](docs/examples/appearance/grid/xticklabels/xticklabels_1.svg)](examples/appearance/grid/xticklabels/xticklabels_1.cpp)
+[![example_xticklabels_1](docs/examples/appearance/grid/xticklabels/xticklabels_1.svg)](examples/appearance/grid/xticklabels/xticklabels_1.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/appearance/grid/xticklabels/xticklabels_1.cpp"
-    ```
+```cpp
+--8<-- "examples/appearance/grid/xticklabels/xticklabels_1.cpp"
+```
 
 **More examples**
 
 ===! "Plot"
 
-    [![example_xticklabels_2](docs/examples/appearance/grid/xticklabels/xticklabels_2.svg)](examples/appearance/grid/xticklabels/xticklabels_2.cpp)
+[![example_xticklabels_2](docs/examples/appearance/grid/xticklabels/xticklabels_2.svg)](examples/appearance/grid/xticklabels/xticklabels_2.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/appearance/grid/xticklabels/xticklabels_2.cpp"
-    ```
+```cpp
+--8<-- "examples/appearance/grid/xticklabels/xticklabels_2.cpp"
+```
 
 
 
 ===! "Plot"
 
-    [![example_xticklabels_3](docs/examples/appearance/grid/xticklabels/xticklabels_3.svg)](examples/appearance/grid/xticklabels/xticklabels_3.cpp)
+[![example_xticklabels_3](docs/examples/appearance/grid/xticklabels/xticklabels_3.svg)](examples/appearance/grid/xticklabels/xticklabels_3.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/appearance/grid/xticklabels/xticklabels_3.cpp"
-    ```
+```cpp
+--8<-- "examples/appearance/grid/xticklabels/xticklabels_3.cpp"
+```
 
 
 
 ===! "Plot"
 
-    [![example_xticklabels_4](docs/examples/appearance/grid/xticklabels/xticklabels_4.svg)](examples/appearance/grid/xticklabels/xticklabels_4.cpp)
+[![example_xticklabels_4](docs/examples/appearance/grid/xticklabels/xticklabels_4.svg)](examples/appearance/grid/xticklabels/xticklabels_4.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/appearance/grid/xticklabels/xticklabels_4.cpp"
-    ```
+```cpp
+--8<-- "examples/appearance/grid/xticklabels/xticklabels_4.cpp"
+```
 
 
 
@@ -7292,49 +7291,49 @@ More examples:
 
 ===! "Plot"
 
-    [![example_yticklabels_1](docs/examples/appearance/grid/yticklabels/yticklabels_1.svg)](examples/appearance/grid/yticklabels/yticklabels_1.cpp)
+[![example_yticklabels_1](docs/examples/appearance/grid/yticklabels/yticklabels_1.svg)](examples/appearance/grid/yticklabels/yticklabels_1.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/appearance/grid/yticklabels/yticklabels_1.cpp"
-    ```
+```cpp
+--8<-- "examples/appearance/grid/yticklabels/yticklabels_1.cpp"
+```
 
 **More examples**
 
 ===! "Plot"
 
-    [![example_yticklabels_2](docs/examples/appearance/grid/yticklabels/yticklabels_2.svg)](examples/appearance/grid/yticklabels/yticklabels_2.cpp)
+[![example_yticklabels_2](docs/examples/appearance/grid/yticklabels/yticklabels_2.svg)](examples/appearance/grid/yticklabels/yticklabels_2.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/appearance/grid/yticklabels/yticklabels_2.cpp"
-    ```
+```cpp
+--8<-- "examples/appearance/grid/yticklabels/yticklabels_2.cpp"
+```
 
 
 
 ===! "Plot"
 
-    [![example_yticklabels_3](docs/examples/appearance/grid/yticklabels/yticklabels_3.svg)](examples/appearance/grid/yticklabels/yticklabels_3.cpp)
+[![example_yticklabels_3](docs/examples/appearance/grid/yticklabels/yticklabels_3.svg)](examples/appearance/grid/yticklabels/yticklabels_3.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/appearance/grid/yticklabels/yticklabels_3.cpp"
-    ```
+```cpp
+--8<-- "examples/appearance/grid/yticklabels/yticklabels_3.cpp"
+```
 
 
 
 ===! "Plot"
 
-    [![example_yticklabels_4](docs/examples/appearance/grid/yticklabels/yticklabels_4.svg)](examples/appearance/grid/yticklabels/yticklabels_4.cpp)
+[![example_yticklabels_4](docs/examples/appearance/grid/yticklabels/yticklabels_4.svg)](examples/appearance/grid/yticklabels/yticklabels_4.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/appearance/grid/yticklabels/yticklabels_4.cpp"
-    ```
+```cpp
+--8<-- "examples/appearance/grid/yticklabels/yticklabels_4.cpp"
+```
 
 
   
@@ -7358,60 +7357,60 @@ More examples:
 
 ===! "Plot"
 
-    [![example_xtickformat_1](docs/examples/appearance/grid/xtickformat/xtickformat_1.svg)](examples/appearance/grid/xtickformat/xtickformat_1.cpp)
+[![example_xtickformat_1](docs/examples/appearance/grid/xtickformat/xtickformat_1.svg)](examples/appearance/grid/xtickformat/xtickformat_1.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/appearance/grid/xtickformat/xtickformat_1.cpp"
-    ```
+```cpp
+--8<-- "examples/appearance/grid/xtickformat/xtickformat_1.cpp"
+```
 
 **More examples**
 
 ===! "Plot"
 
-    [![example_xtickformat_2](docs/examples/appearance/grid/xtickformat/xtickformat_2.svg)](examples/appearance/grid/xtickformat/xtickformat_2.cpp)
+[![example_xtickformat_2](docs/examples/appearance/grid/xtickformat/xtickformat_2.svg)](examples/appearance/grid/xtickformat/xtickformat_2.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/appearance/grid/xtickformat/xtickformat_2.cpp"
-    ```
+```cpp
+--8<-- "examples/appearance/grid/xtickformat/xtickformat_2.cpp"
+```
 
 
 
 ===! "Plot"
 
-    [![example_xtickformat_3](docs/examples/appearance/grid/xtickformat/xtickformat_3.svg)](examples/appearance/grid/xtickformat/xtickformat_3.cpp)
+[![example_xtickformat_3](docs/examples/appearance/grid/xtickformat/xtickformat_3.svg)](examples/appearance/grid/xtickformat/xtickformat_3.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/appearance/grid/xtickformat/xtickformat_3.cpp"
-    ```
+```cpp
+--8<-- "examples/appearance/grid/xtickformat/xtickformat_3.cpp"
+```
 
 
 ===! "Plot"
 
-    [![example_xtickformat_4](docs/examples/appearance/grid/xtickformat/xtickformat_4.svg)](examples/appearance/grid/xtickformat/xtickformat_4.cpp)
+[![example_xtickformat_4](docs/examples/appearance/grid/xtickformat/xtickformat_4.svg)](examples/appearance/grid/xtickformat/xtickformat_4.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/appearance/grid/xtickformat/xtickformat_4.cpp"
-    ```
+```cpp
+--8<-- "examples/appearance/grid/xtickformat/xtickformat_4.cpp"
+```
 
 
 
 ===! "Plot"
 
-    [![example_xtickformat_5](docs/examples/appearance/grid/xtickformat/xtickformat_5.svg)](examples/appearance/grid/xtickformat/xtickformat_5.cpp)
+[![example_xtickformat_5](docs/examples/appearance/grid/xtickformat/xtickformat_5.svg)](examples/appearance/grid/xtickformat/xtickformat_5.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/appearance/grid/xtickformat/xtickformat_5.cpp"
-    ```
+```cpp
+--8<-- "examples/appearance/grid/xtickformat/xtickformat_5.cpp"
+```
 
 
 
@@ -7436,61 +7435,61 @@ More examples:
 
 ===! "Plot"
 
-    [![example_ytickformat_1](docs/examples/appearance/grid/ytickformat/ytickformat_1.svg)](examples/appearance/grid/ytickformat/ytickformat_1.cpp)
+[![example_ytickformat_1](docs/examples/appearance/grid/ytickformat/ytickformat_1.svg)](examples/appearance/grid/ytickformat/ytickformat_1.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/appearance/grid/ytickformat/ytickformat_1.cpp"
-    ```
+```cpp
+--8<-- "examples/appearance/grid/ytickformat/ytickformat_1.cpp"
+```
 
 **More examples**
 
 
 ===! "Plot"
 
-    [![example_ytickformat_2](docs/examples/appearance/grid/ytickformat/ytickformat_2.svg)](examples/appearance/grid/ytickformat/ytickformat_2.cpp)
+[![example_ytickformat_2](docs/examples/appearance/grid/ytickformat/ytickformat_2.svg)](examples/appearance/grid/ytickformat/ytickformat_2.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/appearance/grid/ytickformat/ytickformat_2.cpp"
-    ```
+```cpp
+--8<-- "examples/appearance/grid/ytickformat/ytickformat_2.cpp"
+```
 
 
 
 ===! "Plot"
 
-    [![example_ytickformat_3](docs/examples/appearance/grid/ytickformat/ytickformat_3.svg)](examples/appearance/grid/ytickformat/ytickformat_3.cpp)
+[![example_ytickformat_3](docs/examples/appearance/grid/ytickformat/ytickformat_3.svg)](examples/appearance/grid/ytickformat/ytickformat_3.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/appearance/grid/ytickformat/ytickformat_3.cpp"
-    ```
+```cpp
+--8<-- "examples/appearance/grid/ytickformat/ytickformat_3.cpp"
+```
 
 
 ===! "Plot"
 
-    [![example_ytickformat_4](docs/examples/appearance/grid/ytickformat/ytickformat_4.svg)](examples/appearance/grid/ytickformat/ytickformat_4.cpp)
+[![example_ytickformat_4](docs/examples/appearance/grid/ytickformat/ytickformat_4.svg)](examples/appearance/grid/ytickformat/ytickformat_4.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/appearance/grid/ytickformat/ytickformat_4.cpp"
-    ```
+```cpp
+--8<-- "examples/appearance/grid/ytickformat/ytickformat_4.cpp"
+```
 
 
 
 ===! "Plot"
 
-    [![example_ytickformat_5](docs/examples/appearance/grid/ytickformat/ytickformat_5.svg)](examples/appearance/grid/ytickformat/ytickformat_5.cpp)
+[![example_ytickformat_5](docs/examples/appearance/grid/ytickformat/ytickformat_5.svg)](examples/appearance/grid/ytickformat/ytickformat_5.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/appearance/grid/ytickformat/ytickformat_5.cpp"
-    ```
+```cpp
+--8<-- "examples/appearance/grid/ytickformat/ytickformat_5.cpp"
+```
 
 
 
@@ -7514,60 +7513,60 @@ More examples:
 
 ===! "Plot"
 
-    [![example_ztickformat_1](docs/examples/appearance/grid/ztickformat/ztickformat_1.svg)](examples/appearance/grid/ztickformat/ztickformat_1.cpp)
+[![example_ztickformat_1](docs/examples/appearance/grid/ztickformat/ztickformat_1.svg)](examples/appearance/grid/ztickformat/ztickformat_1.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/appearance/grid/ztickformat/ztickformat_1.cpp"
-    ```
+```cpp
+--8<-- "examples/appearance/grid/ztickformat/ztickformat_1.cpp"
+```
 
 **More examples**
 
 ===! "Plot"
 
-    [![example_ztickformat_2](docs/examples/appearance/grid/ztickformat/ztickformat_2.svg)](examples/appearance/grid/ztickformat/ztickformat_2.cpp)
+[![example_ztickformat_2](docs/examples/appearance/grid/ztickformat/ztickformat_2.svg)](examples/appearance/grid/ztickformat/ztickformat_2.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/appearance/grid/ztickformat/ztickformat_2.cpp"
-    ```
+```cpp
+--8<-- "examples/appearance/grid/ztickformat/ztickformat_2.cpp"
+```
 
 
 
 ===! "Plot"
 
-    [![example_ztickformat_3](docs/examples/appearance/grid/ztickformat/ztickformat_3.svg)](examples/appearance/grid/ztickformat/ztickformat_3.cpp)
+[![example_ztickformat_3](docs/examples/appearance/grid/ztickformat/ztickformat_3.svg)](examples/appearance/grid/ztickformat/ztickformat_3.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/appearance/grid/ztickformat/ztickformat_3.cpp"
-    ```
+```cpp
+--8<-- "examples/appearance/grid/ztickformat/ztickformat_3.cpp"
+```
 
 
 ===! "Plot"
 
-    [![example_ztickformat_4](docs/examples/appearance/grid/ztickformat/ztickformat_4.svg)](examples/appearance/grid/ztickformat/ztickformat_4.cpp)
+[![example_ztickformat_4](docs/examples/appearance/grid/ztickformat/ztickformat_4.svg)](examples/appearance/grid/ztickformat/ztickformat_4.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/appearance/grid/ztickformat/ztickformat_4.cpp"
-    ```
+```cpp
+--8<-- "examples/appearance/grid/ztickformat/ztickformat_4.cpp"
+```
 
 
 
 ===! "Plot"
 
-    [![example_ztickformat_5](docs/examples/appearance/grid/ztickformat/ztickformat_5.svg)](examples/appearance/grid/ztickformat/ztickformat_5.cpp)
+[![example_ztickformat_5](docs/examples/appearance/grid/ztickformat/ztickformat_5.svg)](examples/appearance/grid/ztickformat/ztickformat_5.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/appearance/grid/ztickformat/ztickformat_5.cpp"
-    ```
+```cpp
+--8<-- "examples/appearance/grid/ztickformat/ztickformat_5.cpp"
+```
 
 
 
@@ -7592,37 +7591,37 @@ More examples:
 
 ===! "Plot"
 
-    [![example_xtickangle_1](docs/examples/appearance/grid/xtickangle/xtickangle_1.svg)](examples/appearance/grid/xtickangle/xtickangle_1.cpp)
+[![example_xtickangle_1](docs/examples/appearance/grid/xtickangle/xtickangle_1.svg)](examples/appearance/grid/xtickangle/xtickangle_1.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/appearance/grid/xtickangle/xtickangle_1.cpp"
-    ```
+```cpp
+--8<-- "examples/appearance/grid/xtickangle/xtickangle_1.cpp"
+```
 
 **More examples**
 
 ===! "Plot"
 
-    [![example_xtickangle_2](docs/examples/appearance/grid/xtickangle/xtickangle_2.svg)](examples/appearance/grid/xtickangle/xtickangle_2.cpp)
+[![example_xtickangle_2](docs/examples/appearance/grid/xtickangle/xtickangle_2.svg)](examples/appearance/grid/xtickangle/xtickangle_2.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/appearance/grid/xtickangle/xtickangle_2.cpp"
-    ```
+```cpp
+--8<-- "examples/appearance/grid/xtickangle/xtickangle_2.cpp"
+```
 
 
 
 ===! "Plot"
 
-    [![example_xtickangle_3](docs/examples/appearance/grid/xtickangle/xtickangle_3.svg)](examples/appearance/grid/xtickangle/xtickangle_3.cpp)
+[![example_xtickangle_3](docs/examples/appearance/grid/xtickangle/xtickangle_3.svg)](examples/appearance/grid/xtickangle/xtickangle_3.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/appearance/grid/xtickangle/xtickangle_3.cpp"
-    ```
+```cpp
+--8<-- "examples/appearance/grid/xtickangle/xtickangle_3.cpp"
+```
 
 
 
@@ -7647,37 +7646,37 @@ More examples:
 
 ===! "Plot"
 
-    [![example_ytickangle_1](docs/examples/appearance/grid/ytickangle/ytickangle_1.svg)](examples/appearance/grid/ytickangle/ytickangle_1.cpp)
+[![example_ytickangle_1](docs/examples/appearance/grid/ytickangle/ytickangle_1.svg)](examples/appearance/grid/ytickangle/ytickangle_1.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/appearance/grid/ytickangle/ytickangle_1.cpp"
-    ```
+```cpp
+--8<-- "examples/appearance/grid/ytickangle/ytickangle_1.cpp"
+```
 
 **More examples**
 
 ===! "Plot"
 
-    [![example_ytickangle_2](docs/examples/appearance/grid/ytickangle/ytickangle_2.svg)](examples/appearance/grid/ytickangle/ytickangle_2.cpp)
+[![example_ytickangle_2](docs/examples/appearance/grid/ytickangle/ytickangle_2.svg)](examples/appearance/grid/ytickangle/ytickangle_2.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/appearance/grid/ytickangle/ytickangle_2.cpp"
-    ```
+```cpp
+--8<-- "examples/appearance/grid/ytickangle/ytickangle_2.cpp"
+```
 
 
 
 ===! "Plot"
 
-    [![example_ytickangle_3](docs/examples/appearance/grid/ytickangle/ytickangle_3.svg)](examples/appearance/grid/ytickangle/ytickangle_3.cpp)
+[![example_ytickangle_3](docs/examples/appearance/grid/ytickangle/ytickangle_3.svg)](examples/appearance/grid/ytickangle/ytickangle_3.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/appearance/grid/ytickangle/ytickangle_3.cpp"
-    ```
+```cpp
+--8<-- "examples/appearance/grid/ytickangle/ytickangle_3.cpp"
+```
 
 
 
@@ -7704,49 +7703,49 @@ More examples:
 
 ===! "Plot"
 
-    [![example_hold_1](docs/examples/appearance/multiplot/hold/hold_1.svg)](examples/appearance/multiplot/hold/hold_1.cpp)
+[![example_hold_1](docs/examples/appearance/multiplot/hold/hold_1.svg)](examples/appearance/multiplot/hold/hold_1.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/appearance/multiplot/hold/hold_1.cpp"
-    ```
+```cpp
+--8<-- "examples/appearance/multiplot/hold/hold_1.cpp"
+```
 
 **More examples**
 
 ===! "Plot"
 
-    [![example_hold_2](docs/examples/appearance/multiplot/hold/hold_2.svg)](examples/appearance/multiplot/hold/hold_2.cpp)
+[![example_hold_2](docs/examples/appearance/multiplot/hold/hold_2.svg)](examples/appearance/multiplot/hold/hold_2.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/appearance/multiplot/hold/hold_2.cpp"
-    ```
+```cpp
+--8<-- "examples/appearance/multiplot/hold/hold_2.cpp"
+```
 
 
 
 ===! "Plot"
 
-    [![example_hold_3](docs/examples/appearance/multiplot/hold/hold_3.svg)](examples/appearance/multiplot/hold/hold_3.cpp)
+[![example_hold_3](docs/examples/appearance/multiplot/hold/hold_3.svg)](examples/appearance/multiplot/hold/hold_3.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/appearance/multiplot/hold/hold_3.cpp"
-    ```
+```cpp
+--8<-- "examples/appearance/multiplot/hold/hold_3.cpp"
+```
 
 
 
 ===! "Plot"
 
-    [![example_hold_4](docs/examples/appearance/multiplot/hold/hold_4.svg)](examples/appearance/multiplot/hold/hold_4.cpp)
+[![example_hold_4](docs/examples/appearance/multiplot/hold/hold_4.svg)](examples/appearance/multiplot/hold/hold_4.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/appearance/multiplot/hold/hold_4.cpp"
-    ```
+```cpp
+--8<-- "examples/appearance/multiplot/hold/hold_4.cpp"
+```
 
 
 
@@ -7771,72 +7770,72 @@ More examples:
 
 ===! "Plot"
 
-    [![example_yyaxis_1](docs/examples/appearance/multiplot/yyaxis/yyaxis_1.svg)](examples/appearance/multiplot/yyaxis/yyaxis_1.cpp)
+[![example_yyaxis_1](docs/examples/appearance/multiplot/yyaxis/yyaxis_1.svg)](examples/appearance/multiplot/yyaxis/yyaxis_1.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/appearance/multiplot/yyaxis/yyaxis_1.cpp"
-    ```
+```cpp
+--8<-- "examples/appearance/multiplot/yyaxis/yyaxis_1.cpp"
+```
 
 **More examples**
 
 ===! "Plot"
 
-    [![example_yyaxis_2](docs/examples/appearance/multiplot/yyaxis/yyaxis_2.svg)](examples/appearance/multiplot/yyaxis/yyaxis_2.cpp)
+[![example_yyaxis_2](docs/examples/appearance/multiplot/yyaxis/yyaxis_2.svg)](examples/appearance/multiplot/yyaxis/yyaxis_2.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/appearance/multiplot/yyaxis/yyaxis_2.cpp"
-    ```
+```cpp
+--8<-- "examples/appearance/multiplot/yyaxis/yyaxis_2.cpp"
+```
 
 
 
 ===! "Plot"
 
-    [![example_yyaxis_3](docs/examples/appearance/multiplot/yyaxis/yyaxis_3.svg)](examples/appearance/multiplot/yyaxis/yyaxis_3.cpp)
+[![example_yyaxis_3](docs/examples/appearance/multiplot/yyaxis/yyaxis_3.svg)](examples/appearance/multiplot/yyaxis/yyaxis_3.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/appearance/multiplot/yyaxis/yyaxis_3.cpp"
-    ```
+```cpp
+--8<-- "examples/appearance/multiplot/yyaxis/yyaxis_3.cpp"
+```
 
 
 ===! "Plot"
 
-    [![example_yyaxis_4](docs/examples/appearance/multiplot/yyaxis/yyaxis_4.svg)](examples/appearance/multiplot/yyaxis/yyaxis_4.cpp)
+[![example_yyaxis_4](docs/examples/appearance/multiplot/yyaxis/yyaxis_4.svg)](examples/appearance/multiplot/yyaxis/yyaxis_4.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/appearance/multiplot/yyaxis/yyaxis_4.cpp"
-    ```
-
-
-
-===! "Plot"
-
-    [![example_yyaxis_5](docs/examples/appearance/multiplot/yyaxis/yyaxis_5.svg)](examples/appearance/multiplot/yyaxis/yyaxis_5.cpp)
-
-=== "C++"
-
-    ```cpp
-    --8<-- "examples/appearance/multiplot/yyaxis/yyaxis_5.cpp"
-    ```
+```cpp
+--8<-- "examples/appearance/multiplot/yyaxis/yyaxis_4.cpp"
+```
 
 
 
 ===! "Plot"
 
-    [![example_yyaxis_6](docs/examples/appearance/multiplot/yyaxis/yyaxis_6.svg)](examples/appearance/multiplot/yyaxis/yyaxis_6.cpp)
+[![example_yyaxis_5](docs/examples/appearance/multiplot/yyaxis/yyaxis_5.svg)](examples/appearance/multiplot/yyaxis/yyaxis_5.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/appearance/multiplot/yyaxis/yyaxis_6.cpp"
-    ```
+```cpp
+--8<-- "examples/appearance/multiplot/yyaxis/yyaxis_5.cpp"
+```
+
+
+
+===! "Plot"
+
+[![example_yyaxis_6](docs/examples/appearance/multiplot/yyaxis/yyaxis_6.svg)](examples/appearance/multiplot/yyaxis/yyaxis_6.cpp)
+
+=== "C++"
+
+```cpp
+--8<-- "examples/appearance/multiplot/yyaxis/yyaxis_6.cpp"
+```
 
 
 
@@ -7861,83 +7860,83 @@ More examples:
 
 ===! "Plot"
 
-    [![example_colororder_1](docs/examples/appearance/multiplot/colororder/colororder_1.svg)](examples/appearance/multiplot/colororder/colororder_1.cpp)
+[![example_colororder_1](docs/examples/appearance/multiplot/colororder/colororder_1.svg)](examples/appearance/multiplot/colororder/colororder_1.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/appearance/multiplot/colororder/colororder_1.cpp"
-    ```
+```cpp
+--8<-- "examples/appearance/multiplot/colororder/colororder_1.cpp"
+```
 
 **More examples**
 
 ===! "Plot"
 
-    [![example_colororder_2](docs/examples/appearance/multiplot/colororder/colororder_2.svg)](examples/appearance/multiplot/colororder/colororder_2.cpp)
+[![example_colororder_2](docs/examples/appearance/multiplot/colororder/colororder_2.svg)](examples/appearance/multiplot/colororder/colororder_2.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/appearance/multiplot/colororder/colororder_2.cpp"
-    ```
+```cpp
+--8<-- "examples/appearance/multiplot/colororder/colororder_2.cpp"
+```
 
 
 
 ===! "Plot"
 
-    [![example_colororder_3](docs/examples/appearance/multiplot/colororder/colororder_3.png)](examples/appearance/multiplot/colororder/colororder_3.cpp)
+[![example_colororder_3](docs/examples/appearance/multiplot/colororder/colororder_3.png)](examples/appearance/multiplot/colororder/colororder_3.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/appearance/multiplot/colororder/colororder_3.cpp"
-    ```
+```cpp
+--8<-- "examples/appearance/multiplot/colororder/colororder_3.cpp"
+```
 
 
 ===! "Plot"
 
-    [![example_colororder_4](docs/examples/appearance/multiplot/colororder/colororder_4.svg)](examples/appearance/multiplot/colororder/colororder_4.cpp)
+[![example_colororder_4](docs/examples/appearance/multiplot/colororder/colororder_4.svg)](examples/appearance/multiplot/colororder/colororder_4.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/appearance/multiplot/colororder/colororder_4.cpp"
-    ```
-
-
-
-===! "Plot"
-
-    [![example_colororder_5](docs/examples/appearance/multiplot/colororder/colororder_5.svg)](examples/appearance/multiplot/colororder/colororder_5.cpp)
-
-=== "C++"
-
-    ```cpp
-    --8<-- "examples/appearance/multiplot/colororder/colororder_5.cpp"
-    ```
-
-
-===! "Plot"
-
-    [![example_colororder_6](docs/examples/appearance/multiplot/colororder/colororder_6.svg)](examples/appearance/multiplot/colororder/colororder_6.cpp)
-
-=== "C++"
-
-    ```cpp
-    --8<-- "examples/appearance/multiplot/colororder/colororder_6.cpp"
-    ```
+```cpp
+--8<-- "examples/appearance/multiplot/colororder/colororder_4.cpp"
+```
 
 
 
 ===! "Plot"
 
-    [![example_colororder_7](docs/examples/appearance/multiplot/colororder/colororder_7.svg)](examples/appearance/multiplot/colororder/colororder_7.cpp)
+[![example_colororder_5](docs/examples/appearance/multiplot/colororder/colororder_5.svg)](examples/appearance/multiplot/colororder/colororder_5.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/appearance/multiplot/colororder/colororder_7.cpp"
-    ```
+```cpp
+--8<-- "examples/appearance/multiplot/colororder/colororder_5.cpp"
+```
+
+
+===! "Plot"
+
+[![example_colororder_6](docs/examples/appearance/multiplot/colororder/colororder_6.svg)](examples/appearance/multiplot/colororder/colororder_6.cpp)
+
+=== "C++"
+
+```cpp
+--8<-- "examples/appearance/multiplot/colororder/colororder_6.cpp"
+```
+
+
+
+===! "Plot"
+
+[![example_colororder_7](docs/examples/appearance/multiplot/colororder/colororder_7.svg)](examples/appearance/multiplot/colororder/colororder_7.cpp)
+
+=== "C++"
+
+```cpp
+--8<-- "examples/appearance/multiplot/colororder/colororder_7.cpp"
+```
 
 
 
@@ -7964,152 +7963,152 @@ More examples:
 
 ===! "Plot"
 
-    [![example_subplot_1](docs/examples/appearance/multiplot/subplot/subplot_1.svg)](examples/appearance/multiplot/subplot/subplot_1.cpp)
+[![example_subplot_1](docs/examples/appearance/multiplot/subplot/subplot_1.svg)](examples/appearance/multiplot/subplot/subplot_1.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/appearance/multiplot/subplot/subplot_1.cpp"
-    ```
+```cpp
+--8<-- "examples/appearance/multiplot/subplot/subplot_1.cpp"
+```
 
 **More examples**
 
 ===! "Plot"
 
-    [![example_subplot_2](docs/examples/appearance/multiplot/subplot/subplot_2.svg)](examples/appearance/multiplot/subplot/subplot_2.cpp)
+[![example_subplot_2](docs/examples/appearance/multiplot/subplot/subplot_2.svg)](examples/appearance/multiplot/subplot/subplot_2.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/appearance/multiplot/subplot/subplot_2.cpp"
-    ```
+```cpp
+--8<-- "examples/appearance/multiplot/subplot/subplot_2.cpp"
+```
 
 
 
 ===! "Plot"
 
-    [![example_subplot_3](docs/examples/appearance/multiplot/subplot/subplot_3.svg)](examples/appearance/multiplot/subplot/subplot_3.cpp)
+[![example_subplot_3](docs/examples/appearance/multiplot/subplot/subplot_3.svg)](examples/appearance/multiplot/subplot/subplot_3.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/appearance/multiplot/subplot/subplot_3.cpp"
-    ```
+```cpp
+--8<-- "examples/appearance/multiplot/subplot/subplot_3.cpp"
+```
 
 
 ===! "Plot"
 
-    [![example_subplot_4](docs/examples/appearance/multiplot/subplot/subplot_4.svg)](examples/appearance/multiplot/subplot/subplot_4.cpp)
+[![example_subplot_4](docs/examples/appearance/multiplot/subplot/subplot_4.svg)](examples/appearance/multiplot/subplot/subplot_4.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/appearance/multiplot/subplot/subplot_4.cpp"
-    ```
-
-
-
-===! "Plot"
-
-    [![example_subplot_5](docs/examples/appearance/multiplot/subplot/subplot_5.svg)](examples/appearance/multiplot/subplot/subplot_5.cpp)
-
-=== "C++"
-
-    ```cpp
-    --8<-- "examples/appearance/multiplot/subplot/subplot_5.cpp"
-    ```
-
-
-===! "Plot"
-
-    [![example_subplot_6](docs/examples/appearance/multiplot/subplot/subplot_6.svg)](examples/appearance/multiplot/subplot/subplot_6.cpp)
-
-=== "C++"
-
-    ```cpp
-    --8<-- "examples/appearance/multiplot/subplot/subplot_6.cpp"
-    ```
+```cpp
+--8<-- "examples/appearance/multiplot/subplot/subplot_4.cpp"
+```
 
 
 
 ===! "Plot"
 
-    [![example_subplot_7](docs/examples/appearance/multiplot/subplot/subplot_7.svg)](examples/appearance/multiplot/subplot/subplot_7.cpp)
+[![example_subplot_5](docs/examples/appearance/multiplot/subplot/subplot_5.svg)](examples/appearance/multiplot/subplot/subplot_5.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/appearance/multiplot/subplot/subplot_7.cpp"
-    ```
+```cpp
+--8<-- "examples/appearance/multiplot/subplot/subplot_5.cpp"
+```
 
 
 ===! "Plot"
 
-    [![example_subplot_8](docs/examples/appearance/multiplot/subplot/subplot_8.svg)](examples/appearance/multiplot/subplot/subplot_8.cpp)
+[![example_subplot_6](docs/examples/appearance/multiplot/subplot/subplot_6.svg)](examples/appearance/multiplot/subplot/subplot_6.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/appearance/multiplot/subplot/subplot_8.cpp"
-    ```
-
-
-
-===! "Plot"
-
-    [![example_subplot_9](docs/examples/appearance/multiplot/subplot/subplot_9.svg)](examples/appearance/multiplot/subplot/subplot_9.cpp)
-
-=== "C++"
-
-    ```cpp
-    --8<-- "examples/appearance/multiplot/subplot/subplot_9.cpp"
-    ```
-
-
-===! "Plot"
-
-    [![example_subplot_10](docs/examples/appearance/multiplot/subplot/subplot_10.png)](examples/appearance/multiplot/subplot/subplot_10.cpp)
-
-=== "C++"
-
-    ```cpp
-    --8<-- "examples/appearance/multiplot/subplot/subplot_10.cpp"
-    ```
+```cpp
+--8<-- "examples/appearance/multiplot/subplot/subplot_6.cpp"
+```
 
 
 
 ===! "Plot"
 
-    [![example_subplot_11](docs/examples/appearance/multiplot/subplot/subplot_11.svg)](examples/appearance/multiplot/subplot/subplot_11.cpp)
+[![example_subplot_7](docs/examples/appearance/multiplot/subplot/subplot_7.svg)](examples/appearance/multiplot/subplot/subplot_7.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/appearance/multiplot/subplot/subplot_11.cpp"
-    ```
+```cpp
+--8<-- "examples/appearance/multiplot/subplot/subplot_7.cpp"
+```
 
 
 ===! "Plot"
 
-    [![example_subplot_12](docs/examples/appearance/multiplot/subplot/subplot_12.svg)](examples/appearance/multiplot/subplot/subplot_12.cpp)
+[![example_subplot_8](docs/examples/appearance/multiplot/subplot/subplot_8.svg)](examples/appearance/multiplot/subplot/subplot_8.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/appearance/multiplot/subplot/subplot_12.cpp"
-    ```
+```cpp
+--8<-- "examples/appearance/multiplot/subplot/subplot_8.cpp"
+```
 
 
 
 ===! "Plot"
 
-    [![example_subplot_13](docs/examples/appearance/multiplot/subplot/subplot_13.svg)](examples/appearance/multiplot/subplot/subplot_13.cpp)
+[![example_subplot_9](docs/examples/appearance/multiplot/subplot/subplot_9.svg)](examples/appearance/multiplot/subplot/subplot_9.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/appearance/multiplot/subplot/subplot_13.cpp"
-    ```
+```cpp
+--8<-- "examples/appearance/multiplot/subplot/subplot_9.cpp"
+```
+
+
+===! "Plot"
+
+[![example_subplot_10](docs/examples/appearance/multiplot/subplot/subplot_10.png)](examples/appearance/multiplot/subplot/subplot_10.cpp)
+
+=== "C++"
+
+```cpp
+--8<-- "examples/appearance/multiplot/subplot/subplot_10.cpp"
+```
+
+
+
+===! "Plot"
+
+[![example_subplot_11](docs/examples/appearance/multiplot/subplot/subplot_11.svg)](examples/appearance/multiplot/subplot/subplot_11.cpp)
+
+=== "C++"
+
+```cpp
+--8<-- "examples/appearance/multiplot/subplot/subplot_11.cpp"
+```
+
+
+===! "Plot"
+
+[![example_subplot_12](docs/examples/appearance/multiplot/subplot/subplot_12.svg)](examples/appearance/multiplot/subplot/subplot_12.cpp)
+
+=== "C++"
+
+```cpp
+--8<-- "examples/appearance/multiplot/subplot/subplot_12.cpp"
+```
+
+
+
+===! "Plot"
+
+[![example_subplot_13](docs/examples/appearance/multiplot/subplot/subplot_13.svg)](examples/appearance/multiplot/subplot/subplot_13.cpp)
+
+=== "C++"
+
+```cpp
+--8<-- "examples/appearance/multiplot/subplot/subplot_13.cpp"
+```
 
 
 
@@ -8135,95 +8134,95 @@ More examples:
 
 ===! "Plot"
 
-    [![example_tiledlayout_1](docs/examples/appearance/multiplot/tiledlayout/tiledlayout_1.svg)](examples/appearance/multiplot/tiledlayout/tiledlayout_1.cpp)
+[![example_tiledlayout_1](docs/examples/appearance/multiplot/tiledlayout/tiledlayout_1.svg)](examples/appearance/multiplot/tiledlayout/tiledlayout_1.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/appearance/multiplot/tiledlayout/tiledlayout_1.cpp"
-    ```
+```cpp
+--8<-- "examples/appearance/multiplot/tiledlayout/tiledlayout_1.cpp"
+```
 
 **More examples**
 
 ===! "Plot"
 
-    [![example_tiledlayout_2](docs/examples/appearance/multiplot/tiledlayout/tiledlayout_2.png)](examples/appearance/multiplot/tiledlayout/tiledlayout_2.cpp)
+[![example_tiledlayout_2](docs/examples/appearance/multiplot/tiledlayout/tiledlayout_2.png)](examples/appearance/multiplot/tiledlayout/tiledlayout_2.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/appearance/multiplot/tiledlayout/tiledlayout_2.cpp"
-    ```
+```cpp
+--8<-- "examples/appearance/multiplot/tiledlayout/tiledlayout_2.cpp"
+```
 
 
 
 ===! "Plot"
 
-    [![example_tiledlayout_3](docs/examples/appearance/multiplot/tiledlayout/tiledlayout_3.svg)](examples/appearance/multiplot/tiledlayout/tiledlayout_3.cpp)
+[![example_tiledlayout_3](docs/examples/appearance/multiplot/tiledlayout/tiledlayout_3.svg)](examples/appearance/multiplot/tiledlayout/tiledlayout_3.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/appearance/multiplot/tiledlayout/tiledlayout_3.cpp"
-    ```
+```cpp
+--8<-- "examples/appearance/multiplot/tiledlayout/tiledlayout_3.cpp"
+```
 
 
 ===! "Plot"
 
-    [![example_tiledlayout_4](docs/examples/appearance/multiplot/tiledlayout/tiledlayout_4.svg)](examples/appearance/multiplot/tiledlayout/tiledlayout_4.cpp)
+[![example_tiledlayout_4](docs/examples/appearance/multiplot/tiledlayout/tiledlayout_4.svg)](examples/appearance/multiplot/tiledlayout/tiledlayout_4.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/appearance/multiplot/tiledlayout/tiledlayout_4.cpp"
-    ```
-
-
-
-===! "Plot"
-
-    [![example_tiledlayout_5](docs/examples/appearance/multiplot/tiledlayout/tiledlayout_5.svg)](examples/appearance/multiplot/tiledlayout/tiledlayout_5.cpp)
-
-=== "C++"
-
-    ```cpp
-    --8<-- "examples/appearance/multiplot/tiledlayout/tiledlayout_5.cpp"
-    ```
-
-
-===! "Plot"
-
-    [![example_tiledlayout_6](docs/examples/appearance/multiplot/tiledlayout/tiledlayout_6.svg)](examples/appearance/multiplot/tiledlayout/tiledlayout_6.cpp)
-
-=== "C++"
-
-    ```cpp
-    --8<-- "examples/appearance/multiplot/tiledlayout/tiledlayout_6.cpp"
-    ```
+```cpp
+--8<-- "examples/appearance/multiplot/tiledlayout/tiledlayout_4.cpp"
+```
 
 
 
 ===! "Plot"
 
-    [![example_tiledlayout_7](docs/examples/appearance/multiplot/tiledlayout/tiledlayout_7.png)](examples/appearance/multiplot/tiledlayout/tiledlayout_7.cpp)
+[![example_tiledlayout_5](docs/examples/appearance/multiplot/tiledlayout/tiledlayout_5.svg)](examples/appearance/multiplot/tiledlayout/tiledlayout_5.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/appearance/multiplot/tiledlayout/tiledlayout_7.cpp"
-    ```
+```cpp
+--8<-- "examples/appearance/multiplot/tiledlayout/tiledlayout_5.cpp"
+```
+
+
+===! "Plot"
+
+[![example_tiledlayout_6](docs/examples/appearance/multiplot/tiledlayout/tiledlayout_6.svg)](examples/appearance/multiplot/tiledlayout/tiledlayout_6.cpp)
+
+=== "C++"
+
+```cpp
+--8<-- "examples/appearance/multiplot/tiledlayout/tiledlayout_6.cpp"
+```
 
 
 
 ===! "Plot"
 
-    [![example_tiledlayout_8](docs/examples/appearance/multiplot/tiledlayout/tiledlayout_8.png)](examples/appearance/multiplot/tiledlayout/tiledlayout_8.cpp)
+[![example_tiledlayout_7](docs/examples/appearance/multiplot/tiledlayout/tiledlayout_7.png)](examples/appearance/multiplot/tiledlayout/tiledlayout_7.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/appearance/multiplot/tiledlayout/tiledlayout_8.cpp"
-    ```
+```cpp
+--8<-- "examples/appearance/multiplot/tiledlayout/tiledlayout_7.cpp"
+```
+
+
+
+===! "Plot"
+
+[![example_tiledlayout_8](docs/examples/appearance/multiplot/tiledlayout/tiledlayout_8.png)](examples/appearance/multiplot/tiledlayout/tiledlayout_8.cpp)
+
+=== "C++"
+
+```cpp
+--8<-- "examples/appearance/multiplot/tiledlayout/tiledlayout_8.cpp"
+```
 
 
 
@@ -8254,106 +8253,106 @@ More examples:
 
 ===! "Plot"
 
-    [![example_colormap_1](docs/examples/appearance/colormaps/colormap/colormap_1.png)](examples/appearance/colormaps/colormap/colormap_1.cpp)
+[![example_colormap_1](docs/examples/appearance/colormaps/colormap/colormap_1.png)](examples/appearance/colormaps/colormap/colormap_1.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/appearance/colormaps/colormap/colormap_1.cpp"
-    ```
+```cpp
+--8<-- "examples/appearance/colormaps/colormap/colormap_1.cpp"
+```
 
 **More examples**
 
 ===! "Plot"
 
-    [![example_colormap_2](docs/examples/appearance/colormaps/colormap/colormap_2.png)](examples/appearance/colormaps/colormap/colormap_2.cpp)
+[![example_colormap_2](docs/examples/appearance/colormaps/colormap/colormap_2.png)](examples/appearance/colormaps/colormap/colormap_2.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/appearance/colormaps/colormap/colormap_2.cpp"
-    ```
+```cpp
+--8<-- "examples/appearance/colormaps/colormap/colormap_2.cpp"
+```
 
 
 
 ===! "Plot"
 
-    [![example_colormap_3](docs/examples/appearance/colormaps/colormap/colormap_3.png)](examples/appearance/colormaps/colormap/colormap_3.cpp)
+[![example_colormap_3](docs/examples/appearance/colormaps/colormap/colormap_3.png)](examples/appearance/colormaps/colormap/colormap_3.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/appearance/colormaps/colormap/colormap_3.cpp"
-    ```
+```cpp
+--8<-- "examples/appearance/colormaps/colormap/colormap_3.cpp"
+```
 
 
 ===! "Plot"
 
-    [![example_colormap_4](docs/examples/appearance/colormaps/colormap/colormap_4.png)](examples/appearance/colormaps/colormap/colormap_4.cpp)
+[![example_colormap_4](docs/examples/appearance/colormaps/colormap/colormap_4.png)](examples/appearance/colormaps/colormap/colormap_4.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/appearance/colormaps/colormap/colormap_4.cpp"
-    ```
-
-
-
-===! "Plot"
-
-    [![example_colormap_5](docs/examples/appearance/colormaps/colormap/colormap_5.png)](examples/appearance/colormaps/colormap/colormap_5.cpp)
-
-=== "C++"
-
-    ```cpp
-    --8<-- "examples/appearance/colormaps/colormap/colormap_5.cpp"
-    ```
-
-
-===! "Plot"
-
-    [![example_colormap_6](docs/examples/appearance/colormaps/colormap/colormap_6.png)](examples/appearance/colormaps/colormap/colormap_6.cpp)
-
-=== "C++"
-
-    ```cpp
-    --8<-- "examples/appearance/colormaps/colormap/colormap_6.cpp"
-    ```
+```cpp
+--8<-- "examples/appearance/colormaps/colormap/colormap_4.cpp"
+```
 
 
 
 ===! "Plot"
 
-    [![example_colormap_7](docs/examples/appearance/colormaps/colormap/colormap_7.png)](examples/appearance/colormaps/colormap/colormap_7.cpp)
+[![example_colormap_5](docs/examples/appearance/colormaps/colormap/colormap_5.png)](examples/appearance/colormaps/colormap/colormap_5.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/appearance/colormaps/colormap/colormap_7.cpp"
-    ```
+```cpp
+--8<-- "examples/appearance/colormaps/colormap/colormap_5.cpp"
+```
 
 
 ===! "Plot"
 
-    [![example_colormap_8](docs/examples/appearance/colormaps/colormap/colormap_8.png)](examples/appearance/colormaps/colormap/colormap_8.cpp)
+[![example_colormap_6](docs/examples/appearance/colormaps/colormap/colormap_6.png)](examples/appearance/colormaps/colormap/colormap_6.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/appearance/colormaps/colormap/colormap_8.cpp"
-    ```
+```cpp
+--8<-- "examples/appearance/colormaps/colormap/colormap_6.cpp"
+```
 
 
 
 ===! "Plot"
 
-    [![example_colormap_9](docs/examples/appearance/colormaps/colormap/colormap_9.svg)](examples/appearance/colormaps/colormap/colormap_9.cpp)
+[![example_colormap_7](docs/examples/appearance/colormaps/colormap/colormap_7.png)](examples/appearance/colormaps/colormap/colormap_7.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/appearance/colormaps/colormap/colormap_9.cpp"
-    ```
+```cpp
+--8<-- "examples/appearance/colormaps/colormap/colormap_7.cpp"
+```
+
+
+===! "Plot"
+
+[![example_colormap_8](docs/examples/appearance/colormaps/colormap/colormap_8.png)](examples/appearance/colormaps/colormap/colormap_8.cpp)
+
+=== "C++"
+
+```cpp
+--8<-- "examples/appearance/colormaps/colormap/colormap_8.cpp"
+```
+
+
+
+===! "Plot"
+
+[![example_colormap_9](docs/examples/appearance/colormaps/colormap/colormap_9.svg)](examples/appearance/colormaps/colormap/colormap_9.cpp)
+
+=== "C++"
+
+```cpp
+--8<-- "examples/appearance/colormaps/colormap/colormap_9.cpp"
+```
 
 
 
@@ -8378,83 +8377,83 @@ More examples:
 
 ===! "Plot"
 
-    [![example_colorbar_1](docs/examples/appearance/colormaps/colorbar/colorbar_1.png)](examples/appearance/colormaps/colorbar/colorbar_1.cpp)
+[![example_colorbar_1](docs/examples/appearance/colormaps/colorbar/colorbar_1.png)](examples/appearance/colormaps/colorbar/colorbar_1.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/appearance/colormaps/colorbar/colorbar_1.cpp"
-    ```
+```cpp
+--8<-- "examples/appearance/colormaps/colorbar/colorbar_1.cpp"
+```
 
 **More examples**
 
 ===! "Plot"
 
-    [![example_colorbar_2](docs/examples/appearance/colormaps/colorbar/colorbar_2.png)](examples/appearance/colormaps/colorbar/colorbar_2.cpp)
+[![example_colorbar_2](docs/examples/appearance/colormaps/colorbar/colorbar_2.png)](examples/appearance/colormaps/colorbar/colorbar_2.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/appearance/colormaps/colorbar/colorbar_2.cpp"
-    ```
+```cpp
+--8<-- "examples/appearance/colormaps/colorbar/colorbar_2.cpp"
+```
 
 
 
 ===! "Plot"
 
-    [![example_colorbar_3](docs/examples/appearance/colormaps/colorbar/colorbar_3.png)](examples/appearance/colormaps/colorbar/colorbar_3.cpp)
+[![example_colorbar_3](docs/examples/appearance/colormaps/colorbar/colorbar_3.png)](examples/appearance/colormaps/colorbar/colorbar_3.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/appearance/colormaps/colorbar/colorbar_3.cpp"
-    ```
+```cpp
+--8<-- "examples/appearance/colormaps/colorbar/colorbar_3.cpp"
+```
 
 
 ===! "Plot"
 
-    [![example_colorbar_4](docs/examples/appearance/colormaps/colorbar/colorbar_4.png)](examples/appearance/colormaps/colorbar/colorbar_4.cpp)
+[![example_colorbar_4](docs/examples/appearance/colormaps/colorbar/colorbar_4.png)](examples/appearance/colormaps/colorbar/colorbar_4.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/appearance/colormaps/colorbar/colorbar_4.cpp"
-    ```
-
-
-
-===! "Plot"
-
-    [![example_colorbar_5](docs/examples/appearance/colormaps/colorbar/colorbar_5.svg)](examples/appearance/colormaps/colorbar/colorbar_5.cpp)
-
-=== "C++"
-
-    ```cpp
-    --8<-- "examples/appearance/colormaps/colorbar/colorbar_5.cpp"
-    ```
-
-
-===! "Plot"
-
-    [![example_colorbar_6](docs/examples/appearance/colormaps/colorbar/colorbar_6.png)](examples/appearance/colormaps/colorbar/colorbar_6.cpp)
-
-=== "C++"
-
-    ```cpp
-    --8<-- "examples/appearance/colormaps/colorbar/colorbar_6.cpp"
-    ```
+```cpp
+--8<-- "examples/appearance/colormaps/colorbar/colorbar_4.cpp"
+```
 
 
 
 ===! "Plot"
 
-    [![example_colorbar_7](docs/examples/appearance/colormaps/colorbar/colorbar_7.png)](examples/appearance/colormaps/colorbar/colorbar_7.cpp)
+[![example_colorbar_5](docs/examples/appearance/colormaps/colorbar/colorbar_5.svg)](examples/appearance/colormaps/colorbar/colorbar_5.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/appearance/colormaps/colorbar/colorbar_7.cpp"
-    ```
+```cpp
+--8<-- "examples/appearance/colormaps/colorbar/colorbar_5.cpp"
+```
+
+
+===! "Plot"
+
+[![example_colorbar_6](docs/examples/appearance/colormaps/colorbar/colorbar_6.png)](examples/appearance/colormaps/colorbar/colorbar_6.cpp)
+
+=== "C++"
+
+```cpp
+--8<-- "examples/appearance/colormaps/colorbar/colorbar_6.cpp"
+```
+
+
+
+===! "Plot"
+
+[![example_colorbar_7](docs/examples/appearance/colormaps/colorbar/colorbar_7.png)](examples/appearance/colormaps/colorbar/colorbar_7.cpp)
+
+=== "C++"
+
+```cpp
+--8<-- "examples/appearance/colormaps/colorbar/colorbar_7.cpp"
+```
 
 
 
@@ -8480,26 +8479,26 @@ More examples:
 
 ===! "Plot"
 
-    [![example_rgbplot_1](docs/examples/appearance/colormaps/rgbplot/rgbplot_1.svg)](examples/appearance/colormaps/rgbplot/rgbplot_1.cpp)
+[![example_rgbplot_1](docs/examples/appearance/colormaps/rgbplot/rgbplot_1.svg)](examples/appearance/colormaps/rgbplot/rgbplot_1.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/appearance/colormaps/rgbplot/rgbplot_1.cpp"
-    ```
+```cpp
+--8<-- "examples/appearance/colormaps/rgbplot/rgbplot_1.cpp"
+```
 
 **More examples**
 
 
 ===! "Plot"
 
-    [![example_rgbplot_2](docs/examples/appearance/colormaps/rgbplot/rgbplot_2.svg)](examples/appearance/colormaps/rgbplot/rgbplot_2.cpp)
+[![example_rgbplot_2](docs/examples/appearance/colormaps/rgbplot/rgbplot_2.svg)](examples/appearance/colormaps/rgbplot/rgbplot_2.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/appearance/colormaps/rgbplot/rgbplot_2.cpp"
-    ```
+```cpp
+--8<-- "examples/appearance/colormaps/rgbplot/rgbplot_2.cpp"
+```
 
 
 
@@ -8525,71 +8524,71 @@ More examples:
 
 ===! "Plot"
 
-    [![example_view_1](docs/examples/appearance/camera/view/view_1.png)](examples/appearance/camera/view/view_1.cpp)
+[![example_view_1](docs/examples/appearance/camera/view/view_1.png)](examples/appearance/camera/view/view_1.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/appearance/camera/view/view_1.cpp"
-    ```
+```cpp
+--8<-- "examples/appearance/camera/view/view_1.cpp"
+```
 
 **More examples**
 
 ===! "Plot"
 
-    [![example_view_2](docs/examples/appearance/camera/view/view_2.png)](examples/appearance/camera/view/view_2.cpp)
+[![example_view_2](docs/examples/appearance/camera/view/view_2.png)](examples/appearance/camera/view/view_2.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/appearance/camera/view/view_2.cpp"
-    ```
+```cpp
+--8<-- "examples/appearance/camera/view/view_2.cpp"
+```
 
 
 
 ===! "Plot"
 
-    [![example_view_3](docs/examples/appearance/camera/view/view_3.svg)](examples/appearance/camera/view/view_3.cpp)
+[![example_view_3](docs/examples/appearance/camera/view/view_3.svg)](examples/appearance/camera/view/view_3.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/appearance/camera/view/view_3.cpp"
-    ```
+```cpp
+--8<-- "examples/appearance/camera/view/view_3.cpp"
+```
 
 
 ===! "Plot"
 
-    [![example_view_4](docs/examples/appearance/camera/view/view_4.svg)](examples/appearance/camera/view/view_4.cpp)
+[![example_view_4](docs/examples/appearance/camera/view/view_4.svg)](examples/appearance/camera/view/view_4.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/appearance/camera/view/view_4.cpp"
-    ```
+```cpp
+--8<-- "examples/appearance/camera/view/view_4.cpp"
+```
 
 
 
 ===! "Plot"
 
-    [![example_view_5](docs/examples/appearance/camera/view/view_5.svg)](examples/appearance/camera/view/view_5.cpp)
+[![example_view_5](docs/examples/appearance/camera/view/view_5.svg)](examples/appearance/camera/view/view_5.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/appearance/camera/view/view_5.cpp"
-    ```
+```cpp
+--8<-- "examples/appearance/camera/view/view_5.cpp"
+```
 
 
 ===! "Plot"
 
-    [![example_view_6](docs/examples/appearance/camera/view/view_6.png)](examples/appearance/camera/view/view_6.cpp)
+[![example_view_6](docs/examples/appearance/camera/view/view_6.png)](examples/appearance/camera/view/view_6.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/appearance/camera/view/view_6.cpp"
-    ```
+```cpp
+--8<-- "examples/appearance/camera/view/view_6.cpp"
+```
 
 
 
@@ -8614,72 +8613,72 @@ More examples:
 
 ===! "Plot"
 
-    [![example_lighting_1](docs/examples/appearance/camera/lighting/lighting_1.png)](examples/appearance/camera/lighting/lighting_1.cpp)
+[![example_lighting_1](docs/examples/appearance/camera/lighting/lighting_1.png)](examples/appearance/camera/lighting/lighting_1.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/appearance/camera/lighting/lighting_1.cpp"
-    ```
+```cpp
+--8<-- "examples/appearance/camera/lighting/lighting_1.cpp"
+```
 
 **More examples**
 
 ===! "Plot"
 
-    [![example_lighting_2](docs/examples/appearance/camera/lighting/lighting_2.png)](examples/appearance/camera/lighting/lighting_2.cpp)
+[![example_lighting_2](docs/examples/appearance/camera/lighting/lighting_2.png)](examples/appearance/camera/lighting/lighting_2.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/appearance/camera/lighting/lighting_2.cpp"
-    ```
+```cpp
+--8<-- "examples/appearance/camera/lighting/lighting_2.cpp"
+```
 
 
 
 ===! "Plot"
 
-    [![example_lighting_3](docs/examples/appearance/camera/lighting/lighting_3.png)](examples/appearance/camera/lighting/lighting_3.cpp)
+[![example_lighting_3](docs/examples/appearance/camera/lighting/lighting_3.png)](examples/appearance/camera/lighting/lighting_3.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/appearance/camera/lighting/lighting_3.cpp"
-    ```
+```cpp
+--8<-- "examples/appearance/camera/lighting/lighting_3.cpp"
+```
 
 
 ===! "Plot"
 
-    [![example_lighting_4](docs/examples/appearance/camera/lighting/lighting_4.png)](examples/appearance/camera/lighting/lighting_4.cpp)
+[![example_lighting_4](docs/examples/appearance/camera/lighting/lighting_4.png)](examples/appearance/camera/lighting/lighting_4.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/appearance/camera/lighting/lighting_4.cpp"
-    ```
-
-
-
-===! "Plot"
-
-    [![example_lighting_5](docs/examples/appearance/camera/lighting/lighting_5.png)](examples/appearance/camera/lighting/lighting_5.cpp)
-
-=== "C++"
-
-    ```cpp
-    --8<-- "examples/appearance/camera/lighting/lighting_5.cpp"
-    ```
+```cpp
+--8<-- "examples/appearance/camera/lighting/lighting_4.cpp"
+```
 
 
 
 ===! "Plot"
 
-    [![example_lighting_6](docs/examples/appearance/camera/lighting/lighting_6.png)](examples/appearance/camera/lighting/lighting_6.cpp)
+[![example_lighting_5](docs/examples/appearance/camera/lighting/lighting_5.png)](examples/appearance/camera/lighting/lighting_5.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/appearance/camera/lighting/lighting_6.cpp"
-    ```
+```cpp
+--8<-- "examples/appearance/camera/lighting/lighting_5.cpp"
+```
+
+
+
+===! "Plot"
+
+[![example_lighting_6](docs/examples/appearance/camera/lighting/lighting_6.png)](examples/appearance/camera/lighting/lighting_6.cpp)
+
+=== "C++"
+
+```cpp
+--8<-- "examples/appearance/camera/lighting/lighting_6.cpp"
+```
 
 
 
@@ -8704,37 +8703,37 @@ More examples:
 
 ===! "Plot"
 
-    [![example_figure_1](docs/examples/appearance/figure/figure_1.svg)](examples/appearance/figure/figure_1.cpp)
+[![example_figure_1](docs/examples/appearance/figure/figure_1.svg)](examples/appearance/figure/figure_1.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/appearance/figure/figure_1.cpp"
-    ```
+```cpp
+--8<-- "examples/appearance/figure/figure_1.cpp"
+```
 
 **More examples**
 
 ===! "Plot"
 
-    [![example_figure_2](docs/examples/appearance/figure/figure_2.svg)](examples/appearance/figure/figure_2.cpp)
+[![example_figure_2](docs/examples/appearance/figure/figure_2.svg)](examples/appearance/figure/figure_2.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/appearance/figure/figure_2.cpp"
-    ```
+```cpp
+--8<-- "examples/appearance/figure/figure_2.cpp"
+```
 
 
 
 ===! "Plot"
 
-    [![example_figure_3](docs/examples/appearance/figure/figure_3.svg)](examples/appearance/figure/figure_3.cpp)
+[![example_figure_3](docs/examples/appearance/figure/figure_3.svg)](examples/appearance/figure/figure_3.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/appearance/figure/figure_3.cpp"
-    ```
+```cpp
+--8<-- "examples/appearance/figure/figure_3.cpp"
+```
 
 
 
@@ -8755,13 +8754,13 @@ fplot(fn, spec_str);
 
 ===! "Plot"
 
-    [![example_line_spec_1](docs/examples/appearance/line_spec/line_spec_1.svg)](examples/appearance/line_spec/line_spec_1.cpp)
+[![example_line_spec_1](docs/examples/appearance/line_spec/line_spec_1.svg)](examples/appearance/line_spec/line_spec_1.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/appearance/line_spec/line_spec_1.cpp"
-    ```
+```cpp
+--8<-- "examples/appearance/line_spec/line_spec_1.cpp"
+```
 
 ### Axes Object
 
@@ -8783,37 +8782,37 @@ More examples:
 
 ===! "Plot"
 
-    [![example_axes_1](docs/examples/appearance/axes/axes_1.svg)](examples/appearance/axes/axes_1.cpp)
+[![example_axes_1](docs/examples/appearance/axes/axes_1.svg)](examples/appearance/axes/axes_1.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/appearance/axes/axes_1.cpp"
-    ```
+```cpp
+--8<-- "examples/appearance/axes/axes_1.cpp"
+```
 
 **More examples**
 
 ===! "Plot"
 
-    [![example_axes_2](docs/examples/appearance/axes/axes_2.png)](examples/appearance/axes/axes_2.cpp)
+[![example_axes_2](docs/examples/appearance/axes/axes_2.png)](examples/appearance/axes/axes_2.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/appearance/axes/axes_2.cpp"
-    ```
+```cpp
+--8<-- "examples/appearance/axes/axes_2.cpp"
+```
 
 
 
 ===! "Plot"
 
-    [![example_axes_3](docs/examples/appearance/axes/axes_3.svg)](examples/appearance/axes/axes_3.cpp)
+[![example_axes_3](docs/examples/appearance/axes/axes_3.svg)](examples/appearance/axes/axes_3.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/appearance/axes/axes_3.cpp"
-    ```
+```cpp
+--8<-- "examples/appearance/axes/axes_3.cpp"
+```
 
 
 
@@ -8838,37 +8837,37 @@ More examples:
 
 ===! "Plot"
 
-    [![example_cla_1](docs/examples/appearance/cla/cla_1.svg)](examples/appearance/cla/cla_1.cpp)
+[![example_cla_1](docs/examples/appearance/cla/cla_1.svg)](examples/appearance/cla/cla_1.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/appearance/cla/cla_1.cpp"
-    ```
+```cpp
+--8<-- "examples/appearance/cla/cla_1.cpp"
+```
 
 **More examples**
 
 ===! "Plot"
 
-    [![example_cla_2](docs/examples/appearance/cla/cla_2.svg)](examples/appearance/cla/cla_2.cpp)
+[![example_cla_2](docs/examples/appearance/cla/cla_2.svg)](examples/appearance/cla/cla_2.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/appearance/cla/cla_2.cpp"
-    ```
+```cpp
+--8<-- "examples/appearance/cla/cla_2.cpp"
+```
 
 
 
 ===! "Plot"
 
-    [![example_cla_3](docs/examples/appearance/cla/cla_3.svg)](examples/appearance/cla/cla_3.cpp)
+[![example_cla_3](docs/examples/appearance/cla/cla_3.svg)](examples/appearance/cla/cla_3.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/appearance/cla/cla_3.cpp"
-    ```
+```cpp
+--8<-- "examples/appearance/cla/cla_3.cpp"
+```
 
 
 
@@ -8913,95 +8912,95 @@ More examples:
 
 ===! "Plot"
 
-    [![example_save_1](docs/examples/exporting/save/save_1.png)](examples/exporting/save/save_1.cpp)
+[![example_save_1](docs/examples/exporting/save/save_1.png)](examples/exporting/save/save_1.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/exporting/save/save_1.cpp"
-    ```
+```cpp
+--8<-- "examples/exporting/save/save_1.cpp"
+```
 
 **More examples**
 
 ===! "Plot"
 
-    [![example_save_2](docs/examples/exporting/save/save_2.png)](examples/exporting/save/save_2.cpp)
+[![example_save_2](docs/examples/exporting/save/save_2.png)](examples/exporting/save/save_2.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/exporting/save/save_2.cpp"
-    ```
+```cpp
+--8<-- "examples/exporting/save/save_2.cpp"
+```
 
 
 
 ===! "Plot"
 
-    [![example_save_3](docs/examples/exporting/save/save_3.png)](examples/exporting/save/save_3.cpp)
+[![example_save_3](docs/examples/exporting/save/save_3.png)](examples/exporting/save/save_3.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/exporting/save/save_3.cpp"
-    ```
+```cpp
+--8<-- "examples/exporting/save/save_3.cpp"
+```
 
 
 ===! "Plot"
 
-    [![example_save_4](docs/examples/exporting/save/save_4.svg)](examples/exporting/save/save_4.cpp)
+[![example_save_4](docs/examples/exporting/save/save_4.svg)](examples/exporting/save/save_4.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/exporting/save/save_4.cpp"
-    ```
-
-
-
-===! "Plot"
-
-    [![example_save_5](docs/examples/exporting/save/save_5.svg)](examples/exporting/save/save_5.cpp)
-
-=== "C++"
-
-    ```cpp
-    --8<-- "examples/exporting/save/save_5.cpp"
-    ```
-
-
-===! "Plot"
-
-    [![example_save_6](docs/examples/exporting/save/save_6.svg)](examples/exporting/save/save_6.cpp)
-
-=== "C++"
-
-    ```cpp
-    --8<-- "examples/exporting/save/save_6.cpp"
-    ```
+```cpp
+--8<-- "examples/exporting/save/save_4.cpp"
+```
 
 
 
 ===! "Plot"
 
-    [![example_save_7](docs/examples/exporting/save/save_7.svg)](examples/exporting/save/save_7.cpp)
+[![example_save_5](docs/examples/exporting/save/save_5.svg)](examples/exporting/save/save_5.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/exporting/save/save_7.cpp"
-    ```
+```cpp
+--8<-- "examples/exporting/save/save_5.cpp"
+```
+
+
+===! "Plot"
+
+[![example_save_6](docs/examples/exporting/save/save_6.svg)](examples/exporting/save/save_6.cpp)
+
+=== "C++"
+
+```cpp
+--8<-- "examples/exporting/save/save_6.cpp"
+```
 
 
 
 ===! "Plot"
 
-    [![example_save_8](docs/examples/exporting/save/save_8.png)](examples/exporting/save/save_8.cpp)
+[![example_save_7](docs/examples/exporting/save/save_7.svg)](examples/exporting/save/save_7.cpp)
 
 === "C++"
 
-    ```cpp
-    --8<-- "examples/exporting/save/save_8.cpp"
-    ```
+```cpp
+--8<-- "examples/exporting/save/save_7.cpp"
+```
+
+
+
+===! "Plot"
+
+[![example_save_8](docs/examples/exporting/save/save_8.png)](examples/exporting/save/save_8.cpp)
+
+=== "C++"
+
+```cpp
+--8<-- "examples/exporting/save/save_8.cpp"
+```
 
 
 
@@ -9093,19 +9092,19 @@ These two examples would generate the same plot:
 
 === "Free-standing functions"
 
-    ```cpp
-    auto ax = gca();
-    plot(ax, x, y)->color("red").line_width(2);
-    my_function(ax);
-    ```
+```cpp
+auto ax = gca();
+plot(ax, x, y)->color("red").line_width(2);
+my_function(ax);
+```
 
 === "Object-oriented interface"
 
-    ```cpp
-    auto ax = gca();
-    ax->plot(x, y)->color("red").line_width(2);
-    my_function(ax);
-    ```
+```cpp
+auto ax = gca();
+ax->plot(x, y)->color("red").line_width(2);
+my_function(ax);
+```
 
  
 * Freestanding functions: 
@@ -9135,25 +9134,25 @@ There are also two modes for figures: reactive (or interactive) mode and quiet m
 
 === "Reactive mode"
 
-    ```cpp
-    // Reactive mode
-    auto f = figure(false);
-    auto ax = f->gca();
-    auto p = ax->plot(ax, x, y);   // draws once
-    p->color("red").line_width(2); // draws twice more
-    show();                        // pause console
-    ```
+```cpp
+// Reactive mode
+auto f = figure(false);
+auto ax = f->gca();
+auto p = ax->plot(ax, x, y);   // draws once
+p->color("red").line_width(2); // draws twice more
+show();                        // pause console
+```
 
 === "Quiet mode"
 
-    ```cpp
-    // Quiet mode
-    auto f = figure(true);
-    auto ax = f->gca();
-    auto p = ax->plot(x,y);        // does not draw
-    p->color("red").line_width(2); // does not draw
-    f->show();                     // draw only once and pause console
-    ```
+```cpp
+// Quiet mode
+auto f = figure(true);
+auto ax = f->gca();
+auto p = ax->plot(x,y);        // does not draw
+p->color("red").line_width(2); // does not draw
+f->show();                     // draw only once and pause console
+```
 
 Figures in reactive mode are updated whenever any of their child objects change. This happens through the `touch` function, that gets called on any child object when it changes its appearance. This creates an interactive mode in which figures are updated as soon as we adjust their properties. If we combine interactive figures with free-standing functions, we have a "Matlab-like style" for plots. This is a coding pattern where the figure registry works as a stream for plots. The problem with this coding style is that the user might unnecessarily create useless intermediary plots.
 
@@ -9175,25 +9174,25 @@ To support a more compact syntax, the library allows method chaining on plot obj
 
 === "Object Handle"
 
-    ```cpp
-    // Using the line handle
-    auto p = plot(x,y,"--gs");
-    p->line_width(2);
-    p->marker_size(10);
-    p->marker_color("b");
-    p->marker_face_color({.5,.5,.5});
-    ```
+```cpp
+// Using the line handle
+auto p = plot(x,y,"--gs");
+p->line_width(2);
+p->marker_size(10);
+p->marker_color("b");
+p->marker_face_color({.5,.5,.5});
+```
 
 === "Method Chaining"
 
-    ```cpp
-    // Method chaining
-    plot(x,y,"--gs")
-      ->line_width(2)
-      .marker_size(10)
-      .marker_color("b")
-      .marker_face_color({.5,.5,.5});
-    ```
+```cpp
+// Method chaining
+plot(x,y,"--gs")
+    ->line_width(2)
+    .marker_size(10)
+    .marker_color("b")
+    .marker_face_color({.5,.5,.5});
+```
 
 The first code snippet works because `plot` returns a `line_handle` to the object in the `axes`. We can use this line handle to modify the line plot. Whenever we modify a property, the setter function calls `touch`, which will `draw` the figure again if it is in reactive mode. The second option works because setters return a reference to `*this` rather than void. 
 


### PR DESCRIPTION
In the GitHub rendering of `README.md` the lines starting with four
spaces are converted to a verbatim block. Instead of showing the picture
we now see the markdown instead. The same happens to the indented cpp code
blocks.

To fix the GitHub rendering remove those blocks.