### PR TITLE
Correct cmake variables

### DIFF
--- a/cmake/functions/target_options.cmake
+++ b/cmake/functions/target_options.cmake
@@ -11,7 +11,7 @@ endfunction()
 
 # @brief Maybe enable pedantic warnings for a target
 function(maybe_target_pedantic_warnings TARGET_NAME)
-    if (BUILD_WITH_PEDANTIC_WARNINGS)
+    if (MATPLOTPP_BUILD_WITH_PEDANTIC_WARNINGS)
         target_pedantic_warnings(${TARGET_NAME})
     endif ()
 endfunction ()
@@ -30,7 +30,7 @@ endmacro()
 
 # @brief Maybe set pedantic compiler options for all targets
 macro(maybe_add_pedantic_warnings)
-    if (BUILD_WITH_PEDANTIC_WARNINGS)
+    if (MATPLOTPP_BUILD_WITH_PEDANTIC_WARNINGS)
         add_pedantic_warnings()
     endif ()
 endmacro()

--- a/index.md
+++ b/index.md
@@ -2215,7 +2215,7 @@ There are two dependencies in [`source/3rd_party`](source/3rd_party). These depe
 
 You can define `WITH_SYSTEM_NODESOUP=ON` or `WITH_SYSTEM_CIMG=ON` in the cmake command line to use a system-provided version of these dependencies.
 
-There's an extra target `matplot_opengl` with the experimental [OpenGL backend](#backends). You need to define `BUILD_EXPERIMENTAL_OPENGL_BACKEND=ON` in the CMake command line to build that target. In that case, the build script will also look for these extra dependencies:
+There's an extra target `matplot_opengl` with the experimental [OpenGL backend](#backends). You need to define `MATPLOTPP_BUILD_EXPERIMENTAL_OPENGL_BACKEND=ON` in the CMake command line to build that target. In that case, the build script will also look for these extra dependencies:
 
 * OpenGL
 * GLAD

--- a/source/matplot/CMakeLists.txt
+++ b/source/matplot/CMakeLists.txt
@@ -144,13 +144,13 @@ if (HAVE_FBUFSIZE)
 endif()
 
 # Build for documentation
-if (BUILD_FOR_DOCUMENTATION_IMAGES)
+if (MATPLOTPP_BUILD_FOR_DOCUMENTATION_IMAGES)
     message("Building matplot for documentation images. wait() commands will be ignored. ~figure will save the files.")
     target_compile_definitions(matplot PUBLIC MATPLOT_BUILD_FOR_DOCUMENTATION_IMAGES)
 endif ()
 
 # Include high-resolution world map in the binary
-if (BUILD_HIGH_RESOLUTION_WORLD_MAP)
+if (MATPLOTPP_BUILD_HIGH_RESOLUTION_WORLD_MAP)
     target_compile_definitions(matplot PUBLIC MATPLOT_BUILD_HIGH_RESOLUTION_WORLD_MAP)
 else ()
     message("Not including the high resolution maps for geoplots")
@@ -163,7 +163,7 @@ endif ()
 # Maybe add pedantic warning
 
 
-#if (BUILD_WITH_PEDANTIC_WARNINGS)
+#if (MATPLOTPP_BUILD_WITH_PEDANTIC_WARNINGS)
 #    if (MSVC)
 #        target_compile_options(matplot PRIVATE /W4 /WX)
 #    else ()
@@ -182,7 +182,7 @@ endif ()
 #######################################################
 ### Experimental OpenGL backend                     ###
 #######################################################
-if (BUILD_EXPERIMENTAL_OPENGL_BACKEND)
+if (MATPLOTPP_BUILD_EXPERIMENTAL_OPENGL_BACKEND)
     # Library for the OpenGL example
     # This is an example of what an OpenGL backend *could* look like.
     #     The opengl backend is currently incomplete.

--- a/source/matplot/CMakeLists.txt
+++ b/source/matplot/CMakeLists.txt
@@ -252,7 +252,7 @@ endif()
 #######################################################
 ### Installer                                       ###
 #######################################################
-if (BUILD_INSTALLER)
+if (MATPLOTPP_BUILD_INSTALLER)
     # Install targets
     install(TARGETS matplot
             EXPORT Matplot++Targets

--- a/test/backends/CMakeLists.txt
+++ b/test/backends/CMakeLists.txt
@@ -1,4 +1,4 @@
-if (BUILD_EXPERIMENTAL_OPENGL_BACKEND)
+if (MATPLOTPP_BUILD_EXPERIMENTAL_OPENGL_BACKEND)
     # Use this to create an OpenGL window as backend
     add_executable(matplot_opengl_test ogl_main.cpp)
     target_link_libraries(matplot_opengl_test PUBLIC matplot_opengl)

--- a/test/generate_examples/README.md
+++ b/test/generate_examples/README.md
@@ -4,4 +4,4 @@ This is a visual unit test where the `generate_examples` target will run all oth
 
 Everytime we update the library, we regenerate the examples to make sure everything is not only working ok but also *looking* good.
 
-The library needs to be compiled with the CMake option `BUILD_FOR_DOCUMENTATION_IMAGES` for this test to work. Also, you need to run this target from the project root directory so that the filesystem can find the build and documentation directories.
+The library needs to be compiled with the CMake option `MATPLOTPP_BUILD_FOR_DOCUMENTATION_IMAGES` for this test to work. Also, you need to run this target from the project root directory so that the filesystem can find the build and documentation directories.

--- a/test/generate_examples/main.cpp
+++ b/test/generate_examples/main.cpp
@@ -5,7 +5,7 @@
 #include <regex>
 
 int main() {
-    // Set CMake option BUILD_FOR_DOCUMENTATION_IMAGES to ON and
+    // Set CMake option MATPLOTPP_BUILD_FOR_DOCUMENTATION_IMAGES to ON and
     //       run this executable from the root directory as working
     //       directory to run all examples.
     // If will set 1) the figure object to save the figure when being destroyed


### PR DESCRIPTION
I noticed that cmake `install` target was not working correctly.
So I investigated and found that `BUILD_INSTALLER` variable was recently renamed but not updated.

After more investigation, I found other variables that also were not renamed completely.

This pull request will correct cmake variables by completing the rename for:
 - `BUILD_INSTALLER`
 - `BUILD_FOR_DOCUMENTATION_IMAGES`
 - `BUILD_HIGH_RESOLUTION_WORLD_MAP`
 - `BUILD_WITH_PEDANTIC_WARNINGS`
 - `BUILD_EXPERIMENTAL_OPENGL_BACKEND`