### PR TITLE
Prevent compilation errors because of dangling references with std::minmax

### DIFF
--- a/source/matplot/util/contourc.cpp
+++ b/source/matplot/util/contourc.cpp
@@ -1982,7 +1982,8 @@ namespace matplot {
         double zmin = z[0][0];
         double zmax = z[0][0];
         for (const auto &z_row : z) {
-            auto [minit, maxit] = std::minmax(z_row.begin(), z_row.end());
+            auto [minit, maxit] =
+                std::minmax_element(z_row.begin(), z_row.end());
             if (*minit < zmin) {
                 zmin = *minit;
             }


### PR DESCRIPTION
Hi,

I have followed the [guide section ](https://alandefreitas.github.io/matplotplusplus/integration/cmake/embed-as-subdirectory/)to integrate matplotlib++ as a subdirectory
I tried to build with gcc 13 using the following flags:

[...] -Og -g -std=gnu++17 -Wall -Wextra -pedantic -Werror -MD
and get a compilation errors.

```
matplot/util/contourc.cpp:1985:18: error: possibly dangling reference to a temporary [-Werror=dangling-reference]
 1985 |             auto [minit, maxit] = std::minmax(z_row.begin(), z_row.end());
      |                  ^~~~~~~~~~~~~~
matplot/util/contourc.cpp:1985:46: note: the temporary was destroyed at the end of the full expression 'std::minmax<__gnu_cxx::__normal_iterator<const double*, vector<double> > >((& z_row)->std::vector<double>::begin(), (& z_row)->std::vector<double>::end())'
 1985 |             auto [minit, maxit] = std::minmax(z_row.begin(), z_row.end());
      |                                   ~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~
cc1plus: all warnings being treated as errors
```

As mentionned in the [documentation of std::minmax ](https://en.cppreference.com/w/cpp/algorithm/minmax) some undefined behavior may occurs in this scenario even though in this case, you store the value right after you get them.
It might be safer to replace this function by your own minmax implementation or as I suggest here by 'std::minmax_element' 

