### PR TITLE
Data was not rendering correctly due to low precision rounding in dat…

### DIFF
--- a/source/matplot/axes_objects/bars.cpp
+++ b/source/matplot/axes_objects/bars.cpp
@@ -143,7 +143,7 @@ namespace matplot {
 
     std::string bars::data_string() {
         std::stringstream ss;
-        ss.precision(5);
+        ss.precision(10);
         ss << std::fixed;
         double m = x_minimum_difference();
         double cw = cluster_width();

--- a/source/matplot/axes_objects/box_chart.cpp
+++ b/source/matplot/axes_objects/box_chart.cpp
@@ -127,7 +127,7 @@ namespace matplot {
         }
         std::vector<double> unique_groups = unique(x_data_);
         std::stringstream ss;
-        ss.precision(5);
+        ss.precision(10);
         ss << std::fixed;
         // for each group
         for (size_t i = 0; i < unique_groups.size(); ++i) {

--- a/source/matplot/axes_objects/circles.cpp
+++ b/source/matplot/axes_objects/circles.cpp
@@ -45,7 +45,7 @@ namespace matplot {
 
     std::string circles::data_string() {
         std::stringstream ss;
-        ss.precision(5);
+        ss.precision(10);
         ss << std::fixed;
         for (size_t i = 0; i < x_.size(); ++i) {
             auto value_or_default = [](const std::vector<double> &v,

--- a/source/matplot/axes_objects/contours.cpp
+++ b/source/matplot/axes_objects/contours.cpp
@@ -50,7 +50,7 @@ namespace matplot {
         double contour_max_level = *max_it;
 
         std::stringstream ss;
-        ss.precision(5);
+        ss.precision(10);
         ss << std::fixed;
         if (filled_) {
             auto [lower_levels, upper_levels] = get_lowers_and_uppers();
@@ -478,7 +478,7 @@ namespace matplot {
         double zmin = *min_level_it;
 
         std::stringstream ss;
-        ss.precision(5);
+        ss.precision(10);
         ss << std::fixed;
         for (size_t i = 0; i < lines_.size(); ++i) {
             if (i != 0) {
@@ -771,7 +771,7 @@ namespace matplot {
         auto [lower_levels, upper_levels] = get_lowers_and_uppers();
 
         std::stringstream ss;
-        ss.precision(5);
+        ss.precision(10);
         ss << std::fixed;
         if (filled_) {
             // Plot the line segments

--- a/source/matplot/axes_objects/error_bar.cpp
+++ b/source/matplot/axes_objects/error_bar.cpp
@@ -79,7 +79,7 @@ namespace matplot {
         const bool has_x_bar = !x_negative_delta_.empty();
         const bool has_xy_bar = has_y_bar && has_x_bar;
         std::stringstream ss;
-        ss.precision(5);
+        ss.precision(10);
         ss << std::fixed;
         if (has_xy_bar) {
             for (size_t i = 0; i < y_data_.size(); ++i) {

--- a/source/matplot/axes_objects/filled_area.cpp
+++ b/source/matplot/axes_objects/filled_area.cpp
@@ -58,7 +58,7 @@ namespace matplot {
 
     std::string filled_area::data_string() {
         std::stringstream ss;
-        ss.precision(5);
+        ss.precision(10);
         ss << std::fixed;
 
         std::vector<double> stacked_data;

--- a/source/matplot/axes_objects/histogram.cpp
+++ b/source/matplot/axes_objects/histogram.cpp
@@ -55,7 +55,7 @@ namespace matplot {
     std::string histogram::plot_string() {
         maybe_update_face_color();
         std::stringstream ss;
-        ss.precision(5);
+        ss.precision(10);
         ss << std::fixed;
         if (!is_polar()) {
             if (!stairs_only_) {
@@ -89,7 +89,7 @@ namespace matplot {
     std::string histogram::data_string() {
         make_sure_data_is_preprocessed();
         std::stringstream ss;
-        ss.precision(5);
+        ss.precision(10);
         ss << std::fixed;
         if (!is_polar()) {
             for (size_t i = 0; i < values_.size(); ++i) {

--- a/source/matplot/axes_objects/labels.cpp
+++ b/source/matplot/axes_objects/labels.cpp
@@ -98,7 +98,7 @@ namespace matplot {
             font_size_factor = (xrange_increase + yrange_increase) / 2.;
         }
         std::stringstream ss;
-        ss.precision(5);
+        ss.precision(10);
         ss << std::fixed;
         const bool custom_sizes = !sizes_.empty();
         const bool custom_colors = !colors_.empty();

--- a/source/matplot/axes_objects/line.cpp
+++ b/source/matplot/axes_objects/line.cpp
@@ -163,7 +163,7 @@ namespace matplot {
         const bool x_is_manual = !x_data_.empty();
 
         std::stringstream ss;
-        ss.precision(5);
+        ss.precision(10);
         ss << std::fixed;
         for (const auto &style : styles_to_plot()) {
             if (visible_) {

--- a/source/matplot/axes_objects/matrix.cpp
+++ b/source/matplot/axes_objects/matrix.cpp
@@ -167,7 +167,7 @@ namespace matplot {
 
         // stream matrix
         std::stringstream ss;
-        ss.precision(5);
+        ss.precision(10);
         ss << std::fixed;
         double x_width_ = x_width();
         double y_width_ = y_width();
@@ -275,7 +275,7 @@ namespace matplot {
 
     std::string matrix::image_data_string() {
         std::stringstream ss;
-        ss.precision(5);
+        ss.precision(10);
         ss << std::fixed;
         auto [h, w] = size(matrices_[0]);
         double x_width_ = x_width();

--- a/source/matplot/axes_objects/network.cpp
+++ b/source/matplot/axes_objects/network.cpp
@@ -106,7 +106,7 @@ namespace matplot {
 
     std::string network::data_string() {
         std::stringstream ss;
-        ss.precision(5);
+        ss.precision(10);
         ss << std::fixed;
         bool plot_z_data = z_data_.size() == x_data_.size();
         bool line_width_is_variable = !line_widths_.empty() && z_data_.empty();

--- a/source/matplot/axes_objects/network.h
+++ b/source/matplot/axes_objects/network.h
@@ -83,7 +83,7 @@ namespace matplot {
         network &edge_labels(const IterableValues<C> &e_labels) {
             std::vector<std::string> str_labels;
             std::stringstream ss;
-            ss.precision(5);
+            ss.precision(10);
             ss << std::fixed;
             for (const auto &edge_label : e_labels) {
                 ss << "{/:Italic " << edge_label << " }";
@@ -101,7 +101,7 @@ namespace matplot {
         network &node_labels(const IterableValues<C> &e_labels) {
             std::vector<std::string> str_labels;
             std::stringstream ss;
-            ss.precision(5);
+            ss.precision(10);
             ss << std::fixed;
             for (const auto &edge_label : e_labels) {
                 ss << edge_label;

--- a/source/matplot/axes_objects/parallel_lines.cpp
+++ b/source/matplot/axes_objects/parallel_lines.cpp
@@ -170,7 +170,7 @@ namespace matplot {
 
         const bool color_is_variable = !line_colors_.empty();
         std::stringstream ss;
-        ss.precision(5);
+        ss.precision(10);
         ss << std::fixed;
         // for each point
         for (size_t i = 0; i < data_[0].size(); ++i) {

--- a/source/matplot/axes_objects/surface.cpp
+++ b/source/matplot/axes_objects/surface.cpp
@@ -58,7 +58,7 @@ namespace matplot {
     std::string surface::set_variables_string() {
         maybe_update_line_spec();
         std::stringstream ss;
-        ss.precision(5);
+        ss.precision(10);
         ss << std::fixed;
 
         if (surface_in_2d_) {
@@ -249,7 +249,7 @@ namespace matplot {
 
     std::string surface::plot_string() {
         std::stringstream ss;
-        ss.precision(5);
+        ss.precision(10);
         ss << std::fixed;
         // plot surface
         bool is_solid_surface = palette_map_at_bottom_ ||
@@ -350,7 +350,7 @@ namespace matplot {
 
     std::string surface::grid_data_string() {
         std::stringstream ss;
-        ss.precision(5);
+        ss.precision(10);
         ss << std::fixed;
         const bool contour = (contour_base_ || contour_surface_);
         const bool palette_map_3d = palette_map_at_bottom_ ||
@@ -475,7 +475,7 @@ namespace matplot {
 
     std::string surface::ribbon_data_string() {
         std::stringstream ss;
-        ss.precision(5);
+        ss.precision(10);
         ss << std::fixed;
         auto send_point = [](std::stringstream &ss, double x, double y,
                              double z, double c) {

--- a/source/matplot/axes_objects/vectors.cpp
+++ b/source/matplot/axes_objects/vectors.cpp
@@ -72,7 +72,7 @@ namespace matplot {
     std::string vectors::plot_string() {
         maybe_update_line_spec();
         std::stringstream ss;
-        ss.precision(5);
+        ss.precision(10);
         ss << std::fixed;
         ss << " '-' with vectors";
         if (!c_data_.empty()) {
@@ -115,7 +115,7 @@ namespace matplot {
 
     std::string vectors::data_string() {
         std::stringstream ss;
-        ss.precision(5);
+        ss.precision(10);
         ss << std::fixed;
         if (visible_) {
             for (size_t i = 0; i < v_data_.size(); ++i) {

--- a/source/matplot/core/axes_type.cpp
+++ b/source/matplot/core/axes_type.cpp
@@ -100,7 +100,7 @@ namespace matplot {
         if (any_obj_needs_colormap && !colormap_.empty() &&
             !children_.empty()) {
             std::stringstream ss;
-            ss.precision(5);
+            ss.precision(10);
             ss << std::fixed;
             // limit the number of colors in the palette
             // this is useful for contour plots
@@ -527,7 +527,7 @@ namespace matplot {
 
             if (cb_axis_.visible()) {
                 std::stringstream ss;
-                ss.precision(5);
+                ss.precision(10);
                 ss << std::fixed;
                 ss << "set colorbox";
                 if (!cb_axis_.reverse()) {

--- a/source/matplot/util/common.h
+++ b/source/matplot/util/common.h
@@ -46,7 +46,7 @@ namespace matplot {
 
     template <class T> std::string num2str(Arithmetic<T> num) {
         std::ostringstream ss;
-        ss.precision(5);
+        ss.precision(10);
         ss << std::fixed;
         ss << num;
         return ss.str();


### PR DESCRIPTION
I've been using your library and have been happy with it for the exception of this case. For example with an X vector: [0 , 1e-9... ... 1e-6 - 1e-9, 1e-6] with 1ns steps, all of these coordinates will round to zero instead of keeping their true precise value, due to a hidden rounding feature in the library. This causes my plots to look something like this:

![image](https://github.com/alandefreitas/matplotplusplus/assets/11672668/8e087d08-7d06-43bd-853d-0bd486116ef1)

To fix, I increased precision of all data strings to 10 digits. Was using data sampled at about 0.8ns and it was putting the first 10000+ points at the zero X value instead of where they should have been placed. This commit fixes the issue (at probably a small performance impact). I imagine a better fix for this would to be making the `setprecision` usertunable. Is this hard to do with the current implementation?

This is what it looks like with the correct implementation.

![image](https://github.com/alandefreitas/matplotplusplus/assets/11672668/6bd02043-d811-491e-aab7-9e88a58ec21f)

I am using sampled data at over 1 billion samples per second (requires > 1ns x-axis accuracy), so this precision is potentially needed unless I convert the units, but it broke due to a feature I didn't even know was in the library!

Thanks,

Tim

