### PR TITLE
Add C++20 compatibility

### DIFF
--- a/source/matplot/core/line_spec.cpp
+++ b/source/matplot/core/line_spec.cpp
@@ -73,11 +73,11 @@ namespace matplot {
                 break;
             case '>':
                 marker_style_ = marker_style::custom;
-                custom_marker_ = u8"▶";
+                custom_marker_ = "▶";
                 break;
             case '<':
                 marker_style_ = marker_style::custom;
-                custom_marker_ = u8"◀";
+                custom_marker_ = "◀";
                 break;
             case 'p':
                 marker_style_ = marker_style::pentagram;
@@ -389,11 +389,11 @@ namespace matplot {
             break;
         case '>':
             marker_style_ = marker_style::custom;
-            custom_marker_ = u8"▶";
+            custom_marker_ = "▶";
             break;
         case '<':
             marker_style_ = marker_style::custom;
-            custom_marker_ = u8"◀";
+            custom_marker_ = "◀";
             break;
         case 'P':
         case 'p':


### PR DESCRIPTION
Beginning with C++20 u8"" literals use char8_t as underlying types making them incompatible with char based std::string. Adding reinterpret_casts to char is among the remediation approaches suggested by [1]. There are only 4 uses of u8 literals in the codebase, also this is the simplest backwards compatible solution to this issue (the alternative would be to use ASCII escape codes in regular string literals). Long term it could make sense to replace uses of std::string with std::u8string.

[1]: https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2019/p1423r2.html

This fixes #287.