### PR TITLE
Make r_minor_grid() behavior consistent with {xyz}_minor_grid

### DIFF
--- a/source/matplot/core/axes_type.cpp
+++ b/source/matplot/core/axes_type.cpp
@@ -1973,8 +1973,6 @@ namespace matplot {
 
     void axes_type::r_minor_grid(bool r_minor_grid) {
         r_minor_grid_ = r_minor_grid;
-        r_user_grid_ = true;
-        touch();
     }
 
     const class axis_type &axes_type::t_axis() const { return t_axis_; }


### PR DESCRIPTION
Without this adjustment setting r_minor_grid(true) (or r_minor_grid(false)) would non-intuitively disable the grid entirely on polar plots since the major grid would no longer be enabled by default. An alternative, potentially better solution would be to make {xyzr}_minor_grid(true) to implicitly also set {xyzr}_grid(true).

Note also that at least using gnuplot 5.4 minor grid lines will not show up on polar and non-polar plots unless
'ax->r_axis().tick_length(1.f)' (or some other non-zero tics scale value) is set (non-polar plots default to a non-zero value). This is most likely a gnuplot bug, since setting tics scale 0 is described by the "Internet(tm)" as the correct way to obtain grid lines without tics, apparently this only works for major grid lines.