### PR TITLE
Fix polarhistograms with many bins

### DIFF
--- a/source/matplot/axes_objects/histogram.cpp
+++ b/source/matplot/axes_objects/histogram.cpp
@@ -102,9 +102,10 @@ namespace matplot {
 
         } else {
             // resolutions of the petals
-            constexpr double points_per_circle = 90;
+            constexpr double points_per_circle = 360;
             const double n_histogram_bins = bin_edges_.size() - 1.;
-            const double points_per_bin = points_per_circle / n_histogram_bins;
+            // ensure at least one line segment (2 points) per petal.
+            const size_t points_per_bin = static_cast<size_t>(max(2.0, points_per_circle / n_histogram_bins));
             if (!stairs_only_) {
                 for (size_t i = 0; i < values_.size(); ++i) {
                     // make a petal for each value
@@ -114,8 +115,7 @@ namespace matplot {
                     // theta = edge_end             rho = 0
                     ss << "    " << bin_edges_[i] << "  " << 0 << "\n";
                     auto arc_between_edges =
-                        linspace(bin_edges_[i], bin_edges_[i + 1],
-                                 static_cast<size_t>(ceil(points_per_bin)));
+                        linspace(bin_edges_[i], bin_edges_[i + 1], points_per_bin);
                     for (size_t j = 0; j < arc_between_edges.size(); ++j) {
                         ss << "    " << arc_between_edges[j] << "  "
                            << values_[i] << "\n";
@@ -129,8 +129,7 @@ namespace matplot {
                     // theta = edge_end             rho = bin_value
                     // theta = edge_end             rho = next bin value
                     auto arc_between_edges =
-                        linspace(bin_edges_[i], bin_edges_[i + 1],
-                                 static_cast<size_t>(ceil(points_per_bin)));
+                        linspace(bin_edges_[i], bin_edges_[i + 1], points_per_bin);
                     for (size_t j = 0; j < arc_between_edges.size(); ++j) {
                         ss << "    " << arc_between_edges[j] << "  "
                            << values_[i] << "\n";

--- a/source/matplot/util/common.cpp
+++ b/source/matplot/util/common.cpp
@@ -86,9 +86,10 @@ namespace matplot {
 
     std::vector<double> linspace(double d1, double d2, size_t n) {
         std::vector<double> x(n);
+        // avoid division by zero
+        double step = n > 1? (d2 - d1) / static_cast<double>(n - 1) : 0.;
         for (size_t i = 0; i < x.size(); ++i) {
-            x[i] = d1 + static_cast<double>(i) * (d2 - d1) /
-                            static_cast<double>(n - 1);
+            x[i] = d1 + static_cast<double>(i) * step;
         }
         return x;
     }


### PR DESCRIPTION
This PR consists of two fixes which both affected the correct display of polarhistograms with more than 89 bins.
Note: The second commit also increases the minimum polarhistogram resolution from 89 to 359 line segments.

#### Fix 1: Fix `linspace(a,b,1)` resulting in `NaN` element

This underlying issue caused polarhistograms with more than `89` bins to
not be displayed at all.

Previously passing `n=1` to `linspace` resulted in a one element vector
containing `NaN`. With this change it will result in a one element
vector containing the first ("lower") bound.  This is the natural
solution given the current implementation and matches the behavior of
`numpy.linspace`, unfortunately however it does not match the behavior
of MATLAB `linspace` which returns the "upper" bound instead.


#### Fix 2: Ensure at least two points (one circle segment) is used per polarhistogram petal

Change petal resolution to the larger one of (a) `360` points (`359`
segments) per circle or (b) `n_histogram_bins+1`
points (`n_histogram_bins` segments). Ensuring at least one segment per
bin petal.

Previously polarhistograms had a fixed resolution of `90` points (`89`
segments) per circle. Specifying more than `89` bins would result in
either an empty plot (due to a bug in `linspace`, see Fix 1) or too narrow
petals (with the `linspace` bug fixed).