### PR TITLE
Prevent console window to open in GUI applications on Windows

### DIFF
--- a/source/matplot/CMakeLists.txt
+++ b/source/matplot/CMakeLists.txt
@@ -37,6 +37,7 @@ add_library(matplot
         util/handle_types.h
         util/keywords.h
         util/popen.h
+        util/popen.cpp
         util/type_traits.h
         util/world_cities.cpp
         util/world_map_10m.cpp

--- a/source/matplot/util/common.cpp
+++ b/source/matplot/util/common.cpp
@@ -8,6 +8,7 @@
 #include <iostream>
 #include <matplot/util/colors.h>
 #include <matplot/util/common.h>
+#include <matplot/util/popen.h>
 #include <random>
 #include <regex>
 #include <set>
@@ -23,17 +24,6 @@
 #include <CImg.h>
 #ifdef _MSC_VER
 #pragma warning(pop)
-#endif
-
-#ifdef _WIN32
-#include <windows.h>
-#define PCLOSE _pclose
-#define POPEN _popen
-#define FILENO _fileno
-#else
-#define PCLOSE pclose
-#define POPEN popen
-#define FILENO fileno
 #endif
 
 namespace matplot {

--- a/source/matplot/util/popen.cpp
+++ b/source/matplot/util/popen.cpp
@@ -1,0 +1,97 @@
+#include <matplot/util/popen.h>
+
+#ifdef _WIN32
+
+// Function to create a new process and return a FILE pointer for input/output.
+// Mimics _popen behaviour, but does not open console windows in GUI apps
+FILE *hiddenPopen(const char *command, const char *mode) {
+    SECURITY_ATTRIBUTES saAttr;
+    HANDLE hChildStdinRd, hChildStdinWr, hStdin, hStdout;
+    STARTUPINFO si;
+    PROCESS_INFORMATION pi;
+
+    // Set up security attributes for inheritable handles
+    saAttr.nLength = sizeof(SECURITY_ATTRIBUTES);
+    saAttr.bInheritHandle = TRUE;
+    saAttr.lpSecurityDescriptor = NULL;
+
+    // Create a pipe for the child process's input
+    if (!CreatePipe(&hChildStdinRd, &hChildStdinWr, &saAttr, 0)) {
+        return nullptr;
+    }
+
+    // Ensure the write handle to the pipe is not inherited by child processes
+    if (!SetHandleInformation(hChildStdinWr, HANDLE_FLAG_INHERIT, 0)) {
+        CloseHandle(hChildStdinRd);
+        return nullptr;
+    }
+
+    // Create a pipe for the child process's output
+    if (!CreatePipe(&hStdin, &hStdout, &saAttr, 0)) {
+        CloseHandle(hChildStdinRd);
+        CloseHandle(hChildStdinWr);
+        return nullptr;
+    }
+
+    // Ensure the read handle to the output pipe is not inherited by child
+    // processes
+    if (!SetHandleInformation(hStdout, HANDLE_FLAG_INHERIT, 0)) {
+        CloseHandle(hChildStdinRd);
+        CloseHandle(hChildStdinWr);
+        CloseHandle(hStdin);
+        return nullptr;
+    }
+
+    // Configure STARTUPINFO structure for the new process
+    ZeroMemory(&si, sizeof(STARTUPINFO));
+    si.cb = sizeof(STARTUPINFO);
+    si.hStdError = hStdout;
+    si.hStdOutput = hStdout;
+    si.hStdInput = hChildStdinRd;
+    si.dwFlags |= STARTF_USESTDHANDLES;
+
+    // Create the child process, while hiding the window
+    if (!CreateProcess(NULL, const_cast<char *>(command), NULL, NULL, TRUE,
+                       CREATE_NO_WINDOW, NULL, NULL, &si, &pi)) {
+        CloseHandle(hChildStdinRd);
+        CloseHandle(hChildStdinWr);
+        CloseHandle(hStdin);
+        CloseHandle(hStdout);
+        return nullptr;
+    }
+
+    // Close unnecessary handles
+    CloseHandle(hChildStdinRd);
+    CloseHandle(hStdout);
+
+    // Create a FILE pointer from the write handle to the child process's input
+    FILE *file = _fdopen(_open_osfhandle((intptr_t)hChildStdinWr, 0), mode);
+
+    if (file == nullptr) {
+        CloseHandle(hChildStdinWr);
+        CloseHandle(hStdin);
+        CloseHandle(pi.hProcess);
+        CloseHandle(pi.hThread);
+        return nullptr;
+    }
+
+    return file;
+}
+
+// Function to close the process and retrieve its exit code
+int hiddenPclose(FILE *file) {
+    HANDLE hFile = (HANDLE)_get_osfhandle(_fileno(file));
+    fclose(file);
+    DWORD exitCode;
+
+    // Wait for the process to finish and get its exit code
+    if (WaitForSingleObject(hFile, INFINITE) == WAIT_OBJECT_0 &&
+        GetExitCodeProcess(hFile, &exitCode)) {
+        CloseHandle(hFile);
+        return exitCode;
+    } else {
+        return -1; // Failed to get the exit code
+    }
+}
+
+#endif // _WIN32

--- a/source/matplot/util/popen.cpp
+++ b/source/matplot/util/popen.cpp
@@ -1,97 +1,102 @@
 #include <matplot/util/popen.h>
 
 #ifdef _WIN32
+#include <io.h>
 
-// Function to create a new process and return a FILE pointer for input/output.
-// Mimics _popen behaviour, but does not open console windows in GUI apps
-FILE *hiddenPopen(const char *command, const char *mode) {
-    SECURITY_ATTRIBUTES saAttr;
-    HANDLE hChildStdinRd, hChildStdinWr, hStdin, hStdout;
-    STARTUPINFO si;
-    PROCESS_INFORMATION pi;
+namespace matplot::detail {
+    // Function to create a new process and return a FILE pointer for
+    // input/output. Mimics _popen behaviour, but does not open console windows
+    // in GUI apps
+    FILE *hiddenPopen(const char *command, const char *mode) {
+        SECURITY_ATTRIBUTES saAttr;
+        HANDLE hChildStdinRd, hChildStdinWr, hStdin, hStdout;
+        STARTUPINFO si;
+        PROCESS_INFORMATION pi;
 
-    // Set up security attributes for inheritable handles
-    saAttr.nLength = sizeof(SECURITY_ATTRIBUTES);
-    saAttr.bInheritHandle = TRUE;
-    saAttr.lpSecurityDescriptor = NULL;
+        // Set up security attributes for inheritable handles
+        saAttr.nLength = sizeof(SECURITY_ATTRIBUTES);
+        saAttr.bInheritHandle = TRUE;
+        saAttr.lpSecurityDescriptor = NULL;
 
-    // Create a pipe for the child process's input
-    if (!CreatePipe(&hChildStdinRd, &hChildStdinWr, &saAttr, 0)) {
-        return nullptr;
-    }
+        // Create a pipe for the child process's input
+        if (!CreatePipe(&hChildStdinRd, &hChildStdinWr, &saAttr, 0)) {
+            return nullptr;
+        }
 
-    // Ensure the write handle to the pipe is not inherited by child processes
-    if (!SetHandleInformation(hChildStdinWr, HANDLE_FLAG_INHERIT, 0)) {
+        // Ensure the write handle to the pipe is not inherited by child
+        // processes
+        if (!SetHandleInformation(hChildStdinWr, HANDLE_FLAG_INHERIT, 0)) {
+            CloseHandle(hChildStdinRd);
+            return nullptr;
+        }
+
+        // Create a pipe for the child process's output
+        if (!CreatePipe(&hStdin, &hStdout, &saAttr, 0)) {
+            CloseHandle(hChildStdinRd);
+            CloseHandle(hChildStdinWr);
+            return nullptr;
+        }
+
+        // Ensure the read handle to the output pipe is not inherited by child
+        // processes
+        if (!SetHandleInformation(hStdout, HANDLE_FLAG_INHERIT, 0)) {
+            CloseHandle(hChildStdinRd);
+            CloseHandle(hChildStdinWr);
+            CloseHandle(hStdin);
+            return nullptr;
+        }
+
+        // Configure STARTUPINFO structure for the new process
+        ZeroMemory(&si, sizeof(STARTUPINFO));
+        si.cb = sizeof(STARTUPINFO);
+        si.hStdError = hStdout;
+        si.hStdOutput = hStdout;
+        si.hStdInput = hChildStdinRd;
+        si.dwFlags |= STARTF_USESTDHANDLES;
+
+        // Create the child process, while hiding the window
+        if (!CreateProcess(NULL, const_cast<char *>(command), NULL, NULL, TRUE,
+                           CREATE_NO_WINDOW, NULL, NULL, &si, &pi)) {
+            CloseHandle(hChildStdinRd);
+            CloseHandle(hChildStdinWr);
+            CloseHandle(hStdin);
+            CloseHandle(hStdout);
+            return nullptr;
+        }
+
+        // Close unnecessary handles
         CloseHandle(hChildStdinRd);
-        return nullptr;
-    }
-
-    // Create a pipe for the child process's output
-    if (!CreatePipe(&hStdin, &hStdout, &saAttr, 0)) {
-        CloseHandle(hChildStdinRd);
-        CloseHandle(hChildStdinWr);
-        return nullptr;
-    }
-
-    // Ensure the read handle to the output pipe is not inherited by child
-    // processes
-    if (!SetHandleInformation(hStdout, HANDLE_FLAG_INHERIT, 0)) {
-        CloseHandle(hChildStdinRd);
-        CloseHandle(hChildStdinWr);
-        CloseHandle(hStdin);
-        return nullptr;
-    }
-
-    // Configure STARTUPINFO structure for the new process
-    ZeroMemory(&si, sizeof(STARTUPINFO));
-    si.cb = sizeof(STARTUPINFO);
-    si.hStdError = hStdout;
-    si.hStdOutput = hStdout;
-    si.hStdInput = hChildStdinRd;
-    si.dwFlags |= STARTF_USESTDHANDLES;
-
-    // Create the child process, while hiding the window
-    if (!CreateProcess(NULL, const_cast<char *>(command), NULL, NULL, TRUE,
-                       CREATE_NO_WINDOW, NULL, NULL, &si, &pi)) {
-        CloseHandle(hChildStdinRd);
-        CloseHandle(hChildStdinWr);
-        CloseHandle(hStdin);
         CloseHandle(hStdout);
-        return nullptr;
+
+        // Create a FILE pointer from the write handle to the child process's
+        // input
+        FILE *file = _fdopen(_open_osfhandle((intptr_t)hChildStdinWr, 0), mode);
+
+        if (file == nullptr) {
+            CloseHandle(hChildStdinWr);
+            CloseHandle(hStdin);
+            CloseHandle(pi.hProcess);
+            CloseHandle(pi.hThread);
+            return nullptr;
+        }
+
+        return file;
     }
 
-    // Close unnecessary handles
-    CloseHandle(hChildStdinRd);
-    CloseHandle(hStdout);
+    // Function to close the process and retrieve its exit code
+    int hiddenPclose(FILE *file) {
+        HANDLE hFile = (HANDLE)_get_osfhandle(_fileno(file));
+        fclose(file);
+        DWORD exitCode;
 
-    // Create a FILE pointer from the write handle to the child process's input
-    FILE *file = _fdopen(_open_osfhandle((intptr_t)hChildStdinWr, 0), mode);
-
-    if (file == nullptr) {
-        CloseHandle(hChildStdinWr);
-        CloseHandle(hStdin);
-        CloseHandle(pi.hProcess);
-        CloseHandle(pi.hThread);
-        return nullptr;
+        // Wait for the process to finish and get its exit code
+        if (WaitForSingleObject(hFile, INFINITE) == WAIT_OBJECT_0 &&
+            GetExitCodeProcess(hFile, &exitCode)) {
+            CloseHandle(hFile);
+            return exitCode;
+        } else {
+            return -1; // Failed to get the exit code
+        }
     }
-
-    return file;
-}
-
-// Function to close the process and retrieve its exit code
-int hiddenPclose(FILE *file) {
-    HANDLE hFile = (HANDLE)_get_osfhandle(_fileno(file));
-    fclose(file);
-    DWORD exitCode;
-
-    // Wait for the process to finish and get its exit code
-    if (WaitForSingleObject(hFile, INFINITE) == WAIT_OBJECT_0 &&
-        GetExitCodeProcess(hFile, &exitCode)) {
-        CloseHandle(hFile);
-        return exitCode;
-    } else {
-        return -1; // Failed to get the exit code
-    }
-}
-
+} // namespace matplot::detail
 #endif // _WIN32

--- a/source/matplot/util/popen.h
+++ b/source/matplot/util/popen.h
@@ -6,18 +6,19 @@
 #define MATPLOTPLUSPLUS_POPEN_H
 
 #ifdef _WIN32
-#include <io.h>
-#include <stdio.h>
+#include <stdio.h> //needed for FILE type
 #include <windows.h>
 
-// in a GUI application, _popen pops up a window. This version does not.
-FILE *hiddenPopen(const char *command, const char *mode);
+namespace matplot::detail {
+    // in a GUI application, _popen pops up a window. This version does not.
+    FILE *hiddenPopen(const char *command, const char *mode);
 
-// close the handle opened by hiddenPopen
-int hiddenPclose(FILE *file);
+    // close the handle opened by hiddenPopen
+    int hiddenPclose(FILE *file);
+} // namespace matplot::detail
 
-#define PCLOSE hiddenPclose
-#define POPEN hiddenPopen
+#define PCLOSE ::matplot::detail::hiddenPclose
+#define POPEN ::matplot::detail::hiddenPopen
 #define FILENO _fileno
 #else
 #define PCLOSE pclose

--- a/source/matplot/util/popen.h
+++ b/source/matplot/util/popen.h
@@ -6,9 +6,18 @@
 #define MATPLOTPLUSPLUS_POPEN_H
 
 #ifdef _WIN32
+#include <io.h>
+#include <stdio.h>
 #include <windows.h>
-#define PCLOSE _pclose
-#define POPEN _popen
+
+// in a GUI application, _popen pops up a window. This version does not.
+FILE *hiddenPopen(const char *command, const char *mode);
+
+// close the handle opened by hiddenPopen
+int hiddenPclose(FILE *file);
+
+#define PCLOSE hiddenPclose
+#define POPEN hiddenPopen
 #define FILENO _fileno
 #else
 #define PCLOSE pclose


### PR DESCRIPTION
Fix for https://github.com/alandefreitas/matplotplusplus/issues/376

On Windows, in a GUI app using this library, a console window gets opened when using `_popen`.
It seems (SO reference [here](https://stackoverflow.com/questions/10020653/is-there-any-way-of-stopping-popen-opening-a-dos-window/10020726#10020726)) that the only way to avoid this is to use `CreateProcess`.

The use case that this PR fixes is when you want to use the lib in a GUI app on Windows, to generate figures that you save into files. I think that is what is called non-interactive mode.