### PR TITLE
Add SOVERSION to shared library

### DIFF
--- a/source/matplot/CMakeLists.txt
+++ b/source/matplot/CMakeLists.txt
@@ -98,7 +98,7 @@ target_include_directories(matplot
     PUBLIC $<BUILD_INTERFACE:${MATPLOT_ROOT_DIR}/source>
            $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
 
-set_target_properties(matplot PROPERTIES VERSION ${PROJECT_VERSION})
+set_target_properties(matplot PROPERTIES VERSION ${PROJECT_VERSION} SOVERSION ${PROJECT_VERSION_MAJOR})
 
 # Shared library symbol export
 include(GenerateExportHeader)


### PR DESCRIPTION
Set the soversion of the matplot shared library to the major version number of the project. This provides a guarantee that breaking changes to the library interface shall only be made when the major version is incremented.

Fixes issue #393.