### PR TITLE
Eradicate the "ignoring attributes on template argument" warning

### DIFF
--- a/source/matplot/util/common.cpp
+++ b/source/matplot/util/common.cpp
@@ -51,7 +51,7 @@ namespace matplot {
     }
 
     std::string run_and_get_output(const std::string &cmd) {
-        std::unique_ptr<FILE, decltype(&PCLOSE)> pipe(POPEN(cmd.c_str(), "r"),
+        std::unique_ptr<FILE, int (*)(FILE *)> pipe(POPEN(cmd.c_str(), "r"),
                                                       PCLOSE);
         if (!pipe) {
             throw std::runtime_error("popen() failed!");


### PR DESCRIPTION
At least since 1.2.1 compilation on linux with glibc results in a warning being emitted about an attribute being discarded when `decltype(&PCLOSE)` is passed as a template argument to `std::unique_ptr`:
```
/home/masflam/Clones/matplotplusplus/source/matplot/util/common.cpp: In function ‘std::string matplot::run_and_get_output(const std::string&)’:
/home/masflam/Clones/matplotplusplus/source/matplot/util/common.cpp:54:48: error: ignoring attributes on template argument ‘int (*)(FILE*)’ [-Werror=ignored-attributes]
   54 |         std::unique_ptr<FILE, decltype(&PCLOSE)> pipe(POPEN(cmd.c_str(), "r"),
      |                                                ^
```
This is because `pclose` is declared with the attribute `__nonnull((1))` in glibc headers:
```c
/* Close a stream opened by popen and return the status of its child.

   This function is a possible cancellation point and therefore not
   marked with __THROW.  */
extern int pclose (FILE *__stream) __nonnull ((1));
```
And due to `-Werror` the whole compilation fails. The simple fix in this PR is to pass the deleter's type explicitly, since barring attributes `PCLOSE`'s signature is the same on all platforms.

Fixes #403