### PR TITLE
Fixes compilation issue #403 and improves error reporting

### DIFF
--- a/source/matplot/util/common.cpp
+++ b/source/matplot/util/common.cpp
@@ -370,7 +370,7 @@ namespace matplot {
     std::string fileread(const std::string &filename) {
         std::ifstream t(filename);
         if (!t) {
-            throw std::runtime_error("Cannot open the file " + filename);
+            throw std::system_error(errno, std::system_category(), filename);
         }
         std::string str((std::istreambuf_iterator<char>(t)),
                         std::istreambuf_iterator<char>());

--- a/source/matplot/util/common.cpp
+++ b/source/matplot/util/common.cpp
@@ -50,11 +50,18 @@ namespace matplot {
                iequals(str, "no");
     }
 
+    struct pipe_deleter {
+        int operator()(FILE* pipe) const {
+            if (int status = PCLOSE(pipe); status != -1)
+                return status;
+            throw std::system_error{errno, std::system_category(), "pclose"};
+        }
+    };
+
     std::string run_and_get_output(const std::string &cmd) {
-        std::unique_ptr<FILE, int (*)(FILE *)> pipe(POPEN(cmd.c_str(), "r"),
-                                                      PCLOSE);
+        std::unique_ptr<FILE, pipe_deleter> pipe(POPEN(cmd.c_str(), "r"));
         if (!pipe) {
-            throw std::runtime_error("popen() failed!");
+            throw std::system_error{errno, std::system_category(), cmd};
         }
         std::array<char, 128> buffer{};
         std::string result;


### PR DESCRIPTION
Fixes #403 , similar to pr #423 but improved error reporting (e.g. #408).
Tested on g++-10/11/12/13/14, clang++-16, mingw-g++-13 (Debian testing)

The error reporting is better:
- backward compatible (`std::system_error` inherits `std::runtime_error`, so `catch(std::runtime_error&)` works as before).
- uses C++ standard exceptions.
- uses platform specific error messages (for example "filepath: File not found" on Windows and "filepath: No such file or directory" on Linux).
- includes the details like a filepath or a function name.