### PR TITLE
Fix usage of MATPLOTPP_WITH_SYSTEM_CIMG and MATPLOTPP_WITH_SYSTEM_NODESOUP

### DIFF
--- a/source/3rd_party/CMakeLists.txt
+++ b/source/3rd_party/CMakeLists.txt
@@ -1,7 +1,7 @@
 #######################################################
 ### NodeSoup                                        ###
 #######################################################
-if(WITH_SYSTEM_NODESOUP)
+if(MATPLOTPP_WITH_SYSTEM_NODESOUP)
   find_path(NODESOUP_INCLUDE_DIR nodesoup.hpp REQUIRED)
   find_library(NODESOUP_LIB nodesoup REQUIRED)
 
@@ -52,7 +52,7 @@ endif()
 ### CImg                                            ###
 #######################################################
 add_library(cimg INTERFACE)
-if(WITH_SYSTEM_CIMG)
+if(MATPLOTPP_WITH_SYSTEM_CIMG)
   find_path(CIMG_INCLUDE_DIR CImg.h REQUIRED)
 else()
   set(CIMG_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/cimg)


### PR DESCRIPTION
This fixes a regression in https://github.com/alandefreitas/matplotplusplus/pull/316, where the options `WITH_SYSTEM_CIMG` and `WITH_SYSTEM_NODESOUP` were renamed `MATPLOTPP_WITH_SYSTEM_CIMG` and `MATPLOTPP_WITH_SYSTEM_NODESOUP`, but the point in which they were used were not changed.

I guess the reason why the usage was not changed is the GitHub search problem for which folder that are named `3rd_party` are not searched for (I can't find the issue on GitHub tracking that, but that is a known problem in GitHub code search).