### PR TITLE
Add the option to make the legend transparent

### DIFF
--- a/source/matplot/core/axes_type.cpp
+++ b/source/matplot/core/axes_type.cpp
@@ -690,6 +690,7 @@ namespace matplot {
         //  {{no}box { {linestyle | ls <line_style>}
         //              | {linetype | lt <line_type>}
         //              {linewidth | lw <line_width>}}}
+        //  {{no}opaque {fc <colorspec>}}
         include_comment("Axes legend");
         // Gnuplot version needs to be 5.2.6+ for keyentry
         bool ok = true;
@@ -753,7 +754,7 @@ namespace matplot {
                 cmd += legend_->vertical() ? " vertical" : " horizontal";
                 // text aligned to the left
                 cmd += " Left";
-                cmd += " opaque";
+                cmd += legend_->opaque() ? " opaque" : " noopaque";
                 cmd +=
                     legend_->label_after_sample() ? " reverse" : " noreverse";
                 cmd += legend_->invert() ? " invert" : " noinvert";

--- a/source/matplot/core/legend.cpp
+++ b/source/matplot/core/legend.cpp
@@ -296,4 +296,8 @@ namespace matplot {
         num_columns_ = 0;
         touch();
     }
+
+    bool legend::opaque() const { return opaque_; }
+
+    void legend::opaque(bool opaque) { opaque_ = opaque; };
 } // namespace matplot

--- a/source/matplot/core/legend.h
+++ b/source/matplot/core/legend.h
@@ -123,6 +123,9 @@ namespace matplot {
         void text_color(const color_array &text_color);
         template <class T> void text_color(T c) { text_color(to_array(c)); }
 
+        bool opaque() const;
+        void opaque(bool opaque);
+
       private:
         // The keys
         std::vector<std::string> strings_{};
@@ -150,6 +153,7 @@ namespace matplot {
         bool label_after_sample_{true};
         bool invert_{false};
         bool visible_{true};
+        bool opaque_{true};
 
         size_t num_columns_{0};
         size_t num_rows_{0};


### PR DESCRIPTION
This is useful when automatically generating a large number of plots, when the best legend position is not always the same.