### PR TITLE
Fix bug: qt terminal launches unexpectedly when saving plot (#362)

### DIFF
--- a/source/matplot/backend/backend_interface.cpp
+++ b/source/matplot/backend/backend_interface.cpp
@@ -162,7 +162,6 @@ namespace matplot::backend {
         // The default implementation waits for the user to interact with the
         // console. In interactive backends we expect this to start a render
         // loop that will stop only when the user closes the window.
-        //TODO: initialize the pipe
         f->draw();
         matplot::wait();
     }

--- a/source/matplot/backend/backend_interface.cpp
+++ b/source/matplot/backend/backend_interface.cpp
@@ -162,6 +162,7 @@ namespace matplot::backend {
         // The default implementation waits for the user to interact with the
         // console. In interactive backends we expect this to start a render
         // loop that will stop only when the user closes the window.
+        lazy_init_pipe();
         f->draw();
         matplot::wait();
     }

--- a/source/matplot/backend/backend_interface.cpp
+++ b/source/matplot/backend/backend_interface.cpp
@@ -10,6 +10,11 @@ namespace matplot::backend {
     bool backend_interface::consumes_gnuplot_commands() { return false; }
 
     bool backend_interface::is_interactive() { return true; }
+    
+    void backend_interface::lazy_init_pipe() {
+        // Default implementation does nothing
+        return;
+    }
 
     const std::string &backend_interface::output() {
         const static std::string r{};
@@ -157,6 +162,7 @@ namespace matplot::backend {
         // The default implementation waits for the user to interact with the
         // console. In interactive backends we expect this to start a render
         // loop that will stop only when the user closes the window.
+        //TODO: initialize the pipe
         f->draw();
         matplot::wait();
     }

--- a/source/matplot/backend/backend_interface.h
+++ b/source/matplot/backend/backend_interface.h
@@ -55,6 +55,8 @@ namespace matplot {
             /// libraries such as http://www.geuz.org/gl2ps/
             /// can be used.
             virtual bool is_interactive();
+            
+            virtual void lazy_init_pipe();
 
             /// \brief If non-interactive, get the file where we should output
             /// our data

--- a/source/matplot/backend/backend_interface.h
+++ b/source/matplot/backend/backend_interface.h
@@ -56,6 +56,8 @@ namespace matplot {
             /// can be used.
             virtual bool is_interactive();
             
+
+            /// \brief open the gnuplot pipe not at construction time 
             virtual void lazy_init_pipe();
 
             /// \brief If non-interactive, get the file where we should output

--- a/source/matplot/backend/gnuplot.cpp
+++ b/source/matplot/backend/gnuplot.cpp
@@ -87,6 +87,10 @@ namespace matplot::backend {
     }
 
     void gnuplot::lazy_init_pipe() {
+        if(pipe_.opened()){
+            flush_commands();
+            return;
+        }
         int perr;
         if constexpr (windows_should_persist_by_default) {
             perr = pipe_.open("gnuplot --persist");

--- a/source/matplot/backend/gnuplot.cpp
+++ b/source/matplot/backend/gnuplot.cpp
@@ -62,12 +62,6 @@ namespace matplot::backend {
             // 2nd option: wxt on windows, even if not default
             terminal_ = "wxt";
 #endif
-            /***
-             * TODO:when we construct gnuplot object,
-             * we should not set terminal to dumb directly,
-             * we should check the saving command
-             ***/
-
         } else if (terminal_is_available("qt")) {
             // 3rd option: qt
             terminal_ = "qt";

--- a/source/matplot/backend/gnuplot.cpp
+++ b/source/matplot/backend/gnuplot.cpp
@@ -76,26 +76,6 @@ namespace matplot::backend {
             terminal_ = default_terminal_type();
         }
 
-        // Open the gnuplot pipe_
-        // int perr;
-        // if constexpr (windows_should_persist_by_default) {
-        //     perr = pipe_.open("gnuplot --persist");
-        // } else {
-        //     perr = pipe_.open("gnuplot");
-        // }
-
-        // // if (perr == 0 && pipe_.opened()) {
-        // //     run_command("set terminal dumb");
-        // //     run_command("set output '/dev/null'");
-        // // }
-        // // Check if everything is OK
-        // if (perr != 0 || !pipe_.opened()) {
-        //     std::cerr << "Opening the gnuplot failed: ";
-        //     std::cerr << pipe_.error() << std::endl;
-        //     std::cerr
-        //         << "Please install gnuplot 5.2.6+: http://www.gnuplot.info"
-        //         << std::endl;
-        // }
     }
 
     gnuplot::~gnuplot() {
@@ -309,20 +289,6 @@ namespace matplot::backend {
         if constexpr (dont_let_it_close_too_fast) {
             last_flush_ = std::chrono::high_resolution_clock::now();
         }
-        // if (!pipe_.opened()) {
-        //     int perr;
-        //     if constexpr (windows_should_persist_by_default) {
-        //         perr = pipe_.open("gnuplot --persist");
-        //     } else {
-        //         perr = pipe_.open("gnuplot");
-        //     }
-        // }
-        // pipe_.flush("\n");
-        // if constexpr (trace_commands) {
-        //     std::cout << "\n\n\n\n" << std::endl;
-        // }
-
-        // when the pipe has been opend, flushed the content in pipe
         if (pipe_.opened()) {
             pipe_.flush("\n");
             if constexpr (trace_commands) {

--- a/source/matplot/backend/gnuplot.h
+++ b/source/matplot/backend/gnuplot.h
@@ -17,6 +17,7 @@ namespace matplot::backend {
       public:
         gnuplot();
         virtual ~gnuplot();
+        void lazy_init_pipe() override;
         bool is_interactive() override;
         const std::string &output() override;
         const std::string &output_format() override;

--- a/source/matplot/core/figure_type.cpp
+++ b/source/matplot/core/figure_type.cpp
@@ -42,8 +42,6 @@ namespace matplot {
         backend_->run_command(command);
     }
 
-
-    //TODO:save logic
     void figure_type::draw() {
         // if there's no backend, then we use the default
         if (backend_ == nullptr) {
@@ -137,6 +135,7 @@ namespace matplot {
     }
 
     void figure_type::show() { 
+        // open the gnu pipe when show method is called
         backend_->lazy_init_pipe();
         backend_->show(this); }
 
@@ -151,7 +150,6 @@ namespace matplot {
         backend_->render_data();
     }
 
-    //TODO: Save logical
     bool figure_type::save(const std::string &filename,
                            const std::string &format) {
         try {
@@ -167,7 +165,6 @@ namespace matplot {
         }
     }
     
-    //TODO: Save logical
     bool figure_type::save(const std::string &filename) {
         try {
             auto pout = backend_->output();

--- a/source/matplot/core/figure_type.cpp
+++ b/source/matplot/core/figure_type.cpp
@@ -32,6 +32,8 @@ namespace matplot {
     figure_type::~figure_type() = default;
 #endif
 
+
+
     void figure_type::include_comment(const std::string &text) {
         backend_->include_comment(text);
     }
@@ -40,6 +42,8 @@ namespace matplot {
         backend_->run_command(command);
     }
 
+
+    //TODO:save logic
     void figure_type::draw() {
         // if there's no backend, then we use the default
         if (backend_ == nullptr) {
@@ -92,6 +96,7 @@ namespace matplot {
     }
 
     void figure_type::send_gnuplot_draw_commands() {
+        
         include_comment("Setting figure properties");
         run_figure_properties_command();
         if (children_.empty()) {
@@ -131,7 +136,9 @@ namespace matplot {
         }
     }
 
-    void figure_type::show() { backend_->show(this); }
+    void figure_type::show() { 
+        backend_->lazy_init_pipe();
+        backend_->show(this); }
 
     void figure_type::touch() {
         if (!quiet_mode_) {
@@ -144,6 +151,7 @@ namespace matplot {
         backend_->render_data();
     }
 
+    //TODO: Save logical
     bool figure_type::save(const std::string &filename,
                            const std::string &format) {
         try {
@@ -158,7 +166,8 @@ namespace matplot {
             return false;
         }
     }
-
+    
+    //TODO: Save logical
     bool figure_type::save(const std::string &filename) {
         try {
             auto pout = backend_->output();

--- a/source/matplot/core/figure_type.cpp
+++ b/source/matplot/core/figure_type.cpp
@@ -94,7 +94,7 @@ namespace matplot {
     }
 
     void figure_type::send_gnuplot_draw_commands() {
-        
+
         include_comment("Setting figure properties");
         run_figure_properties_command();
         if (children_.empty()) {
@@ -134,10 +134,9 @@ namespace matplot {
         }
     }
 
-    void figure_type::show() { 
-        // open the gnu pipe when show method is called
-        backend_->lazy_init_pipe();
-        backend_->show(this); }
+    void figure_type::show() {
+        backend_->show(this);
+    }
 
     void figure_type::touch() {
         if (!quiet_mode_) {
@@ -164,7 +163,7 @@ namespace matplot {
             return false;
         }
     }
-    
+
     bool figure_type::save(const std::string &filename) {
         try {
             auto pout = backend_->output();


### PR DESCRIPTION
As described in #362, when the user only wants to save the plot, the terminal is still set to qt and the graphic view is invoked.
This behavior should not occur when the plot is only exported without interactive display.

Root cause
- The gnuplot pipe is opened too early during the backend construction. https://github.com/alandefreitas/matplotplusplus/blob/master/source/matplot/backend/gnuplot.cpp#L73-L87
- Each component is rendered twice:
   1. once when it is touched
   2. once again when rendering the entire plot.
  
Fix
- Open the gnuplot pipe lazily only when show() or save() is called.
- Render the plot only when necessary (either show or save), avoiding redundant rendering.
