### PR TITLE
Compatibility: fix compiler errors

### DIFF
--- a/source/matplot/core/axes_object.h
+++ b/source/matplot/core/axes_object.h
@@ -29,6 +29,8 @@ namespace matplot {
 
         explicit axes_object(axes_handle parent);
 
+        virtual ~axes_object() = default;
+
       public:
         virtual double xmax();
         virtual double xmin();

--- a/source/matplot/util/common.cpp
+++ b/source/matplot/util/common.cpp
@@ -866,8 +866,8 @@ namespace matplot {
 
         // Initial calculations
         if (log) {
-            std::invalid_argument("Not implemented yet. The library does not "
-                                  "need that as it is.");
+            throw std::invalid_argument("Not implemented yet. The library does "
+                                        "not need that as it is.");
         }
 
         // Data range

--- a/source/matplot/util/common.h
+++ b/source/matplot/util/common.h
@@ -605,9 +605,10 @@ namespace matplot {
         /// \brief Helper method for determining the whole array size.
         /// Required for caching inner vector's size.
         std::size_t calculate_size(const vector_2d &vec) {
-            return std::accumulate(
-                vec.begin(), vec.end(), (std::size_t)(0),
-                [](auto cnt, const auto &vec) { return cnt + vec.size(); });
+            return std::accumulate(vec.begin(), vec.end(), (std::size_t)(0),
+                                   [](auto cnt, const auto &inner_vec) {
+                                       return cnt + inner_vec.size();
+                                   });
         }
 
       public:


### PR DESCRIPTION
Resolve three compiler warnings and errors in support of adoption into hardened projects. Found with Ubuntu 22.04 / G++ 14.2.0 / Release configuration during development of [FrancoisCarouge/Kalman](https://github.com/FrancoisCarouge/Kalman) plotter support.

- `axes_object.h:18` The class has an accessible destructor that is not virtual. Resolution: added a default polymorphic destructor for memory safety guarantees.
- `common.h:609`: `vec` variable shadows local. Resolution: variable renamed to the more specific `inner_vec` name.
- `common.cpp:869` Return variable not used. Resolution: throw exception.

Notes:
- Formatted touched sources with the project rules.
- There remains a variety of shadowed enumeration values, keywords, and constructors. These would be non-trivial resolution here. Workaround remains to disable shadowing hardening for the respective targets with `-Wno-shadow`.
